### PR TITLE
feat: add cache_control to OpWrite

### DIFF
--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -61,6 +61,7 @@ impl oio::Write for S3Writer {
             Some(bs.len()),
             self.op.content_type(),
             self.op.content_disposition(),
+            self.op.cache_control(),
             AsyncBody::Bytes(bs),
         )?;
 

--- a/core/src/types/ops.rs
+++ b/core/src/types/ops.rs
@@ -284,6 +284,7 @@ pub struct OpWrite {
 
     content_type: Option<String>,
     content_disposition: Option<String>,
+    cache_control: Option<String>,
 }
 
 impl OpWrite {
@@ -296,6 +297,7 @@ impl OpWrite {
 
             content_type: None,
             content_disposition: None,
+            cache_control: None,
         }
     }
 
@@ -327,6 +329,17 @@ impl OpWrite {
     /// Set the content disposition of option
     pub fn with_content_disposition(mut self, content_disposition: &str) -> Self {
         self.content_disposition = Some(content_disposition.to_string());
+        self
+    }
+
+    /// Get the cache control from option
+    pub fn cache_control(&self) -> Option<&str> {
+        self.cache_control.as_deref()
+    }
+
+    /// Set the content type of option
+    pub fn with_cache_control(mut self, cache_control: &str) -> Self {
+        self.cache_control = Some(cache_control.to_string());
         self
     }
 }


### PR DESCRIPTION
Adds `cache_control` to `OpWrite`.

Fixes: https://github.com/apache/incubator-opendal/issues/1747