### PR TITLE
test: Increate copy/move nested path test depth

### DIFF
--- a/core/tests/behavior/blocking_copy.rs
+++ b/core/tests/behavior/blocking_copy.rs
@@ -167,7 +167,12 @@ pub fn test_copy_nested(op: BlockingOperator) -> Result<()> {
 
     op.write(&source_path, source_content.clone())?;
 
-    let target_path = format!("{}/{}", uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+    let target_path = format!(
+        "{}/{}/{}",
+        uuid::Uuid::new_v4(),
+        uuid::Uuid::new_v4(),
+        uuid::Uuid::new_v4()
+    );
 
     op.copy(&source_path, &target_path)?;
 

--- a/core/tests/behavior/blocking_rename.rs
+++ b/core/tests/behavior/blocking_rename.rs
@@ -170,7 +170,12 @@ pub fn test_rename_nested(op: BlockingOperator) -> Result<()> {
 
     op.write(&source_path, source_content.clone())?;
 
-    let target_path = format!("{}/{}", uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+    let target_path = format!(
+        "{}/{}/{}",
+        uuid::Uuid::new_v4(),
+        uuid::Uuid::new_v4(),
+        uuid::Uuid::new_v4()
+    );
 
     op.rename(&source_path, &target_path)?;
 

--- a/core/tests/behavior/copy.rs
+++ b/core/tests/behavior/copy.rs
@@ -170,7 +170,12 @@ pub async fn test_copy_nested(op: Operator) -> Result<()> {
 
     op.write(&source_path, source_content.clone()).await?;
 
-    let target_path = format!("{}/{}", uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+    let target_path = format!(
+        "{}/{}/{}",
+        uuid::Uuid::new_v4(),
+        uuid::Uuid::new_v4(),
+        uuid::Uuid::new_v4()
+    );
 
     op.copy(&source_path, &target_path).await?;
 

--- a/core/tests/behavior/rename.rs
+++ b/core/tests/behavior/rename.rs
@@ -173,7 +173,12 @@ pub async fn test_rename_nested(op: Operator) -> Result<()> {
 
     op.write(&source_path, source_content.clone()).await?;
 
-    let target_path = format!("{}/{}", uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+    let target_path = format!(
+        "{}/{}/{}",
+        uuid::Uuid::new_v4(),
+        uuid::Uuid::new_v4(),
+        uuid::Uuid::new_v4()
+    );
 
     op.rename(&source_path, &target_path).await?;
 


### PR DESCRIPTION
Since some backends may need to create parent directories one layer at a time, increase the nested depth to cover this scenario.