### PR TITLE
feat(bindings/c): Introduce builder in C binding

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -155,22 +155,31 @@ typedef struct opendal_result_is_exist {
   enum opendal_code code;
 } opendal_result_is_exist;
 
+/*
+ The builder of building [`od::services::Memory`] service.
+ Fields' semantics could be checked in [`od::services::Memory`]
+ */
+typedef struct opendal_builder_memory {
+  const char *root;
+} opendal_builder_memory;
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
 /*
- Returns a result type [`opendal_result_op`], with operator_ptr. If the construction succeeds
- the error is nullptr, otherwise it contains the error information.
+ Returns a pointer [`opendal_operator_ptr`], with operator_ptr. If the construction failed,
+ the pointer will be pointing at NULL.
 
  # Safety
 
- It is [safe] under two cases below
+ It is [safe] under if followings are satisfied
  * The memory pointed to by `scheme` must contain a valid nul terminator at the end of
-   the string.
- * The `scheme` points to NULL, this function simply returns you a null opendal_operator_ptr
+   the string. Or the `scheme` points to NULL, this function simply returns you a
+   null [`opendal_operator_ptr`].
+ * The `builder` is pointing at a valid opendal_builder, e.g. [`opendal_builder_memory`]
  */
-opendal_operator_ptr opendal_operator_new(const char *scheme);
+opendal_operator_ptr opendal_operator_new(const char *scheme, void *builder);
 
 /*
  Free the allocated operator pointed by [`opendal_operator_ptr`]
@@ -233,6 +242,19 @@ struct opendal_result_read opendal_operator_blocking_read(opendal_operator_ptr o
  */
 struct opendal_result_is_exist opendal_operator_is_exist(opendal_operator_ptr op_ptr,
                                                          const char *path);
+
+/*
+ Construct a new [`opendal_builder_memory`], the memory is allocated on the heap.
+ The memory will be deallocated when it is used to build the [`opendal_operator_ptr`],
+ i.e. will become invalid.
+ */
+struct opendal_builder_memory *opendal_builder_memory_new(void);
+
+/*
+ Set the `root` of the [`od::services::Memory`] service
+ */
+struct opendal_builder_memory *opendal_builder_memory_set_root(const struct opendal_builder_memory *self,
+                                                               const char *root);
 
 /*
  Frees the heap memory used by the [`opendal_bytes`]

--- a/bindings/c/src/builders/memory.rs
+++ b/bindings/c/src/builders/memory.rs
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::os::raw::c_char;
+
+use ::opendal as od;
+
+use super::CastBuilder;
+
+use od::services::Memory;
+
+/// The builder of building [`od::services::Memory`] service.
+/// Fields' semantics could be checked in [`od::services::Memory`]
+#[repr(C)]
+pub struct opendal_builder_memory {
+    root: *const c_char,
+}
+
+impl opendal_builder_memory {
+    /// Construct a new [`opendal_builder_memory`], the memory is allocated on the heap.
+    /// The memory will be deallocated when it is used to build the [`opendal_operator_ptr`],
+    /// i.e. will become invalid.
+    #[no_mangle]
+    pub extern "C" fn opendal_builder_memory_new() -> *mut Self {
+        let b = opendal_builder_memory {
+            root: std::ptr::null(),
+        };
+        Box::leak(Box::new(b))
+    }
+
+    /// Set the `root` of the [`od::services::Memory`] service
+    #[no_mangle]
+    pub extern "C" fn opendal_builder_memory_set_root(&self, root: *const c_char) -> *mut Self {
+        let mut b = unsafe { Box::from_raw(self as *const _ as *mut Self) };
+        b.root = root;
+        Box::leak(b)
+    }
+}
+
+impl CastBuilder for opendal_builder_memory {
+    type CastTo = Memory;
+
+    fn cast_to_builder(&self) -> Memory {
+        let boxed = unsafe { Box::from_raw(self as *const _ as *mut Self) };
+        let root = unsafe { std::ffi::CStr::from_ptr(boxed.root).to_str().unwrap() };
+
+        let mut b = Memory::default();
+        b.root(root);
+        b
+    }
+}

--- a/bindings/c/src/builders/mod.rs
+++ b/bindings/c/src/builders/mod.rs
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+mod memory;
+
+use ::opendal as od;
+
+pub(crate) use memory::opendal_builder_memory;
+
+/// The trait must be implemented for all builders in C binding.
+///
+/// IMPORTANT: Make sure that you consume and deallocate the &self in your implementation
+/// of this trait. For example, in [`cast_to_builder`], using the following pattern is recommended:
+/// ```ignore
+/// fn cast_to_builder(&self) -> Self::CastTo {
+///     // it will be dropped when the function ends
+///     let boxed = unsafe { Box::from_raw(self as *const _ as *mut Self) };
+///
+///     // some other codes...
+/// }
+/// ```
+/// This makes sure that the `boxed` is dropped when the function ends.
+/// For more details, see [`crate::builders::memory::opendal_builder_memory`].
+pub(crate) trait CastBuilder {
+    /// The `CastTo` is the [`od::Builder`] type to be casted, e.g. [`od::services::Memory`]
+    /// and [`od::services::Fs`]
+    type CastTo: od::Builder;
+
+    /// Deallocate the `&self` and returned the casted [`od::Builder`]
+    fn cast_to_builder(&self) -> Self::CastTo;
+}

--- a/bindings/c/src/macros.rs
+++ b/bindings/c/src/macros.rs
@@ -15,13 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-/// Macro used to generate operator upon construction and return C-compatible
-/// error if failed
+/// Macro used to generate operator upon construction and return a NULL [`opendal_operator_ptr`]
+/// if failed. Examples can be seen in [`crate::opendal_operator_new`].
+///
+/// Arguments:
+/// * cast_to: The builder type you want to cast to, e.g. [`opendal_builder_memory`]
+/// * builder: The pointer to the builder
 #[macro_export]
 macro_rules! generate_operator {
-    ($type:ty, $map:expr) => {{
-        let b = od::Operator::from_map::<$type>($map);
-        match b {
+    ($cast_to:ty, $builder:expr) => {{
+        let builder = (*($builder as *mut $cast_to)).cast_to_builder();
+        match od::Operator::new(builder) {
             Ok(b) => b.finish(),
             Err(_) => {
                 return opendal_operator_ptr::null();

--- a/bindings/c/src/result.rs
+++ b/bindings/c/src/result.rs
@@ -15,11 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! This is for better naming in C header file. If we use generics for Result type,
-//! it will no doubt work find. However, the generics will lead to naming like
-//! "opendal_result_opendal_operator_ptr", which is unacceptable. Therefore,
-//! we are defining all Result types here
-
 use crate::error::opendal_code;
 use crate::types::opendal_bytes;
 

--- a/bindings/c/tests/basicio.c
+++ b/bindings/c/tests/basicio.c
@@ -28,42 +28,50 @@
 // * The blocking write operation is successful
 // * The blocking read operation is successful and works as expected
 void test_operator_rw(opendal_operator_ptr ptr) {
-    // have to be valid ptr
-    assert(ptr);
+  // have to be valid ptr
+  assert(ptr);
 
-    // write some contents by the operator, must be successful
-    char path[] = "test";
-    char content[] = "Hello World";
-    const opendal_bytes data = {
-        .len = sizeof(content) - 1,
-        .data = (uint8_t *)content,
-    };
-    opendal_code code = opendal_operator_blocking_write(ptr, path, data);
-    assert(code == OPENDAL_OK);
+  // write some contents by the operator, must be successful
+  char path[] = "test";
+  char content[] = "Hello World";
+  const opendal_bytes data = {
+      .len = sizeof(content) - 1,
+      .data = (uint8_t *)content,
+  };
+  opendal_code code = opendal_operator_blocking_write(ptr, path, data);
+  assert(code == OPENDAL_OK);
 
-    // reads the data out from the bytes, must be successful
-    struct opendal_result_read r = opendal_operator_blocking_read(ptr, path);
-    assert(r.code == OPENDAL_OK);
-    assert(r.data->len == (sizeof(content) - 1));
+  // reads the data out from the bytes, must be successful
+  struct opendal_result_read r = opendal_operator_blocking_read(ptr, path);
+  assert(r.code == OPENDAL_OK);
+  assert(r.data->len == (sizeof(content) - 1));
 
-    for (int i = 0; i < r.data->len; i++) {
-        printf("%c", (char)(r.data->data[i]));
-    }
+  for (int i = 0; i < r.data->len; i++) {
+    printf("%c", (char)(r.data->data[i]));
+  }
 
-    // free the bytes's heap memory
-    opendal_bytes_free(r.data);
+  // free the bytes's heap memory
+  opendal_bytes_free(r.data);
 }
 
 int main(int argc, char *argv[]) {
-    // construct the memory operator
-    char scheme1[] = "memory";
-    opendal_operator_ptr p1 = opendal_operator_new(scheme1);
-    assert(p1);
+  // construct the memory operator
+  char scheme[] = "memory";
+  char root[] = "someroot";
 
-    test_operator_rw(p1);
+  // construct builder
+  opendal_builder_memory *builder = opendal_builder_memory_new();
+  builder = opendal_builder_memory_set_root(builder, root);
 
-    // free the operator
-    opendal_operator_free(p1);
+  // build the operator using builder
+  opendal_operator_ptr p1 = opendal_operator_new(scheme, builder);
+  assert(p1);
 
-    return 0;
+  // test it!
+  test_operator_rw(p1);
+
+  // free the operator
+  opendal_operator_free(p1);
+
+  return 0;
 }


### PR DESCRIPTION
This commit does following things:

* Use builder to build the operator
* Implement builder for Memory backend
* Add builder to the test

For each backend in the future, they can simply be integrated by implementing a builder with trait `CastBuilder`.