### PR TITLE
feat(bindings/python): add `__repr__` to `Operator` and `AsyncOperator`

### DIFF
--- a/bindings/python/src/asyncio.rs
+++ b/bindings/python/src/asyncio.rs
@@ -153,6 +153,24 @@ impl AsyncOperator {
             Ok(pylister)
         })
     }
+
+    fn __repr__(&self) -> String {
+        let info = self.0.info();
+        let name = info.name();
+        if name.is_empty() {
+            format!(
+                "AsyncOperator(\"{}\", root=\"{}\")",
+                info.scheme(),
+                info.root()
+            )
+        } else {
+            format!(
+                "AsyncOperator(\"{}\", root=\"{}\", name=\"{name}\")",
+                info.scheme(),
+                info.root()
+            )
+        }
+    }
 }
 
 enum ReaderState {

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -198,6 +198,20 @@ impl Operator {
     pub fn scan(&self, path: &str) -> PyResult<BlockingLister> {
         Ok(BlockingLister(self.0.scan(path).map_err(format_pyerr)?))
     }
+
+    fn __repr__(&self) -> String {
+        let info = self.0.info();
+        let name = info.name();
+        if name.is_empty() {
+            format!("Operator(\"{}\", root=\"{}\")", info.scheme(), info.root())
+        } else {
+            format!(
+                "Operator(\"{}\", root=\"{}\", name=\"{name}\")",
+                info.scheme(),
+                info.root()
+            )
+        }
+    }
 }
 
 /// A file-like blocking reader.


### PR DESCRIPTION
It's nice to have these.

```python
>>> import opendal
>>> op = opendal.Operator("memory")
>>> op
Operator("memory", root="/", name="0x6000008c4050")
```