### PR TITLE
demo: Adding effect in OpenDAL

### DIFF
--- a/core/src/raw/mod.rs
+++ b/core/src/raw/mod.rs
@@ -31,6 +31,8 @@ pub use accessor::Accessor;
 pub use accessor::AccessorCapability;
 pub use accessor::AccessorHint;
 pub use accessor::AccessorInfo;
+pub use accessor::AccessorX;
+pub use accessor::EResult;
 pub use accessor::FusedAccessor;
 
 mod layer;

--- a/core/src/types/effect.rs
+++ b/core/src/types/effect.rs
@@ -15,48 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-mod mode;
-pub use mode::EntryMode;
+pub trait Effect {}
 
-mod entry;
-pub use entry::Entry;
+pub struct Async;
+impl Effect for Async {}
 
-mod metadata;
-pub use metadata::Metadata;
-pub use metadata::Metakey;
-
-mod reader;
-pub use reader::BlockingReader;
-pub use reader::Reader;
-
-mod writer;
-pub use writer::BlockingWriter;
-pub use writer::Writer;
-
-mod list;
-pub use list::BlockingLister;
-pub use list::Lister;
-
-mod operator;
-pub use operator::BlockingOperator;
-pub use operator::Operator;
-pub use operator::OperatorBuilder;
-pub use operator::OperatorInfo;
-
-mod builder;
-pub use builder::Builder;
-
-mod error;
-pub use error::Error;
-pub use error::ErrorKind;
-pub use error::Result;
-
-mod scheme;
-pub use scheme::Scheme;
-
-mod effect;
-pub use effect::Async;
-pub use effect::Blocking;
-pub use effect::Effect;
-
-pub mod ops;
+pub struct Blocking;
+impl Effect for Blocking {}


### PR DESCRIPTION
This PR is for researching. PLEASE DON'T MERGE.

I expect to expose something like this to users:

```rust
pub struct Operator<Effect>;

pub type AsyncOperator = Operator<Async>;
pub type BlockingOperator = Operator<Blocking>;
```

So users can:

- Use `AsyncOperator` if they want to use inside async context.
- Use `BlockingOperator` if they want to use inside blocking context.
- Use `Operator<Effect>` in context that they want to support both async and blocking context

Take databend's block reader as an example, they can:

```rust
struct BlockReader<E> {
  op: Operator<E>
}

impl BlockReader<Async> {
   ...
}

impl BlockReader<Blocking> {
   ...
}
```

---

After the Rust `keyword generic` becomes stable, we can migrate to it.