### PR TITLE
Add check for s3 bucket name

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -1687,10 +1687,10 @@ mod tests {
             ("test.xyz", true, false),
         ];
 
-        for (bucket, enable_virutal_host_style, expected) in bucket_cases {
+        for (bucket, enable_virtual_host_style, expected) in bucket_cases {
             let mut b = S3Builder::default();
             b.bucket(bucket);
-            if enable_virutal_host_style {
+            if enable_virtual_host_style {
                 b.enable_virtual_host_style();
             }
             assert_eq!(b.is_bucket_valid(), expected)


### PR DESCRIPTION
For issue https://github.com/apache/incubator-opendal/issues/1375, changes include:

- Add a helper function `is_valid_bucket`, combine non empty check and `enable_virtual_host_style` check for bucket name
- Update `build_endpoint` and `build` functions to apply the helper
- Add unit tests