### PR TITLE
ci: set main branch to be protected

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -28,6 +28,10 @@ github:
     squash: true
     merge: false
     rebase: false
+  protected_branches:
+    main:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
 
 notifications:
   commits:      commits@opendal.apache.org


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

Summary about this PR

* I think it would be better to set the main branch to be protected
