### PR TITLE
fix(oli): set the root of fs service to '/'

### DIFF
--- a/bin/oli/src/commands/cat.rs
+++ b/bin/oli/src/commands/cat.rs
@@ -34,7 +34,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
         .ok_or_else(|| anyhow!("missing target"))?;
     let (op, path) = cfg.parse_location(target)?;
 
-    let mut reader = op.reader(path).await?;
+    let mut reader = op.reader(&path).await?;
     let mut stdout = io::stdout();
     io::copy(&mut reader, &mut stdout).await?;
     Ok(())

--- a/bin/oli/src/commands/cp.rs
+++ b/bin/oli/src/commands/cp.rs
@@ -41,9 +41,9 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
         .ok_or_else(|| anyhow!("missing target"))?;
     let (dst_op, dst_path) = cfg.parse_location(dst)?;
 
-    let mut dst_w = dst_op.writer(dst_path).await?;
+    let mut dst_w = dst_op.writer(&dst_path).await?;
 
-    let reader = src_op.reader(src_path).await?;
+    let reader = src_op.reader(&src_path).await?;
     let buf_reader = futures::io::BufReader::with_capacity(8 * 1024 * 1024, reader);
     futures::io::copy_buf(buf_reader, &mut dst_w).await?;
     // flush data

--- a/bin/oli/src/commands/ls.rs
+++ b/bin/oli/src/commands/ls.rs
@@ -39,7 +39,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
     let (op, path) = cfg.parse_location(target)?;
 
     if !recursive {
-        let mut ds = op.list(path).await?;
+        let mut ds = op.list(&path).await?;
         while let Some(de) = ds.try_next().await? {
             println!("{}", de.name());
         }


### PR DESCRIPTION
Per https://github.com/apache/incubator-opendal/discussions/1765#discussioncomment-5425812:

>  Instead, all serivces should stick to / as root to make the internal logic cleaner.