### PR TITLE
Add docs buttons to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenDAL &emsp; [![Build Status]][actions] [![chat]][discord]
+# OpenDAL &emsp; [![Build Status]][actions] [![chat]][discord] [![Rust Docs](https://img.shields.io/badge/docs-rust-brightgreen)](https://opendal.apache.org/docs/rust/opendal/index.html) [![Python Docs](https://img.shields.io/badge/docs-python-brightgreen)](https://opendal.apache.org/docs/python/opendal.html)
 
 [build status]: https://img.shields.io/github/actions/workflow/status/apache/incubator-opendal/ci.yml?branch=main
 [actions]: https://github.com/apache/incubator-opendal/actions?query=branch%3Amain

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,4 +1,4 @@
-# OpenDAL Python Binding
+# OpenDAL Python Binding [![Python Docs](https://img.shields.io/badge/docs-python-brightgreen)](https://opendal.apache.org/docs/python/opendal.html)
 
 This crate intends to build a native python binding.
 


### PR DESCRIPTION
- add python and rust docs buttons to root README.md
- add python docs button to the python binding README.md