### PR TITLE
feat: make oli support more services

### DIFF
--- a/bin/oli/Cargo.toml
+++ b/bin/oli/Cargo.toml
@@ -27,6 +27,26 @@ name = "oli"
 repository = "https://github.com/apache/incubator-opendal"
 version = "0.30.3"
 
+[features]
+# Enable services dashmap support
+services-dashmap = ["opendal/services-dashmap"]
+# Enable services ftp support
+services-ftp = ["opendal/services-ftp"]
+# Enable services hdfs support
+services-hdfs = ["opendal/services-hdfs"]
+# Enable services ipfs support
+services-ipfs = ["opendal/services-ipfs"]
+# Enable services memcached support
+services-memcached = ["opendal/services-memcached"]
+# Enable services moka support
+services-moka = ["opendal/services-moka"]
+# Enable services redis support
+services-redis = ["opendal/services-redis"]
+# Enable services rocksdb support
+services-rocksdb = ["opendal/services-rocksdb"]
+# Enable services sled support
+services-sled = ["opendal/services-sled"]
+
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["cargo", "string"] }

--- a/bin/oli/src/config/mod.rs
+++ b/bin/oli/src/config/mod.rs
@@ -85,12 +85,94 @@ impl Config {
             .ok_or_else(|| anyhow!("missing 'type' in profile"))?;
         let scheme = Scheme::from_str(svc)?;
         match scheme {
-            Scheme::S3 => Ok((
-                Operator::from_map::<services::S3>(profile.clone())?.finish(),
+            Scheme::Azblob => Ok((
+                Operator::from_map::<services::Azblob>(profile.clone())?.finish(),
+                path,
+            )),
+            Scheme::Azdfs => Ok((
+                Operator::from_map::<services::Azdfs>(profile.clone())?.finish(),
+                path,
+            )),
+            #[cfg(feature = "services-dashmap")]
+            Scheme::Dashmap => Ok((
+                Operator::from_map::<services::Dashmap>(profile.clone())?.finish(),
+                path,
+            )),
+            Scheme::Gcs => Ok((
+                Operator::from_map::<services::Gcs>(profile.clone())?.finish(),
+                path,
+            )),
+            Scheme::Ghac => Ok((
+                Operator::from_map::<services::Ghac>(profile.clone())?.finish(),
+                path,
+            )),
+            #[cfg(feature = "services-hdfs")]
+            Scheme::Hdfs => Ok((
+                Operator::from_map::<services::Hdfs>(profile.clone())?.finish(),
+                path,
+            )),
+            Scheme::Http => Ok((
+                Operator::from_map::<services::Http>(profile.clone())?.finish(),
+                path,
+            )),
+            #[cfg(feature = "services-ftp")]
+            Scheme::Ftp => Ok((
+                Operator::from_map::<services::Ftp>(profile.clone())?.finish(),
+                path,
+            )),
+            #[cfg(feature = "services-ipfs")]
+            Scheme::Ipfs => Ok((
+                Operator::from_map::<services::Ipfs>(profile.clone())?.finish(),
+                path,
+            )),
+            Scheme::Ipmfs => Ok((
+                Operator::from_map::<services::Ipmfs>(profile.clone())?.finish(),
+                path,
+            )),
+            #[cfg(feature = "services-memcached")]
+            Scheme::Memcached => Ok((
+                Operator::from_map::<services::Memcached>(profile.clone())?.finish(),
+                path,
+            )),
+            // ignore the memory backend
+            #[cfg(feature = "services-moka")]
+            Scheme::Moka => Ok((
+                Operator::from_map::<services::Moka>(profile.clone())?.finish(),
+                path,
+            )),
+            Scheme::Obs => Ok((
+                Operator::from_map::<services::Obs>(profile.clone())?.finish(),
                 path,
             )),
             Scheme::Oss => Ok((
                 Operator::from_map::<services::Oss>(profile.clone())?.finish(),
+                path,
+            )),
+            #[cfg(feature = "services-redis")]
+            Scheme::Redis => Ok((
+                Operator::from_map::<services::Redis>(profile.clone())?.finish(),
+                path,
+            )),
+            #[cfg(feature = "services-rocksdb")]
+            Scheme::Rocksdb => Ok((
+                Operator::from_map::<services::Rocksdb>(profile.clone())?.finish(),
+                path,
+            )),
+            Scheme::S3 => Ok((
+                Operator::from_map::<services::S3>(profile.clone())?.finish(),
+                path,
+            )),
+            #[cfg(feature = "services-sled")]
+            Scheme::Sled => Ok((
+                Operator::from_map::<services::Sled>(profile.clone())?.finish(),
+                path,
+            )),
+            Scheme::Webdav => Ok((
+                Operator::from_map::<services::Webdav>(profile.clone())?.finish(),
+                path,
+            )),
+            Scheme::Webhdfs => Ok((
+                Operator::from_map::<services::Webhdfs>(profile.clone())?.finish(),
                 path,
             )),
             _ => Err(anyhow!("invalid profile")),


### PR DESCRIPTION
Ref #422 

Now with the following config:
```
[profiles.redis]
type = "redis"

[profiles.ustcmirror]
type = "http"
endpoint = "https://mirrors.ustc.edu.cn"
```
and compile `oli` with the following command
```
cargo build -p oli -F services-redis
```

`oli` could download a file from a website and save it to redis 🚀 
```
$ ./target/debug/oli cp ustcmirror://archlinux/lastupdate redis://oli:lastsync
$ redis-cli get "oli:lastsync"
"1679393591\n"
```