### PR TITLE
feat: Add override_content_disposition for OpRead

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -1338,20 +1338,14 @@ impl S3Backend {
         let p = build_abs_path(&self.root, path);
 
         // Construct headers to add to the request
-        let mut query_args = Vec::new();
-        if let Some(override_content_disposition) = override_content_disposition {
-            query_args.push(format!(
-                "{}={}",
-                constants::RESPONSE_CONTENT_DISPOSITION,
-                percent_encode_path(override_content_disposition)
-            ))
-        }
-
         let mut url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
-        // Add the query arguments to the uri
-        if !query_args.is_empty() {
-            url = format!("{url}?{}", query_args.join("&"))
+        if let Some(override_content_disposition) = override_content_disposition {
+            url.push_str(&format!(
+                "?{}={}",
+                constants::RESPONSE_CONTENT_DISPOSITION,
+                percent_encode_path(override_content_disposition)
+            ));
         }
 
         let mut req = Request::get(&url);

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -76,6 +76,8 @@ mod constants {
     pub const X_AMZ_SERVER_SIDE_ENCRYPTION_AWS_KMS_KEY_ID: &str =
         "x-amz-server-side-encryption-aws-kms-key-id";
     pub const X_AMZ_BUCKET_REGION: &str = "x-amz-bucket-region";
+
+    pub const RESPONSE_CONTENT_DISPOSITION: &str = "response-content-disposition";
 }
 
 /// Aws S3 and compatible services (including minio, digitalocean space and so on) support
@@ -1239,7 +1241,9 @@ impl Accessor for S3Backend {
         // We will not send this request out, just for signing.
         let mut req = match args.operation() {
             PresignOperation::Stat(_) => self.s3_head_object_request(path)?,
-            PresignOperation::Read(v) => self.s3_get_object_request(path, v.range())?,
+            PresignOperation::Read(v) => {
+                self.s3_get_object_request(path, v.range(), v.override_content_disposition())?
+            }
             PresignOperation::Write(_) => {
                 self.s3_put_object_request(path, None, None, None, AsyncBody::Empty)?
             }
@@ -1325,10 +1329,30 @@ impl S3Backend {
         Ok(req)
     }
 
-    fn s3_get_object_request(&self, path: &str, range: BytesRange) -> Result<Request<AsyncBody>> {
+    fn s3_get_object_request(
+        &self,
+        path: &str,
+        range: BytesRange,
+        override_content_disposition: Option<&str>,
+    ) -> Result<Request<AsyncBody>> {
         let p = build_abs_path(&self.root, path);
 
-        let url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
+        // Construct headers to add to the request
+        let mut query_args = Vec::new();
+        if let Some(override_content_disposition) = override_content_disposition {
+            query_args.push(format!(
+                "{}={}",
+                constants::RESPONSE_CONTENT_DISPOSITION,
+                percent_encode_path(override_content_disposition)
+            ))
+        }
+
+        let mut url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
+
+        // Add the query arguments to the uri
+        if !query_args.is_empty() {
+            url = format!("{url}?{}", query_args.join("&"))
+        }
 
         let mut req = Request::get(&url);
 
@@ -1352,7 +1376,7 @@ impl S3Backend {
         path: &str,
         range: BytesRange,
     ) -> Result<Response<IncomingAsyncBody>> {
-        let mut req = self.s3_get_object_request(path, range)?;
+        let mut req = self.s3_get_object_request(path, range, None)?;
 
         self.signer.sign(&mut req).map_err(new_request_sign_error)?;
 

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -950,6 +950,41 @@ impl Operator {
         Ok(rp.into_presigned_request())
     }
 
+    /// Presign an operation for read option described in OpenDAL [rfc-1735](../../docs/rfcs/1735_operation_extension.md).
+    ///
+    /// You can pass `OpRead` to this method to specify the content disposition.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use anyhow::Result;
+    /// use futures::io;
+    /// use opendal::Operator;
+    /// use time::Duration;
+    /// use opendal::ops::OpRead;
+    ///
+    /// #[tokio::main]
+    /// async fn test(op: Operator) -> Result<()> {
+    ///     let op = OpRead::new()
+    ///         .with_override_content_disposition("attachment; filename=\"othertext.txt\"");
+    ///     let signed_req = op.presign_read("test.txt", op, Duration::hours(1))?;
+    /// #    Ok(())
+    /// # }
+    /// ```
+    pub fn presign_read_with(
+        &self,
+        path: &str,
+        op: OpRead,
+        expire: Duration,
+    ) -> Result<PresignedRequest> {
+        let path = normalize_path(path);
+
+        let op = OpPresign::new(op, expire);
+
+        let rp = self.inner().presign(&path, op)?;
+        Ok(rp.into_presigned_request())
+    }
+
     /// Presign an operation for write.
     ///
     /// # Example

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -965,9 +965,9 @@ impl Operator {
     ///
     /// #[tokio::main]
     /// async fn test(op: Operator) -> Result<()> {
-    ///     let op = OpRead::new()
+    ///     let args = OpRead::new()
     ///         .with_override_content_disposition("attachment; filename=\"othertext.txt\"");
-    ///     let signed_req = op.presign_read("test.txt", op, Duration::hours(1))?;
+    ///     let signed_req = op.presign_read_with("test.txt", args, Duration::hours(1))?;
     /// #    Ok(())
     /// # }
     /// ```

--- a/core/src/types/ops.rs
+++ b/core/src/types/ops.rs
@@ -230,6 +230,7 @@ impl BatchOperations {
 #[derive(Debug, Clone, Default)]
 pub struct OpRead {
     br: BytesRange,
+    override_content_disposition: Option<String>,
 }
 
 impl OpRead {
@@ -247,6 +248,21 @@ impl OpRead {
     /// Get range from OpRead.
     pub fn range(&self) -> BytesRange {
         self.br
+    }
+
+    /// Sets the content-disposition header that should be send back by the remote read operation.
+    pub fn with_override_content_disposition(
+        mut self,
+        content_disposition: impl Into<String>,
+    ) -> Self {
+        self.override_content_disposition = Some(content_disposition.into());
+        self
+    }
+
+    /// Returns the content-disposition header that should be send back by the remote read
+    /// operation.
+    pub fn override_content_disposition(&self) -> Option<&str> {
+        self.override_content_disposition.as_deref()
     }
 }
 


### PR DESCRIPTION
Adds the `override_content_disposition` field as described in #1735 

Fix https://github.com/apache/incubator-opendal/issues/1739