### PR TITLE
website: Add GitHub entry

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -130,6 +130,12 @@ const config = {
             label: 'Releases',
             position: 'right'
           },
+          {
+            href: repoAddress,
+            position: 'right',
+            className: 'header-github-link',
+            'aria-label': 'GitHub repository',
+          },
         ],
       },
       footer: {


### PR DESCRIPTION
Currently, the website only had one link to the project's GitHub address at the bottom, which was not very prominent.
 I restored the GitHub link button in the nav bar for user convenience.