### PR TITLE
binding/c: build: add phony to makefile, and some improve

### DIFF
--- a/bindings/c/Makefile
+++ b/bindings/c/Makefile
@@ -21,17 +21,19 @@ LDFLAGS = -L$(RPATH) -Wl,-rpath,$(RPATH)
 LIBS = -lopendal_c
 OBJ_DIR=build
 
-all: objdir build test
+.PHONY: all
+all: build test
 
-objdir:
-	mkdir -p $(OBJ_DIR)
-
+.PHONY: build
 build:
+	mkdir -p $(OBJ_DIR)
 	cargo build
 
+.PHONY: test
 test:
 	$(CC) tests/hello.c -o $(OBJ_DIR)/hello $(CFLAGS) $(LDFLAGS) $(LIBS)
 
+.PHONY: clean
 clean:
 	cargo clean
-	rm -rf $(OBJ_DIR)
+	rm -rf "./$(OBJ_DIR)"


### PR DESCRIPTION
1. `make build` will do nothing if `build` dir existed without `.PHONY`
2. only `make build` should create the `build` dir, so keep it under `make build`
3. we should be careful to `rf -rf`, so added a quote and `./`