### PR TITLE
feat(bindings/c): fix c bindings makefile

### DIFF
--- a/bindings/c/Makefile
+++ b/bindings/c/Makefile
@@ -18,13 +18,13 @@
 RPATH=$(PWD)/../../target/debug
 CFLAGS = -I./include
 LDFLAGS = -L$(RPATH) -Wl,-rpath,$(RPATH)
-LIBS = -lopendal
-OBJ_DIR=build/
+LIBS = -lopendal_c
+OBJ_DIR=build
 
-all: $(OBJ_DIR) build test
+all: objdir build test
 
-$(OBJ_DIR):
-	mkdir -p $@
+objdir:
+	mkdir -p $(OBJ_DIR)
 
 build:
 	cargo build


### PR DESCRIPTION
Fixed the OBJDIR creation and library link flag

* The library created by cbindgen is called libopendal_c instead of libopendal, so the original `-lopendal` does not work
* At least on my machine, the `OBJDIR` is not created by the Makefile, so this change make sure that the directory is created.