### PR TITLE
fix(services/azblob): fix copy missing content-length

### DIFF
--- a/core/src/services/azblob/core.rs
+++ b/core/src/services/azblob/core.rs
@@ -235,6 +235,7 @@ impl AzblobCore {
 
         let mut req = Request::put(&target)
             .header(X_MS_COPY_SOURCE, source)
+            .header(CONTENT_LENGTH, 0)
             .body(AsyncBody::Empty)
             .map_err(new_request_build_error)?;
 


### PR DESCRIPTION
fix #1999 

It looks like the image `mcr.microsoft.com/azure-storage/azurite` is slightly different from the production service. 
This problem has also been seen on the `azdfs` service.
cc @Xuanwo 