### PR TITLE
feat: add Writer::abort method

### DIFF
--- a/core/src/layers/concurrent_limit.rs
+++ b/core/src/layers/concurrent_limit.rs
@@ -320,6 +320,10 @@ impl<R: oio::Write> oio::Write for ConcurrentLimitWrapper<R> {
         self.inner.append(bs).await
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        self.inner.abort().await
+    }
+
     async fn close(&mut self) -> Result<()> {
         self.inner.close().await
     }

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -419,6 +419,14 @@ impl<T: oio::Write> oio::Write for ErrorContextWrapper<T> {
         })
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        self.inner.abort().await.map_err(|err| {
+            err.with_operation(WriteOperation::Append)
+                .with_context("service", self.scheme)
+                .with_context("path", &self.path)
+        })
+    }
+
     async fn close(&mut self) -> Result<()> {
         self.inner.close().await.map_err(|err| {
             err.with_operation(WriteOperation::Close)

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -1419,6 +1419,36 @@ impl<W: oio::Write> oio::Write for LoggingWriter<W> {
         }
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        match self.inner.abort().await {
+            Ok(_) => {
+                trace!(
+                    target: LOGGING_TARGET,
+                    "service={} operation={} path={} written={} -> abort writer",
+                    self.scheme,
+                    WriteOperation::Abort,
+                    self.path,
+                    self.written,
+                );
+                Ok(())
+            }
+            Err(err) => {
+                if let Some(lvl) = self.failure_level {
+                    log!(
+                        target: LOGGING_TARGET,
+                        lvl,
+                        "service={} operation={} path={} written={} -> abort writer failed: {err:?}",
+                        self.scheme,
+                        WriteOperation::Abort,
+                        self.path,
+                        self.written,
+                    )
+                }
+                Err(err)
+            }
+        }
+    }
+
     async fn close(&mut self) -> Result<()> {
         match self.inner.close().await {
             Ok(_) => Ok(()),

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -27,7 +27,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::FutureExt;
 use futures::TryFutureExt;
-use hyper::body::HttpBody;
 use metrics::increment_counter;
 use metrics::register_counter;
 use metrics::register_histogram;

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -27,6 +27,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::FutureExt;
 use futures::TryFutureExt;
+use hyper::body::HttpBody;
 use metrics::increment_counter;
 use metrics::register_counter;
 use metrics::register_histogram;
@@ -935,6 +936,13 @@ impl<R: oio::Write> oio::Write for MetricWrapper<R> {
                 self.handle.increment_errors_total(self.op, err.kind());
                 err
             })
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        self.inner.abort().await.map_err(|err| {
+            self.handle.increment_errors_total(self.op, err.kind());
+            err
+        })
     }
 
     async fn close(&mut self) -> Result<()> {

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -325,6 +325,16 @@ impl<R: oio::Write> oio::Write for MinitraceWrapper<R> {
             .await
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        self.inner
+            .abort()
+            .in_span(Span::enter_with_parent(
+                WriteOperation::Abort.into_static(),
+                &self.span,
+            ))
+            .await
+    }
+
     async fn close(&mut self) -> Result<()> {
         self.inner
             .close()

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -738,6 +738,13 @@ impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
             })
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        self.inner.abort().await.map_err(|err| {
+            self.stats.increment_errors_total(self.op, err.kind());
+            err
+        })
+    }
+
     async fn close(&mut self) -> Result<()> {
         self.inner.close().await.map_err(|err| {
             self.stats.increment_errors_total(self.op, err.kind());

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -336,6 +336,14 @@ impl<R: oio::Write> oio::Write for TracingWrapper<R> {
         parent = &self.span,
         level = "trace",
         skip_all)]
+    async fn abort(&mut self) -> Result<()> {
+        self.inner.abort().await
+    }
+
+    #[tracing::instrument(
+        parent = &self.span,
+        level = "trace",
+        skip_all)]
     async fn close(&mut self) -> Result<()> {
         self.inner.close().await
     }

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -293,6 +293,14 @@ impl<S: Adapter> oio::Write for KvWriter<S> {
         Ok(())
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        // TODO(hl)
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "output writer doesn't support abort",
+        ))
+    }
+
     async fn close(&mut self) -> Result<()> {
         if let Some(buf) = self.buf.as_deref() {
             self.kv.set(&self.path, buf).await?;

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -294,7 +294,6 @@ impl<S: Adapter> oio::Write for KvWriter<S> {
     }
 
     async fn abort(&mut self) -> Result<()> {
-        // TODO(hl)
         Err(Error::new(
             ErrorKind::Unsupported,
             "output writer doesn't support abort",

--- a/core/src/raw/oio/write.rs
+++ b/core/src/raw/oio/write.rs
@@ -31,6 +31,8 @@ pub enum WriteOperation {
     Write,
     /// Operation for [`Write::append`]
     Append,
+    /// Operation for [`Write::abort`]
+    Abort,
     /// Operation for [`Write::close`]
     Close,
     /// Operation for [`BlockingWrite::write`]
@@ -65,6 +67,7 @@ impl From<WriteOperation> for &'static str {
             BlockingWrite => "BlockingWriter::write",
             BlockingAppend => "BlockingWriter::append",
             BlockingClose => "BlockingWriter::close",
+            Abort => "Writer::abort",
         }
     }
 }
@@ -87,6 +90,11 @@ pub trait Write: Unpin + Send + Sync {
     /// and compatibility.
     async fn append(&mut self, bs: Bytes) -> Result<()>;
 
+    /// Abort the pending appendable writer.
+    /// #note
+    /// This method is only applicable to writers opened in append mode.
+    async fn abort(&mut self) -> Result<()>;
+
     /// Close the writer and make sure all data has been flushed.
     async fn close(&mut self) -> Result<()>;
 }
@@ -108,6 +116,13 @@ impl Write for () {
         ))
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "output writer doesn't support abort",
+        ))
+    }
+
     async fn close(&mut self) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
@@ -126,6 +141,10 @@ impl<T: Write + ?Sized> Write for Box<T> {
 
     async fn append(&mut self, bs: Bytes) -> Result<()> {
         (**self).append(bs).await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        (**self).abort().await
     }
 
     async fn close(&mut self) -> Result<()> {

--- a/core/src/raw/oio/write.rs
+++ b/core/src/raw/oio/write.rs
@@ -63,11 +63,11 @@ impl From<WriteOperation> for &'static str {
         match v {
             Write => "Writer::write",
             Append => "Writer::append",
+            Abort => "Writer::abort",
             Close => "Writer::close",
             BlockingWrite => "BlockingWriter::write",
             BlockingAppend => "BlockingWriter::append",
             BlockingClose => "BlockingWriter::close",
-            Abort => "Writer::abort",
         }
     }
 }

--- a/core/src/services/azblob/writer.rs
+++ b/core/src/services/azblob/writer.rs
@@ -74,6 +74,10 @@ impl oio::Write for AzblobWriter {
         ))
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     async fn close(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/azdfs/writer.rs
+++ b/core/src/services/azdfs/writer.rs
@@ -96,6 +96,10 @@ impl oio::Write for AzdfsWriter {
         ))
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     async fn close(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/fs/writer.rs
+++ b/core/src/services/fs/writer.rs
@@ -75,6 +75,14 @@ impl oio::Write for FsWriter<tokio::fs::File> {
         Ok(())
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        // TODO(hl)
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "output writer doesn't support close",
+        ))
+    }
+
     async fn close(&mut self) -> Result<()> {
         self.f.sync_all().await.map_err(parse_io_error)?;
 

--- a/core/src/services/fs/writer.rs
+++ b/core/src/services/fs/writer.rs
@@ -76,10 +76,9 @@ impl oio::Write for FsWriter<tokio::fs::File> {
     }
 
     async fn abort(&mut self) -> Result<()> {
-        // TODO(hl)
         Err(Error::new(
             ErrorKind::Unsupported,
-            "output writer doesn't support close",
+            "output writer doesn't support abort",
         ))
     }
 

--- a/core/src/services/ftp/writer.rs
+++ b/core/src/services/ftp/writer.rs
@@ -62,6 +62,10 @@ impl oio::Write for FtpWriter {
         ))
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     async fn close(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/gcs/writer.rs
+++ b/core/src/services/gcs/writer.rs
@@ -74,6 +74,10 @@ impl oio::Write for GcsWriter {
         ))
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     async fn close(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/ghac/writer.rs
+++ b/core/src/services/ghac/writer.rs
@@ -71,6 +71,10 @@ impl oio::Write for GhacWriter {
         ))
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     async fn close(&mut self) -> Result<()> {
         let req = self.backend.ghac_commit(self.cache_id, self.size).await?;
         let resp = self.backend.client.send(req).await?;

--- a/core/src/services/hdfs/writer.rs
+++ b/core/src/services/hdfs/writer.rs
@@ -71,10 +71,9 @@ impl oio::Write for HdfsWriter<hdrs::AsyncFile> {
     }
 
     async fn abort(&mut self) -> Result<()> {
-        // TODO(hl)
         Err(Error::new(
             ErrorKind::Unsupported,
-            "output writer doesn't support close",
+            "output writer doesn't support abort",
         ))
     }
 

--- a/core/src/services/hdfs/writer.rs
+++ b/core/src/services/hdfs/writer.rs
@@ -70,6 +70,14 @@ impl oio::Write for HdfsWriter<hdrs::AsyncFile> {
         Ok(())
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        // TODO(hl)
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "output writer doesn't support close",
+        ))
+    }
+
     async fn close(&mut self) -> Result<()> {
         self.f.close().await.map_err(parse_io_error)?;
 

--- a/core/src/services/ipmfs/writer.rs
+++ b/core/src/services/ipmfs/writer.rs
@@ -64,6 +64,10 @@ impl oio::Write for IpmfsWriter {
         ))
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     async fn close(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/obs/writer.rs
+++ b/core/src/services/obs/writer.rs
@@ -74,6 +74,10 @@ impl oio::Write for ObsWriter {
         ))
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     async fn close(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/oss/writer.rs
+++ b/core/src/services/oss/writer.rs
@@ -114,6 +114,14 @@ impl oio::Write for OssWriter {
         }
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        // TODO(hl)
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "output writer doesn't support abort",
+        ))
+    }
+
     async fn close(&mut self) -> Result<()> {
         let upload_id = if let Some(upload_id) = &self.upload_id {
             upload_id

--- a/core/src/services/oss/writer.rs
+++ b/core/src/services/oss/writer.rs
@@ -115,7 +115,6 @@ impl oio::Write for OssWriter {
     }
 
     async fn abort(&mut self) -> Result<()> {
-        // TODO(hl)
         Err(Error::new(
             ErrorKind::Unsupported,
             "output writer doesn't support abort",

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -616,7 +616,6 @@ impl S3Core {
         self.send(req).await
     }
 
-
     pub async fn s3_delete_objects(
         &self,
         paths: Vec<String>,

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -594,6 +594,29 @@ impl S3Core {
         self.send(req).await
     }
 
+    /// Abort an on-going multipart upload.
+    pub async fn s3_abort_multipart_upload(
+        &self,
+        path: &str,
+        upload_id: &str,
+    ) -> Result<Response<IncomingAsyncBody>> {
+        let p = build_abs_path(&self.root, path);
+
+        let url = format!(
+            "{}/{}?uploadId={}",
+            self.endpoint,
+            percent_encode_path(&p),
+            percent_encode_path(upload_id)
+        );
+
+        let mut req = Request::delete(&url)
+            .body(AsyncBody::Empty)
+            .map_err(new_request_build_error)?;
+        self.sign(&mut req).await?;
+        self.send(req).await
+    }
+
+
     pub async fn s3_delete_objects(
         &self,
         paths: Vec<String>,

--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -125,6 +125,14 @@ impl oio::Write for S3Writer {
         }
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        // TODO(hl)
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "output writer doesn't support close",
+        ))
+    }
+
     async fn close(&mut self) -> Result<()> {
         let upload_id = if let Some(upload_id) = &self.upload_id {
             upload_id

--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -132,7 +132,10 @@ impl oio::Write for S3Writer {
             return Ok(());
         };
 
-        let resp = self.core.s3_abort_multipart_upload(&self.path, upload_id).await?;
+        let resp = self
+            .core
+            .s3_abort_multipart_upload(&self.path, upload_id)
+            .await?;
         match resp.status() {
             StatusCode::OK => {
                 resp.into_body().consume().await?;

--- a/core/src/services/webdav/writer.rs
+++ b/core/src/services/webdav/writer.rs
@@ -72,6 +72,10 @@ impl oio::Write for WebdavWriter {
         ))
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     async fn close(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -72,6 +72,10 @@ impl oio::Write for WebhdfsWriter {
         ))
     }
 
+    async fn abort(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     async fn close(&mut self) -> Result<()> {
         Ok(())
     }


### PR DESCRIPTION
This PR:
- adds `oio::Write::abort` API to allow cancellation of an on-going append writer
- for those writers do not support `append`, adds a `Write::abort` implementation that simply return `Ok(())`
- adds delegated implementations of `oio::Write::abort` for all layers
- adds `oio::Write::abort` implementation for `S3Writer` as an example

This PR does not add an equivalent API in `oio::BlockingWrite`, since we can always add a `Drop` implementation for blocking writers and delete partial objects in `Drop::drop`.

## Related issue
#1607
