### PR TITLE
refactor(bindings/python): only enable `pyo3/entension-module` feature when building with maturin

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -34,6 +34,6 @@ name = "opendal"
 chrono = { version = "0.4.24", default-features = false, features = ["std"] }
 futures = "0.3.27"
 opendal = { version = "0.30", path = "../../core" }
-pyo3 = { version = "0.18", features = ["extension-module", "chrono"] }
+pyo3 = { version = "0.18", features = ["chrono"] }
 pyo3-asyncio = { version = "0.18", features = ["tokio-runtime"] }
 tokio = "1"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -38,3 +38,6 @@ test = ["behave"]
 Documentation = "https://docs.rs/opendal/"
 Homepage = "https://opendal.apache.org/"
 Repository = "https://github.com/apache/incubator-opendal"
+
+[tool.maturin]
+features = ["pyo3/extension-module"]


### PR DESCRIPTION
See https://pyo3.rs/v0.18.1/faq#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror

`maturin` has changed the default project layout generated from `maturin new` to exactly this to avoid such issue.

Fixes #1675 