### PR TITLE
feat: add move support for opendal

### DIFF
--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -363,6 +363,46 @@ impl<A: Accessor> LayeredAccessor for LoggingAccessor<A> {
             })
     }
 
+    async fn moves(&self, from: &str, to: &str, args: OpMove) -> Result<RpMove> {
+        debug!(
+            target: LOGGING_TARGET,
+            "service={} operation={} from={} to={} -> started",
+            self.scheme,
+            Operation::Moves,
+            from,
+            to
+        );
+        self.inner
+            .moves(from, to, args)
+            .await
+            .map(|v| {
+                debug!(
+                    target: LOGGING_TARGET,
+                    "service={} operation={} from={} to={} -> finished",
+                    self.scheme,
+                    Operation::Moves,
+                    from,
+                    to
+                );
+                v
+            })
+            .map_err(|err| {
+                if let Some(lvl) = self.err_level(&err) {
+                    log!(
+                        target: LOGGING_TARGET,
+                        lvl,
+                        "service={} operation={} from={} to={} -> {}: {err:?}",
+                        self.scheme,
+                        Operation::Moves,
+                        from,
+                        to,
+                        self.err_status(&err)
+                    )
+                };
+                err
+            })
+    }
+
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
         debug!(
             target: LOGGING_TARGET,
@@ -776,6 +816,45 @@ impl<A: Accessor> LayeredAccessor for LoggingAccessor<A> {
                         self.err_status(&err)
                     );
                 }
+                err
+            })
+    }
+
+    fn blocking_moves(&self, from: &str, to: &str, args: OpMove) -> Result<RpMove> {
+        debug!(
+            target: LOGGING_TARGET,
+            "service={} operation={} from={} to={} -> started",
+            self.scheme,
+            Operation::BlockingMoves,
+            from,
+            to
+        );
+        self.inner
+            .blocking_moves(from, to, args)
+            .map(|v| {
+                debug!(
+                    target: LOGGING_TARGET,
+                    "service={} operation={} from={} to={} -> finished",
+                    self.scheme,
+                    Operation::BlockingMoves,
+                    from,
+                    to
+                );
+                v
+            })
+            .map_err(|err| {
+                if let Some(lvl) = self.err_level(&err) {
+                    log!(
+                        target: LOGGING_TARGET,
+                        lvl,
+                        "service={} operation={} from={} to={} -> {}: {err:?}",
+                        self.scheme,
+                        Operation::BlockingMoves,
+                        from,
+                        to,
+                        self.err_status(&err)
+                    )
+                };
                 err
             })
     }

--- a/core/src/raw/layer.rs
+++ b/core/src/raw/layer.rs
@@ -163,6 +163,10 @@ pub trait LayeredAccessor: Send + Sync + Debug + Unpin + 'static {
         self.inner().copy(from, to, args).await
     }
 
+    async fn moves(&self, from: &str, to: &str, args: OpMove) -> Result<RpMove> {
+        self.inner().moves(from, to, args).await
+    }
+
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
         self.inner().stat(path, args).await
     }
@@ -193,6 +197,10 @@ pub trait LayeredAccessor: Send + Sync + Debug + Unpin + 'static {
 
     fn blocking_copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
         self.inner().blocking_copy(from, to, args)
+    }
+
+    fn blocking_moves(&self, from: &str, to: &str, args: OpMove) -> Result<RpMove> {
+        self.inner().blocking_moves(from, to, args)
     }
 
     fn blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/raw/operation.rs
+++ b/core/src/raw/operation.rs
@@ -32,6 +32,8 @@ pub enum Operation {
     Write,
     /// Operation for [`crate::raw::Accessor::copy`]
     Copy,
+    /// Operation for [`crate::raw::Accessor::moves`]
+    Moves,
     /// Operation for [`crate::raw::Accessor::stat`]
     Stat,
     /// Operation for [`crate::raw::Accessor::delete`]
@@ -52,6 +54,8 @@ pub enum Operation {
     BlockingWrite,
     /// Operation for [`crate::raw::Accessor::blocking_copy`]
     BlockingCopy,
+    /// Operation for [`crate::raw::Accessor::blocking_moves`]
+    BlockingMoves,
     /// Operation for [`crate::raw::Accessor::blocking_stat`]
     BlockingStat,
     /// Operation for [`crate::raw::Accessor::blocking_delete`]
@@ -89,6 +93,7 @@ impl From<Operation> for &'static str {
             Operation::Read => "read",
             Operation::Write => "write",
             Operation::Copy => "copy",
+            Operation::Moves => "moves",
             Operation::Stat => "stat",
             Operation::Delete => "delete",
             Operation::List => "list",
@@ -103,6 +108,7 @@ impl From<Operation> for &'static str {
             Operation::BlockingDelete => "blocking_delete",
             Operation::BlockingList => "blocking_list",
             Operation::BlockingScan => "blocking_scan",
+            Operation::BlockingMoves => "blocking_moves",
         }
     }
 }

--- a/core/src/raw/rps.rs
+++ b/core/src/raw/rps.rs
@@ -210,6 +210,17 @@ impl RpCopy {
     }
 }
 
+/// Reply for `moves` operation.
+#[derive(Debug, Clone, Default)]
+pub struct RpMove {}
+
+impl RpMove {
+    /// Create a new reply for moves.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::Result;

--- a/core/src/types/operator/blocking_operator.rs
+++ b/core/src/types/operator/blocking_operator.rs
@@ -505,6 +505,41 @@ impl BlockingOperator {
         Ok(())
     }
 
+    /// Moves object from `from` to `to`.
+    ///
+    /// # Notes
+    ///
+    /// - `from` and `to` MUST be within the working directory.
+    /// - `to` MUST be file path.
+    /// - Moving non-existing file/directory SHOULD fail.
+    /// - Moving to a directory path SHOULD fail.
+    /// - Moving directory to a file path SHOULD:
+    ///     - path not occupied: rename into `<path>/`, succeed.
+    ///     - path occupied by file: fail.
+    /// - Moving file to a file path SHOULD:
+    ///     - path not occupied: rename, succeed.
+    ///     - path occupied by file: rewrite and truncate, succeed.
+    ///
+    /// ## Term
+    /// - `directory`: path ends with '/'.
+    /// - `file`: path does not end with '/'.
+    ///
+    /// # Example
+    /// ```
+    /// # use std::io::Result;
+    /// # use opendal::BlockingOperator;
+    /// # fn test(op: BlockingOperator) -> Result<()> {
+    /// op.moves("path/to/file", "path/to/file2")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn moves(&self, from: &str, to: &str) -> Result<()> {
+        let from = normalize_path(from);
+        let to = normalize_path(to);
+        self.inner().blocking_moves(&from, &to, OpMove::new())?;
+        Ok(())
+    }
+
     /// Write data with option described in OpenDAL [rfc-0661](../../docs/rfcs/0661-path-in-accessor.md)
     ///
     /// # Notes

--- a/core/src/types/operator/metadata.rs
+++ b/core/src/types/operator/metadata.rs
@@ -62,6 +62,11 @@ impl OperatorInfo {
         self.0.capabilities().contains(AccessorCapability::Copy)
     }
 
+    /// Check if current backend supports [`Accessor::moves`] or not.
+    pub fn can_moves(&self) -> bool {
+        self.0.capabilities().contains(AccessorCapability::Moves)
+    }
+
     /// Check if current backend supports [`Accessor::list`] or not.
     pub fn can_list(&self) -> bool {
         self.0.capabilities().contains(AccessorCapability::List)

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -603,6 +603,41 @@ impl Operator {
         Ok(())
     }
 
+    /// Moves object from `from` to `to`.
+    ///
+    /// # Notes
+    ///
+    /// - `from` and `to` MUST be within the working directory.
+    /// - `to` MUST be file path.
+    /// - Moving non-existing file/directory SHOULD fail.
+    /// - Moving to a directory path SHOULD fail.
+    /// - Moving directory to a file path SHOULD:
+    ///     - path not occupied: rename into `<path>/`, succeed.
+    ///     - path occupied by file: fail.
+    /// - Moving file to a file path SHOULD:
+    ///     - path not occupied: rename, succeed.
+    ///     - path occupied by file: rewrite and truncate, succeed.
+    ///
+    /// ## Term
+    /// - `directory`: path ends with '/'.
+    /// - `file`: path does not end with '/'.
+    ///
+    /// # Example
+    /// ```
+    /// # use std::io::Result;
+    /// # use opendal::Operator;
+    /// # async fn test(op: Operator) -> Result<()> {
+    /// op.moves("path/to/file", "path/to/file2").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn moves(&self, from: &str, to: &str) -> Result<()> {
+        let from = normalize_path(from);
+        let to = normalize_path(to);
+        self.inner().moves(&from, &to, OpMove::new()).await?;
+        Ok(())
+    }
+
     /// Write multiple bytes into path.
     ///
     /// # Notes

--- a/core/src/types/ops.rs
+++ b/core/src/types/ops.rs
@@ -372,3 +372,14 @@ impl OpCopy {
         Self::default()
     }
 }
+
+/// Args for `moves` operation
+#[derive(Debug, Clone, Default)]
+pub struct OpMove {}
+
+impl OpMove {
+    /// Create a new `moves`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/core/tests/behavior/blocking_copy.rs
+++ b/core/tests/behavior/blocking_copy.rs
@@ -25,6 +25,7 @@ use super::utils::*;
 ///
 /// - can_read
 /// - can_write
+/// - can_copy
 /// - can_blocking
 macro_rules! behavior_blocking_copy_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {

--- a/core/tests/behavior/blocking_moves.rs
+++ b/core/tests/behavior/blocking_moves.rs
@@ -1,0 +1,245 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use anyhow::Result;
+use opendal::BlockingOperator;
+use opendal::ErrorKind;
+
+use super::utils::*;
+
+/// Test services that meet the following capability:
+///
+/// - can_read
+/// - can_write
+/// - can_moves
+/// - can_blocking
+macro_rules! behavior_blocking_moves_test {
+    ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
+        paste::item! {
+            mod [<services_ $service:lower _blocking_moves>] {
+                $(
+                    #[tokio::test]
+                    $(
+                        #[$meta]
+                    )*
+                    async fn [< $test >]() -> anyhow::Result<()> {
+                        let op = $crate::utils::init_service::<opendal::services::$service>(true);
+                        match op {
+                            Some(op) if op.info().can_read()
+                              && op.info().can_write()
+                              && op.info().can_moves()
+                              && op.info().can_blocking()
+                              => $crate::blocking_moves::$test(op.blocking()),
+                            Some(_) => {
+                                log::warn!("service {} doesn't support blocking_moves, ignored", opendal::Scheme::$service);
+                                Ok(())
+                            },
+                            None => {
+                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                                Ok(())
+                            }
+                        }
+                    }
+                )*
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! behavior_blocking_moves_tests {
+     ($($service:ident),*) => {
+        $(
+            behavior_blocking_moves_test!(
+                $service,
+
+                test_moves_file,
+                test_moves_dir,
+                test_moves_non_existing_source,
+                test_moves_file_to_directory,
+                test_moves_dir_to_dir,
+                test_moves_self,
+                test_moves_nested,
+                test_moves_overwrite,
+
+            );
+        )*
+    };
+}
+
+// moves file and test with stat.
+pub fn test_moves_file(op: BlockingOperator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (source_content, _) = gen_bytes();
+
+    op.write(&source_path, source_content.clone())?;
+
+    let target_path = uuid::Uuid::new_v4().to_string();
+
+    op.moves(&source_path, &target_path)?;
+
+    let read_source_err = op.stat(&source_path).expect_err("read source must fail");
+    assert_eq!(read_source_err.kind(), ErrorKind::NotFound);
+
+    let target_content = op.read(&target_path).expect("read must succeed");
+    assert_eq!(target_content, source_content);
+
+    op.delete(&target_path).expect("delete must succeed");
+    Ok(())
+}
+
+// Moving directory and test with stat.
+pub fn test_moves_dir(op: BlockingOperator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string() + "/";
+    let sub_file = format!("{}{}", source_path, uuid::Uuid::new_v4());
+    let (source_content, _) = gen_bytes();
+
+    op.write(&sub_file, source_content.clone())?;
+
+    let target_path = uuid::Uuid::new_v4().to_string();
+
+    op.moves(&source_path, &target_path)?;
+
+    let read_source_err = op
+        .stat(&sub_file)
+        .expect_err("read source sub file must fail");
+    assert_eq!(read_source_err.kind(), ErrorKind::NotFound);
+
+    let target_sub_file = format!("{}/{}", target_path, sub_file);
+    let target_content = op.read(&target_sub_file).expect("read must succeed");
+    assert_eq!(target_content, source_content);
+
+    op.delete(&target_path).expect("delete must succeed");
+    Ok(())
+}
+
+// Moving a nonexistent source should return an error.
+pub fn test_moves_non_existing_source(op: BlockingOperator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let target_path = uuid::Uuid::new_v4().to_string();
+
+    let err = op
+        .moves(&source_path, &target_path)
+        .expect_err("moves must fail");
+    assert_eq!(err.kind(), ErrorKind::NotFound);
+    Ok(())
+}
+
+// Moving file to a dir should return an error.
+pub fn test_moves_file_to_directory(op: BlockingOperator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (content, _) = gen_bytes();
+
+    op.write(&source_path, content)?;
+
+    let target_path = format!("{}/", uuid::Uuid::new_v4());
+
+    op.create_dir(&target_path)?;
+
+    let err = op
+        .moves(&source_path, &target_path)
+        .expect_err("moves must fail");
+    assert_eq!(err.kind(), ErrorKind::IsADirectory);
+
+    op.delete(&target_path).expect("delete must succeed");
+    Ok(())
+}
+
+// Moving directory to a dir
+pub fn test_moves_dir_to_dir(op: BlockingOperator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string() + "/";
+    op.create_dir(&source_path)?;
+
+    let target_path = format!("{}/", uuid::Uuid::new_v4());
+    op.create_dir(&target_path)?;
+
+    let occupy = format!("{}{}", target_path, uuid::Uuid::new_v4());
+    op.write(
+        &occupy,
+        b"this file is used for occupying the directory, and making move fail".to_vec(),
+    )?;
+
+    let err = op
+        .moves(&source_path, &target_path)
+        .expect_err("moves directory to non-empty directory must fail");
+
+    assert_eq!(err.kind(), ErrorKind::AlreadyExists);
+
+    op.delete(&occupy).expect("delete must succeed");
+
+    let _ = op
+        .moves(&source_path, &target_path)
+        .expect("moves directory to empty directory should success");
+
+    op.delete(&target_path).expect("delete must succeed");
+    Ok(())
+}
+
+// Moving to self should be allowed
+pub fn test_moves_self(op: BlockingOperator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (content, _) = gen_bytes();
+
+    op.write(&source_path, content)?;
+
+    let _ = op
+        .moves(&source_path, &source_path)
+        .expect("move must success");
+
+    op.delete(&source_path).expect("delete must succeed");
+    Ok(())
+}
+
+// Move to a nested path, parent path should be created successfully.
+pub fn test_moves_nested(op: BlockingOperator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (source_content, _) = gen_bytes();
+
+    op.write(&source_path, source_content.clone())?;
+
+    let target_path = format!("{}/{}", uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+
+    op.moves(&source_path, &target_path)?;
+
+    let target_content = op.read(&target_path).expect("read must succeed");
+    assert_eq!(target_content, source_content);
+
+    op.delete(&target_path).expect("delete must succeed");
+    Ok(())
+}
+
+// Copy to a exist path should overwrite successfully.
+pub fn test_moves_overwrite(op: BlockingOperator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (source_content, _) = gen_bytes();
+
+    op.write(&source_path, source_content.clone())?;
+
+    let target_path = uuid::Uuid::new_v4().to_string();
+    let (target_content, _) = gen_bytes();
+    assert_ne!(source_content, target_content);
+
+    op.write(&target_path, target_content)?;
+
+    op.moves(&source_path, &target_path)?;
+
+    let target_content = op.read(&target_path).expect("read must succeed");
+    assert_eq!(target_content, source_content);
+
+    op.delete(&target_path).expect("delete must succeed");
+    Ok(())
+}

--- a/core/tests/behavior/main.rs
+++ b/core/tests/behavior/main.rs
@@ -24,6 +24,8 @@ mod blocking_read;
 #[macro_use]
 mod blocking_write;
 #[macro_use]
+mod blocking_moves;
+#[macro_use]
 mod copy;
 #[macro_use]
 mod list;
@@ -35,6 +37,8 @@ mod presign;
 mod read_only;
 #[macro_use]
 mod write;
+#[macro_use]
+mod moves;
 
 mod utils;
 
@@ -53,6 +57,10 @@ macro_rules! behavior_tests {
             behavior_blocking_write_tests!($service);
             // can_read && can_write && can_copy
             behavior_copy_tests!($service);
+            // can_read && can_write && can_moves
+            behavior_moves_tests!($service);
+            // can_read && can_write && can_moves && can_blocking
+            behavior_blocking_moves_tests!($service);
             // can read && can_write && can_blocking && can_copy
             behavior_blocking_copy_tests!($service);
             // can_read && can_write && can_list

--- a/core/tests/behavior/moves.rs
+++ b/core/tests/behavior/moves.rs
@@ -1,0 +1,252 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use anyhow::Result;
+use opendal::ErrorKind;
+use opendal::Operator;
+
+use super::utils::*;
+
+/// Test services that meet the following capability:
+///
+/// - can_read
+/// - can_write
+/// - can_moves
+macro_rules! behavior_moves_test {
+    ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
+        paste::item! {
+            mod [<services_ $service:lower _moves>] {
+                $(
+                    #[tokio::test]
+                    $(
+                        #[$meta]
+                    )*
+                    async fn [< $test >]() -> anyhow::Result<()> {
+                        let op = $crate::utils::init_service::<opendal::services::$service>(true);
+                        match op {
+                            Some(op) if op.info().can_read()
+                              && op.info().can_write()
+                              && op.info().can_moves() => $crate::moves::$test(op).await,
+                            Some(_) => {
+                                log::warn!("service {} doesn't support moves, ignored", opendal::Scheme::$service);
+                                Ok(())
+                            },
+                            None => {
+                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                                Ok(())
+                            }
+                        }
+                    }
+                )*
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! behavior_moves_tests {
+     ($($service:ident),*) => {
+        $(
+            behavior_moves_test!(
+                $service,
+
+                test_moves_file,
+                test_moves_dir,
+                test_moves_non_existing_source,
+                test_moves_file_to_directory,
+                test_moves_dir_to_dir,
+                test_moves_self,
+                test_moves_nested,
+                test_moves_overwrite,
+
+            );
+        )*
+    };
+}
+
+// moves file and test with stat.
+pub async fn test_moves_file(op: Operator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (source_content, _) = gen_bytes();
+
+    op.write(&source_path, source_content.clone()).await?;
+
+    let target_path = uuid::Uuid::new_v4().to_string();
+
+    op.moves(&source_path, &target_path).await?;
+
+    let read_source_err = op
+        .stat(&source_path)
+        .await
+        .expect_err("read source must fail");
+    assert_eq!(read_source_err.kind(), ErrorKind::NotFound);
+
+    let target_content = op.read(&target_path).await.expect("read must succeed");
+    assert_eq!(target_content, source_content);
+
+    op.delete(&target_path).await.expect("delete must succeed");
+    Ok(())
+}
+
+// Moving directory and test with stat.
+pub async fn test_moves_dir(op: Operator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string() + "/";
+    let sub_file = format!("{}{}", source_path, uuid::Uuid::new_v4());
+    let (source_content, _) = gen_bytes();
+
+    op.write(&sub_file, source_content.clone()).await?;
+
+    let target_path = uuid::Uuid::new_v4().to_string();
+
+    op.moves(&source_path, &target_path).await?;
+
+    let read_source_err = op
+        .stat(&sub_file)
+        .await
+        .expect_err("read source sub file must fail");
+    assert_eq!(read_source_err.kind(), ErrorKind::NotFound);
+
+    let target_sub_file = format!("{}/{}", target_path, sub_file);
+    let target_content = op.read(&target_sub_file).await.expect("read must succeed");
+    assert_eq!(target_content, source_content);
+
+    op.delete(&target_path).await.expect("delete must succeed");
+    Ok(())
+}
+
+// Moving a nonexistent source should return an error.
+pub async fn test_moves_non_existing_source(op: Operator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let target_path = uuid::Uuid::new_v4().to_string();
+
+    let err = op
+        .moves(&source_path, &target_path)
+        .await
+        .expect_err("moves must fail");
+    assert_eq!(err.kind(), ErrorKind::NotFound);
+    Ok(())
+}
+
+// Moving file to a dir should return an error.
+pub async fn test_moves_file_to_directory(op: Operator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (content, _) = gen_bytes();
+
+    op.write(&source_path, content).await?;
+
+    let target_path = format!("{}/", uuid::Uuid::new_v4());
+
+    op.create_dir(&target_path).await?;
+
+    let err = op
+        .moves(&source_path, &target_path)
+        .await
+        .expect_err("moves must fail");
+    assert_eq!(err.kind(), ErrorKind::IsADirectory);
+
+    op.delete(&target_path).await.expect("delete must succeed");
+    Ok(())
+}
+
+// Moving directory to a dir
+pub async fn test_moves_dir_to_dir(op: Operator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string() + "/";
+    op.create_dir(&source_path).await?;
+
+    let target_path = format!("{}/", uuid::Uuid::new_v4());
+    op.create_dir(&target_path).await?;
+
+    let occupy = format!("{}{}", target_path, uuid::Uuid::new_v4());
+    op.write(
+        &occupy,
+        b"this file is used for occupying the directory, and making move fail".to_vec(),
+    )
+    .await?;
+
+    let err = op
+        .moves(&source_path, &target_path)
+        .await
+        .expect_err("moves directory to non-empty directory must fail");
+
+    assert_eq!(err.kind(), ErrorKind::AlreadyExists);
+
+    op.delete(&occupy).await.expect("delete must succeed");
+
+    let _ = op
+        .moves(&source_path, &target_path)
+        .await
+        .expect("moves directory to empty directory should success");
+
+    op.delete(&target_path).await.expect("delete must succeed");
+    Ok(())
+}
+
+// Moving to self should be allowed
+pub async fn test_moves_self(op: Operator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (content, _) = gen_bytes();
+
+    op.write(&source_path, content).await?;
+
+    let _ = op
+        .moves(&source_path, &source_path)
+        .await
+        .expect("move must success");
+
+    op.delete(&source_path).await.expect("delete must succeed");
+    Ok(())
+}
+
+// Move to a nested path, parent path should be created successfully.
+pub async fn test_moves_nested(op: Operator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (source_content, _) = gen_bytes();
+
+    op.write(&source_path, source_content.clone()).await?;
+
+    let target_path = format!("{}/{}", uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+
+    op.moves(&source_path, &target_path).await?;
+
+    let target_content = op.read(&target_path).await.expect("read must succeed");
+    assert_eq!(target_content, source_content);
+
+    op.delete(&target_path).await.expect("delete must succeed");
+    Ok(())
+}
+
+// Copy to a exist path should overwrite successfully.
+pub async fn test_moves_overwrite(op: Operator) -> Result<()> {
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (source_content, _) = gen_bytes();
+
+    op.write(&source_path, source_content.clone()).await?;
+
+    let target_path = uuid::Uuid::new_v4().to_string();
+    let (target_content, _) = gen_bytes();
+    assert_ne!(source_content, target_content);
+
+    op.write(&target_path, target_content).await?;
+
+    op.moves(&source_path, &target_path).await?;
+
+    let target_content = op.read(&target_path).await.expect("read must succeed");
+    assert_eq!(target_content, source_content);
+
+    op.delete(&target_path).await.expect("delete must succeed");
+    Ok(())
+}


### PR DESCRIPTION
`move` is on the 2023 road map of opendal. This PR implements this feature.

== implemented:

1. raw::accessor api's blocking `moves` and `blocking_moves`
2. Operator's `moves`
3. BlockingOperator's `blocking_moves`
4. services::fs's `moves` and `blocking_moves`
5. behavior test's `moves` and `blocking_moves` tests

== notes about this PR:

- `move` unfortunately is a keyword in rust, so I have to use `moves`
- thanks to @suyanhanxx's copy support