### PR TITLE
feat(layers): add a basic minitrace layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,6 +1921,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minitrace"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317e28b8c337ada2fd437611c241ce053d5b7f5480b79e945597996b87b1de96"
+dependencies = [
+ "futures",
+ "minitrace-macro",
+ "minstant",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "pin-project",
+]
+
+[[package]]
+name = "minitrace-macro"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77814d165883613a1846517efdc50b88fabd9c210b7ff4d3745b38b99d539652"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "minstant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5dcfca9a0725105ac948b84cfeb69c3942814c696326743797215413f854b9"
+dependencies = [
+ "ctor",
+ "libc",
+ "wasi 0.7.0",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,6 +2255,7 @@ dependencies = [
  "log",
  "md-5",
  "metrics",
+ "minitrace",
  "moka",
  "once_cell",
  "opentelemetry 0.19.0",
@@ -2736,6 +2774,30 @@ dependencies = [
  "diff",
  "output_vt100",
  "yansi",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -4268,6 +4330,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 
 [[package]]
 name = "wasi"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -68,11 +68,18 @@ native-tls = ["reqwest/native-tls"]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
 
 # Enable all layers.
-layers-all = ["layers-chaos", "layers-metrics", "layers-tracing"]
+layers-all = [
+  "layers-chaos",
+  "layers-metrics",
+  "layers-tracing",
+  "layers-minitrace",
+]
 # Enable layers chaos support
 layers-chaos = ["dep:rand"]
 # Enable layers metrics support
 layers-metrics = ["dep:metrics"]
+# Enable layers minitrace support.
+layers-minitrace = ["dep:minitrace"]
 # Enable layers tracing support.
 layers-tracing = ["dep:tracing"]
 
@@ -150,6 +157,7 @@ lazy-regex = { version = "2.5.0", optional = true }
 log = "0.4"
 md-5 = "0.10"
 metrics = { version = "0.20", optional = true }
+minitrace = { version = "0.4.0", optional = true }
 moka = { version = "0.10", optional = true, features = ["future"] }
 once_cell = "1"
 parking_lot = "0.12"

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -1,0 +1,340 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::Debug;
+use std::io;
+use std::task::Context;
+use std::task::Poll;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::FutureExt;
+use minitrace::trace;
+
+use crate::ops::*;
+use crate::raw::*;
+use crate::*;
+
+/// Add [minitrace](https://docs.rs/minitrace/) for every operations.
+///
+/// # Examples
+///
+/// ## Basic Setup
+///
+/// ```
+/// use anyhow::Result;
+/// use opendal::layers::MinitraceLayer;
+/// use opendal::services;
+/// use opendal::Operator;
+///
+/// let _ = Operator::new(services::Memory::default())
+///     .expect("must init")
+///     .layer(MinitraceLayer)
+///     .finish();
+/// ```
+///
+/// ## Real usage
+///
+/// ```no_run
+/// use std::error::Error;
+///
+/// use anyhow::Result;
+/// use futures::executor::block_on;
+/// use opendal::layers::MinitraceLayer;
+/// use opendal::services;
+/// use opendal::Operator;
+///
+/// fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+///     let collector = {
+///         let (span, collector) = minitrace::Span::root("op");
+///         let _g = span.set_local_parent();
+///         let runtime = tokio::runtime::Runtime::new()?;
+///
+///         runtime.block_on(async {
+///             let _ = dotenvy::dotenv();
+///             let op = Operator::from_env::<services::Memory>()
+///                 .expect("init operator must succeed")
+///                 .layer(MinitraceLayer)
+///                 .finish();
+///
+///             op.write("test", "0".repeat(16 * 1024 * 1024).into_bytes())
+///                 .await
+///                 .expect("must succeed");
+///             op.stat("test").await.expect("must succeed");
+///             op.read("test").await.expect("must succeed");
+///         });
+///         collector
+///     };
+///
+///     let spans = block_on(collector.collect());
+///
+///     let bytes =
+///         minitrace_jaeger::encode("opendal".to_owned(), rand::random(), 0, 0, &spans).unwrap();
+///     minitrace_jaeger::report_blocking("127.0.0.1:6831".parse().unwrap(), &bytes)
+///         .expect("report error");
+///
+///     Ok(())
+/// }
+/// ```
+///
+/// # Output
+///
+/// OpenDAL is using [`minitrace`](https://docs.rs/minitrace/latest/minitrace/) for tracing internally.
+///
+/// To enable minitrace output, please init one of the reporter that `minitrace` supports.
+///
+/// For example:
+///
+/// ```ignore
+/// extern crate minitrace_jaeger;
+///
+/// let spans = block_on(collector.collect());
+///
+/// let bytes =
+///     minitrace_jaeger::encode("opendal".to_owned(), rand::random(), 0, 0, &spans).unwrap();
+/// minitrace_jaeger::report_blocking("127.0.0.1:6831".parse().unwrap(), &bytes).expect("report error");
+/// ```
+///
+/// For real-world usage, please take a look at [`minitrace-datadog`](https://crates.io/crates/minitrace-datadog) or [`minitrace-jaeger`](https://crates.io/crates/minitrace-jaeger) .
+pub struct MinitraceLayer;
+
+impl<A: Accessor> Layer<A> for MinitraceLayer {
+    type LayeredAccessor = MinitraceAccessor<A>;
+
+    fn layer(&self, inner: A) -> Self::LayeredAccessor {
+        MinitraceAccessor { inner }
+    }
+}
+
+#[derive(Debug)]
+pub struct MinitraceAccessor<A> {
+    inner: A,
+}
+
+#[async_trait]
+impl<A: Accessor> LayeredAccessor for MinitraceAccessor<A> {
+    type Inner = A;
+    type Reader = MinitraceWrapper<A::Reader>;
+    type BlockingReader = MinitraceWrapper<A::BlockingReader>;
+    type Writer = MinitraceWrapper<A::Writer>;
+    type BlockingWriter = MinitraceWrapper<A::BlockingWriter>;
+    type Pager = MinitraceWrapper<A::Pager>;
+    type BlockingPager = MinitraceWrapper<A::BlockingPager>;
+
+    fn inner(&self) -> &Self::Inner {
+        &self.inner
+    }
+
+    #[trace("metadata")]
+    fn metadata(&self) -> AccessorInfo {
+        self.inner.info()
+    }
+
+    #[trace("create", enter_on_poll = true)]
+    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        self.inner.create(path, args).await
+    }
+
+    #[trace("read", enter_on_poll = true)]
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        self.inner
+            .read(path, args)
+            .map(|v| v.map(|(rp, r)| (rp, MinitraceWrapper::new(r))))
+            .await
+    }
+
+    #[trace("write", enter_on_poll = true)]
+    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
+        self.inner
+            .write(path, args)
+            .await
+            .map(|(rp, r)| (rp, MinitraceWrapper::new(r)))
+    }
+
+    #[trace("stat", enter_on_poll = true)]
+    async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
+        self.inner.stat(path, args).await
+    }
+
+    #[trace("delete", enter_on_poll = true)]
+    async fn delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
+        self.inner.delete(path, args).await
+    }
+
+    #[trace("list", enter_on_poll = true)]
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
+        self.inner
+            .list(path, args)
+            .map(|v| v.map(|(rp, s)| (rp, MinitraceWrapper::new(s))))
+            .await
+    }
+
+    #[trace("scan", enter_on_poll = true)]
+    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        self.inner
+            .scan(path, args)
+            .map(|v| v.map(|(rp, s)| (rp, MinitraceWrapper::new(s))))
+            .await
+    }
+
+    #[trace("presign", enter_on_poll = true)]
+    async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
+        self.inner.presign(path, args).await
+    }
+
+    #[trace("batch", enter_on_poll = true)]
+    async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
+        self.inner.batch(args).await
+    }
+
+    #[trace("blocking_create")]
+    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        self.inner.blocking_create(path, args)
+    }
+
+    #[trace("blocking_read")]
+    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
+        self.inner
+            .blocking_read(path, args)
+            .map(|(rp, r)| (rp, MinitraceWrapper::new(r)))
+    }
+
+    #[trace("blocking_write")]
+    fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
+        self.inner
+            .blocking_write(path, args)
+            .map(|(rp, r)| (rp, MinitraceWrapper::new(r)))
+    }
+
+    #[trace("blocking_stat")]
+    fn blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
+        self.inner.blocking_stat(path, args)
+    }
+
+    #[trace("blocking_delete")]
+    fn blocking_delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
+        self.inner.blocking_delete(path, args)
+    }
+
+    #[trace("blocking_list")]
+    fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
+        self.inner
+            .blocking_list(path, args)
+            .map(|(rp, it)| (rp, MinitraceWrapper::new(it)))
+    }
+
+    #[trace("blocking_scan")]
+    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
+        self.inner
+            .blocking_scan(path, args)
+            .map(|(rp, it)| (rp, MinitraceWrapper::new(it)))
+    }
+}
+
+pub struct MinitraceWrapper<R> {
+    inner: R,
+}
+
+impl<R> MinitraceWrapper<R> {
+    fn new(inner: R) -> Self {
+        Self { inner }
+    }
+}
+
+impl<R: oio::Read> oio::Read for MinitraceWrapper<R> {
+    #[trace("poll_read")]
+    fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
+        self.inner.poll_read(cx, buf)
+    }
+
+    #[trace("poll_seek")]
+    fn poll_seek(&mut self, cx: &mut Context<'_>, pos: io::SeekFrom) -> Poll<Result<u64>> {
+        self.inner.poll_seek(cx, pos)
+    }
+
+    #[trace("poll_next")]
+    fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
+        self.inner.poll_next(cx)
+    }
+}
+
+impl<R: oio::BlockingRead> oio::BlockingRead for MinitraceWrapper<R> {
+    #[trace("read")]
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        self.inner.read(buf)
+    }
+
+    #[trace("seek")]
+    fn seek(&mut self, pos: io::SeekFrom) -> Result<u64> {
+        self.inner.seek(pos)
+    }
+
+    #[trace("next")]
+    fn next(&mut self) -> Option<Result<Bytes>> {
+        self.inner.next()
+    }
+}
+
+#[async_trait]
+impl<R: oio::Write> oio::Write for MinitraceWrapper<R> {
+    #[trace("write", enter_on_poll = true)]
+    async fn write(&mut self, bs: Bytes) -> Result<()> {
+        self.inner.write(bs).await
+    }
+
+    #[trace("append", enter_on_poll = true)]
+    async fn append(&mut self, bs: Bytes) -> Result<()> {
+        self.inner.append(bs).await
+    }
+
+    #[trace("close", enter_on_poll = true)]
+    async fn close(&mut self) -> Result<()> {
+        self.inner.close().await
+    }
+}
+
+impl<R: oio::BlockingWrite> oio::BlockingWrite for MinitraceWrapper<R> {
+    #[trace("write")]
+    fn write(&mut self, bs: Bytes) -> Result<()> {
+        self.inner.write(bs)
+    }
+
+    #[trace("append")]
+    fn append(&mut self, bs: Bytes) -> Result<()> {
+        self.inner.append(bs)
+    }
+
+    #[trace("close")]
+    fn close(&mut self) -> Result<()> {
+        self.inner.close()
+    }
+}
+
+#[async_trait]
+impl<R: oio::Page> oio::Page for MinitraceWrapper<R> {
+    #[trace("next", enter_on_poll = true)]
+    async fn next(&mut self) -> Result<Option<Vec<oio::Entry>>> {
+        self.inner.next().await
+    }
+}
+
+impl<R: oio::BlockingPage> oio::BlockingPage for MinitraceWrapper<R> {
+    #[trace("next")]
+    fn next(&mut self) -> Result<Option<Vec<oio::Entry>>> {
+        self.inner.next()
+    }
+}

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -151,32 +151,18 @@ impl<A: Accessor> LayeredAccessor for MinitraceAccessor<A> {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        let span = Span::enter_with_local_parent("read");
         self.inner
             .read(path, args)
-            .map(|v| {
-                v.map(|(rp, r)| {
-                    (
-                        rp,
-                        MinitraceWrapper::new(Span::enter_with_local_parent("ReadOperation"), r),
-                    )
-                })
-            })
-            .enter_on_poll("read")
+            .map(|v| v.map(|(rp, r)| (rp, MinitraceWrapper::new(span, r))))
             .await
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
+        let span = Span::enter_with_local_parent("write");
         self.inner
             .write(path, args)
-            .map(|v| {
-                v.map(|(rp, r)| {
-                    (
-                        rp,
-                        MinitraceWrapper::new(Span::enter_with_local_parent("WriteOperation"), r),
-                    )
-                })
-            })
-            .enter_on_poll("write")
+            .map(|v| v.map(|(rp, r)| (rp, MinitraceWrapper::new(span, r))))
             .await
     }
 
@@ -191,32 +177,18 @@ impl<A: Accessor> LayeredAccessor for MinitraceAccessor<A> {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
+        let span = Span::enter_with_local_parent("list");
         self.inner
             .list(path, args)
-            .map(|v| {
-                v.map(|(rp, s)| {
-                    (
-                        rp,
-                        MinitraceWrapper::new(Span::enter_with_local_parent("PageOperation"), s),
-                    )
-                })
-            })
-            .enter_on_poll("list")
+            .map(|v| v.map(|(rp, s)| (rp, MinitraceWrapper::new(span, s))))
             .await
     }
 
     async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
+        let span = Span::enter_with_local_parent("scan");
         self.inner
             .scan(path, args)
-            .map(|v| {
-                v.map(|(rp, s)| {
-                    (
-                        rp,
-                        MinitraceWrapper::new(Span::enter_with_local_parent("PageOperation"), s),
-                    )
-                })
-            })
-            .enter_on_poll("scan")
+            .map(|v| v.map(|(rp, s)| (rp, MinitraceWrapper::new(span, s))))
             .await
     }
 

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -256,34 +256,34 @@ impl<R> MinitraceWrapper<R> {
 }
 
 impl<R: oio::Read> oio::Read for MinitraceWrapper<R> {
-    #[trace("poll_read")]
+    #[trace("inner_poll_read")]
     fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
         self.inner.poll_read(cx, buf)
     }
 
-    #[trace("poll_seek")]
+    #[trace("inner_poll_seek")]
     fn poll_seek(&mut self, cx: &mut Context<'_>, pos: io::SeekFrom) -> Poll<Result<u64>> {
         self.inner.poll_seek(cx, pos)
     }
 
-    #[trace("poll_next")]
+    #[trace("inner_poll_next")]
     fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
         self.inner.poll_next(cx)
     }
 }
 
 impl<R: oio::BlockingRead> oio::BlockingRead for MinitraceWrapper<R> {
-    #[trace("read")]
+    #[trace("inner_blocking_read")]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         self.inner.read(buf)
     }
 
-    #[trace("seek")]
+    #[trace("inner_blocking_seek")]
     fn seek(&mut self, pos: io::SeekFrom) -> Result<u64> {
         self.inner.seek(pos)
     }
 
-    #[trace("next")]
+    #[trace("inner_blocking_next")]
     fn next(&mut self) -> Option<Result<Bytes>> {
         self.inner.next()
     }
@@ -291,34 +291,34 @@ impl<R: oio::BlockingRead> oio::BlockingRead for MinitraceWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for MinitraceWrapper<R> {
-    #[trace("write", enter_on_poll = true)]
+    #[trace("inner_write", enter_on_poll = true)]
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         self.inner.write(bs).await
     }
 
-    #[trace("append", enter_on_poll = true)]
+    #[trace("inner_append", enter_on_poll = true)]
     async fn append(&mut self, bs: Bytes) -> Result<()> {
         self.inner.append(bs).await
     }
 
-    #[trace("close", enter_on_poll = true)]
+    #[trace("inner_close", enter_on_poll = true)]
     async fn close(&mut self) -> Result<()> {
         self.inner.close().await
     }
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for MinitraceWrapper<R> {
-    #[trace("write")]
+    #[trace("inner_blocking_write")]
     fn write(&mut self, bs: Bytes) -> Result<()> {
         self.inner.write(bs)
     }
 
-    #[trace("append")]
+    #[trace("inner_blocking_append")]
     fn append(&mut self, bs: Bytes) -> Result<()> {
         self.inner.append(bs)
     }
 
-    #[trace("close")]
+    #[trace("inner_blocking_close")]
     fn close(&mut self) -> Result<()> {
         self.inner.close()
     }
@@ -326,14 +326,14 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for MinitraceWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Page> oio::Page for MinitraceWrapper<R> {
-    #[trace("next", enter_on_poll = true)]
+    #[trace("inner_next", enter_on_poll = true)]
     async fn next(&mut self) -> Result<Option<Vec<oio::Entry>>> {
         self.inner.next().await
     }
 }
 
 impl<R: oio::BlockingPage> oio::BlockingPage for MinitraceWrapper<R> {
-    #[trace("next")]
+    #[trace("inner_blocking_next")]
     fn next(&mut self) -> Result<Option<Vec<oio::Entry>>> {
         self.inner.next()
     }

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -237,7 +237,6 @@ impl<A: Accessor> LayeredAccessor for MinitraceAccessor<A> {
             .map(|(rp, it)| (rp, MinitraceWrapper::new(span, it)))
     }
 
-    #[trace("blocking_scan")]
     fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
         let span = Span::enter_with_local_parent("blocking_scan");
         self.inner
@@ -259,40 +258,34 @@ impl<R> MinitraceWrapper<R> {
 
 impl<R: oio::Read> oio::Read for MinitraceWrapper<R> {
     fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
-        let _guard = self.span.set_local_parent();
-        let _span = Span::enter_with_local_parent("inner_poll_read");
+        let _span = Span::enter_with_parent("inner_poll_read", &self.span);
         self.inner.poll_read(cx, buf)
     }
 
     fn poll_seek(&mut self, cx: &mut Context<'_>, pos: io::SeekFrom) -> Poll<Result<u64>> {
-        let _guard = self.span.set_local_parent();
-        let _span = Span::enter_with_local_parent("inner_poll_seek");
+        let _span = Span::enter_with_parent("inner_poll_seek", &self.span);
         self.inner.poll_seek(cx, pos)
     }
 
     fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
-        let _guard = self.span.set_local_parent();
-        let _span = Span::enter_with_local_parent("inner_poll_next");
+        let _span = Span::enter_with_parent("inner_poll_next", &self.span);
         self.inner.poll_next(cx)
     }
 }
 
 impl<R: oio::BlockingRead> oio::BlockingRead for MinitraceWrapper<R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let _guard = self.span.set_local_parent();
-        let _span = Span::enter_with_local_parent("inner_blocking_read");
+        let _span = Span::enter_with_parent("inner_blocking_read", &self.span);
         self.inner.read(buf)
     }
 
     fn seek(&mut self, pos: io::SeekFrom) -> Result<u64> {
-        let _guard = self.span.set_local_parent();
-        let _span = Span::enter_with_local_parent("inner_blocking_seek");
+        let _span = Span::enter_with_parent("inner_blocking_seek", &self.span);
         self.inner.seek(pos)
     }
 
     fn next(&mut self) -> Option<Result<Bytes>> {
-        let _guard = self.span.set_local_parent();
-        let _span = Span::enter_with_local_parent("inner_blocking_next");
+        let _span = Span::enter_with_parent("inner_blocking_next", &self.span);
         self.inner.next()
     }
 }
@@ -323,20 +316,17 @@ impl<R: oio::Write> oio::Write for MinitraceWrapper<R> {
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for MinitraceWrapper<R> {
     fn write(&mut self, bs: Bytes) -> Result<()> {
-        let _guard = self.span.set_local_parent();
-        let _span = Span::enter_with_local_parent("inner_blocking_write");
+        let _span = Span::enter_with_parent("inner_blocing_write", &self.span);
         self.inner.write(bs)
     }
 
     fn append(&mut self, bs: Bytes) -> Result<()> {
-        let _guard = self.span.set_local_parent();
-        let _span = Span::enter_with_local_parent("inner_blocking_append");
+        let _span = Span::enter_with_parent("inner_blocking_append", &self.span);
         self.inner.append(bs)
     }
 
     fn close(&mut self) -> Result<()> {
-        let _guard = self.span.set_local_parent();
-        let _span = Span::enter_with_local_parent("inner_blocking_close");
+        let _span = Span::enter_with_parent("inner_blocking_close", &self.span);
         self.inner.close()
     }
 }
@@ -353,8 +343,7 @@ impl<R: oio::Page> oio::Page for MinitraceWrapper<R> {
 
 impl<R: oio::BlockingPage> oio::BlockingPage for MinitraceWrapper<R> {
     fn next(&mut self) -> Result<Option<Vec<oio::Entry>>> {
-        let _guard = self.span.set_local_parent();
-        let _span = Span::enter_with_local_parent("inner_blocking_next");
+        let _span = Span::enter_with_parent("inner_blocking_next", &self.span);
         self.inner.next()
     }
 }

--- a/core/src/layers/mod.rs
+++ b/core/src/layers/mod.rs
@@ -44,6 +44,11 @@ mod tracing;
 #[cfg(feature = "layers-tracing")]
 pub use self::tracing::TracingLayer;
 
+#[cfg(feature = "layers-minitrace")]
+mod minitrace;
+#[cfg(feature = "layers-minitrace")]
+pub use self::minitrace::MinitraceLayer;
+
 mod type_eraser;
 pub(crate) use type_eraser::TypeEraseLayer;
 


### PR DESCRIPTION
It simply works and needs to consider how to properly reflect the parent-child relationship of the call.

![](https://user-images.githubusercontent.com/36896360/231551852-7fa0dc09-9e15-444a-8a6e-016dbd234794.png)

Fix #691 