### PR TITLE
docs: Adding docs link to python binding

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,5 +1,7 @@
 # OpenDAL Python Binding
 
+Documentation: [main](https://opendal.apache.org/docs/python/)
+
 This crate intends to build a native python binding.
 
 ## Installation


### PR DESCRIPTION
Following up from #1920 