### PR TITLE
feat(oli): implement `oli stat`

### DIFF
--- a/bin/oli/src/bin/oli.rs
+++ b/bin/oli/src/bin/oli.rs
@@ -81,6 +81,10 @@ async fn main() -> Result<()> {
             let cmd = oli::commands::rm::cli(new_cmd("orm")?);
             oli::commands::rm::main(&cmd.get_matches()).await?;
         }
+        Some("ostat") => {
+            let cmd = oli::commands::stat::cli(new_cmd("ostat")?);
+            oli::commands::stat::main(&cmd.get_matches()).await?;
+        }
         Some(v) => {
             println!("{v} is not supported")
         }

--- a/bin/oli/src/commands/cli.rs
+++ b/bin/oli/src/commands/cli.rs
@@ -26,6 +26,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
         Some(("cp", sub_args)) => super::cp::main(sub_args).await?,
         Some(("ls", sub_args)) => super::ls::main(sub_args).await?,
         Some(("rm", sub_args)) => super::rm::main(sub_args).await?,
+        Some(("stat", sub_args)) => super::stat::main(sub_args).await?,
         _ => return Err(anyhow!("not handled")),
     }
 
@@ -39,4 +40,5 @@ pub fn cli(cmd: Command) -> Command {
         .subcommand(super::cp::cli(Command::new("cp")))
         .subcommand(super::ls::cli(Command::new("ls")))
         .subcommand(super::rm::cli(Command::new("rm")))
+        .subcommand(super::stat::cli(Command::new("stat")))
 }

--- a/bin/oli/src/commands/mod.rs
+++ b/bin/oli/src/commands/mod.rs
@@ -38,3 +38,4 @@ pub mod cli;
 pub mod cp;
 pub mod ls;
 pub mod rm;
+pub mod stat;

--- a/bin/oli/src/commands/stat.rs
+++ b/bin/oli/src/commands/stat.rs
@@ -34,19 +34,19 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
     let (op, path) = cfg.parse_location(target)?;
 
     let meta = op.stat(&path).await?;
-    println!("Path: {path}");
+    println!("path: {path}");
     let size = meta.content_length();
-    println!("Size: {size}");
+    println!("size: {size}");
     if let Some(etag) = meta.etag() {
-        println!("Etag: {etag}");
+        println!("etag: {etag}");
     }
     let file_type = meta.mode();
-    println!("Type: {file_type}");
+    println!("type: {file_type}");
     if let Some(content_type) = meta.content_type() {
-        println!("Content-Type: {content_type}");
+        println!("content-type: {content_type}");
     }
     if let Some(last_modified) = meta.last_modified() {
-        println!("LastModified: {last_modified}");
+        println!("last-modified: {last_modified}");
     }
 
     Ok(())

--- a/bin/oli/src/commands/stat.rs
+++ b/bin/oli/src/commands/stat.rs
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+use clap::{Arg, ArgMatches, Command};
+
+use crate::config::Config;
+
+pub async fn main(args: &ArgMatches) -> Result<()> {
+    let config_path = args
+        .get_one::<PathBuf>("config")
+        .ok_or_else(|| anyhow!("missing config path"))?;
+    let cfg = Config::load(config_path)?;
+
+    let target = args
+        .get_one::<String>("target")
+        .ok_or_else(|| anyhow!("missing target"))?;
+    let (op, path) = cfg.parse_location(target)?;
+
+    let meta = op.stat(&path).await?;
+    println!("Path: {path}");
+    let size = meta.content_length();
+    println!("Size: {size}");
+    if let Some(etag) = meta.etag() {
+        println!("Etag: {etag}");
+    }
+    let file_type = meta.mode();
+    println!("Type: {file_type}");
+    if let Some(content_type) = meta.content_type() {
+        println!("Content-Type: {content_type}");
+    }
+    if let Some(last_modifed) = meta.last_modified() {
+        println!("LastModified: {last_modifed}");
+    }
+
+    Ok(())
+}
+
+pub fn cli(cmd: Command) -> Command {
+    cmd.version("0.10.0")
+        .about("show object metadata")
+        .arg(Arg::new("target").required(true))
+}

--- a/bin/oli/src/commands/stat.rs
+++ b/bin/oli/src/commands/stat.rs
@@ -45,8 +45,8 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
     if let Some(content_type) = meta.content_type() {
         println!("Content-Type: {content_type}");
     }
-    if let Some(last_modifed) = meta.last_modified() {
-        println!("LastModified: {last_modifed}");
+    if let Some(last_modified) = meta.last_modified() {
+        println!("LastModified: {last_modified}");
     }
 
     Ok(())


### PR DESCRIPTION
Fix #1775 

Output:
```
$ ./target/debug/oli stat s3://prod/20230313/model_asset.txt
Path: prod/20230313/model_asset.txt
Size: 85248
Etag: "44739e04cf530998004923a11a981728"
Type: file
Content-Type: binary/octet-stream
LastModified: 2023-03-13 2:42:28.0 +00:00:00

$ ./target/debug/oli stat s3://prod/20230313/
Path: prod/20230313/
Size: 0
Type: dir

$ ./target/debug/oli stat ./Cargo.toml
Path: github/opendal/Cargo.toml
Size: 990
Type: file
LastModified: 2023-03-24 15:24:29.749171368 +00:00:00
```