### PR TITLE
doc: uncomment the use expr for operator example

### DIFF
--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -790,9 +790,9 @@ impl Operator {
     /// ```no_run
     /// # use anyhow::Result;
     /// # use futures::io;
-    /// # use opendal::Operator;
-    /// # use opendal::EntryMode;
-    /// # use futures::TryStreamExt;
+    /// use opendal::Operator;
+    /// use opendal::EntryMode;
+    /// use futures::TryStreamExt;
     /// use opendal::Metakey;
     /// # #[tokio::main]
     /// # async fn test(op: Operator) -> Result<()> {
@@ -841,9 +841,9 @@ impl Operator {
     /// ```no_run
     /// # use anyhow::Result;
     /// # use futures::io;
-    /// # use opendal::Operator;
-    /// # use opendal::EntryMode;
-    /// # use futures::TryStreamExt;
+    /// use opendal::Operator;
+    /// use opendal::EntryMode;
+    /// use futures::TryStreamExt;
     /// use opendal::Metakey;
     /// #
     /// # #[tokio::main]


### PR DESCRIPTION
we should not comment out the `use` expr as it is used explicitly in examples.

especially the `futures::TryStreamExt`, it was not mentioned in docs, but has to be added to make `try_next` work.