### PR TITLE
feat: deterministic simulation support

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -92,6 +92,7 @@ anyhow = { version = "1.0.30", features = ["std"] }
 async-compat = "0.2"
 async-tls = { version = "0.11", optional = true }
 async-trait = "0.1.68"
+aws-sdk-s3 = { version = "0.2", package = "madsim-aws-sdk-s3" }
 backon = "0.4.0"
 base64 = "0.21"
 bb8 = { version = "0.8", optional = true }
@@ -104,6 +105,7 @@ http = "0.2.5"
 hyper = "0.14"
 lazy-regex = { version = "2.5.0", optional = true }
 log = "0.4"
+madsim = "0.2"
 md-5 = "0.10"
 metrics = { version = "0.20", optional = true }
 moka = { version = "0.10", optional = true, features = ["future"] }

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,0 +1,2 @@
+test_s3_sim:
+	RUSTFLAGS="--cfg madsim" cargo test S3

--- a/core/src/docs/concepts.rs
+++ b/core/src/docs/concepts.rs
@@ -19,7 +19,7 @@
 //!
 //! OpenDAL provides a unified abstraction for all storage services.
 //!
-//! There are three core concepts in OpenDAL:
+//! There are two core concepts in OpenDAL:
 //!
 //! - [`Builder`]: Build an instance of underlying services.
 //! - [`Operator`]: A bridge between underlying implementation detail and unified abstraction.


### PR DESCRIPTION
Hi, this is a very simple demo that illustrates the overall idea. The are some issues that need to be discussed.

1. Madsim has already provided a wrapper for aws-sdk-s3 crate, something like this: 
```rust
#[cfg(madsim)]
#[path = "sim.rs"]
mod sim;

#[cfg(not(madsim))]
pub use aws_sdk_s3::*;
#[cfg(madsim)]
pub use sim::*;
```
  Should we reuse the S3 simulation logic from the madsim wrapper or develop our own?If we use madsim's simulation, since the interface simulated by madsim and that of aws-sdk-s3 are the same, we need to use that interface to implement our `Accessor` trait. If we choose to develop our own simulation logic, we need to completely eliminate uncertainty, such as multi-threaded scheduling(seems a lot of work).

2. Can different backends use the same simulation? For example, S3 and OSS may be similar, but I'm not sure.