### PR TITLE
feat: Retry when some of batch operations are failing

### DIFF
--- a/core/src/raw/rps.rs
+++ b/core/src/raw/rps.rs
@@ -190,6 +190,14 @@ impl BatchedResults {
             Delete(v) => v.iter().filter(|v| v.1.is_err()).count(),
         }
     }
+
+    /// Return an iterator over error results.
+    pub fn errors(&self) -> Box<dyn Iterator<Item = &Error> + '_> {
+        use BatchedResults::*;
+        match self {
+            Delete(v) => Box::new(v.iter().filter_map(|v| v.1.as_ref().err())),
+        }
+    }
 }
 
 /// Reply for `stat` operation.


### PR DESCRIPTION
Also added a test for retry on batch operation.

This implementation works as expected but is not so elegant as far as I'm considering. Batch operation could possibly be retried even when result is `Ok`. So I had to wrap it in a `Result<(), Result<RpBatch>>` type. And the `errors` method on `BatchedResults` requires dynamic dispatching.

Regarding the issue mentioned above, would you be able to suggest any better solutions or provide further guidance?