### PR TITLE
chore(bin/oli): Set oli version from package version

### DIFF
--- a/bin/oli/src/commands/cat.rs
+++ b/bin/oli/src/commands/cat.rs
@@ -41,7 +41,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
 }
 
 pub fn cli(cmd: Command) -> Command {
-    cmd.version("0.10.0")
+    cmd.version(env!("CARGO_PKG_VERSION"))
         .about("display object content")
         .arg(Arg::new("target").required(true))
 }

--- a/bin/oli/src/commands/cli.rs
+++ b/bin/oli/src/commands/cli.rs
@@ -34,7 +34,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
 }
 
 pub fn cli(cmd: Command) -> Command {
-    cmd.version("0.10.0")
+    cmd.version(env!("CARGO_PKG_VERSION"))
         .about("OpenDAL Command Line Interface")
         .subcommand(super::cat::cli(Command::new("cat")))
         .subcommand(super::cp::cli(Command::new("cp")))

--- a/bin/oli/src/commands/cp.rs
+++ b/bin/oli/src/commands/cp.rs
@@ -52,7 +52,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
 }
 
 pub fn cli(cmd: Command) -> Command {
-    cmd.version("0.10.0")
+    cmd.version(env!("CARGO_PKG_VERSION"))
         .about("copy")
         .arg(Arg::new("source").required(true))
         .arg(Arg::new("destination").required(true))

--- a/bin/oli/src/commands/ls.rs
+++ b/bin/oli/src/commands/ls.rs
@@ -52,7 +52,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
 }
 
 pub fn cli(cmd: Command) -> Command {
-    cmd.version("0.10.0")
+    cmd.version(env!("CARGO_PKG_VERSION"))
         .about("ls")
         .arg(Arg::new("target").required(true))
         .arg(

--- a/bin/oli/src/commands/rm.rs
+++ b/bin/oli/src/commands/rm.rs
@@ -47,7 +47,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
 }
 
 pub fn cli(cmd: Command) -> Command {
-    cmd.version("0.10.0")
+    cmd.version(env!("CARGO_PKG_VERSION"))
         .about("remove object")
         .arg(Arg::new("target").required(true))
         .arg(

--- a/bin/oli/src/commands/stat.rs
+++ b/bin/oli/src/commands/stat.rs
@@ -53,7 +53,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
 }
 
 pub fn cli(cmd: Command) -> Command {
-    cmd.version("0.10.0")
+    cmd.version(env!("CARGO_PKG_VERSION"))
         .about("show object metadata")
         .arg(Arg::new("target").required(true))
 }


### PR DESCRIPTION
Use `env!` to get the package version in compiling time