### PR TITLE
ci: Use gh-pages instead

### DIFF
--- a/.asf.yml
+++ b/.asf.yml
@@ -1,2 +1,3 @@
-publish:
-  whoami:  gh-pages
+github:
+  ghp_branch:  gh-pages
+  ghp_path:    /

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,7 +85,7 @@ jobs:
         if: github.event_name == 'push' && github.ref_name == 'main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          cname: opendal.databend.rs
+          cname: opendal.apache.org
           publish_dir: website/build
           publish_branch: gh-pages
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

ci: Use gh-pages instead
