### PR TITLE
docs(services/memory): Fix wrong explanation

### DIFF
--- a/core/src/services/memory/backend.rs
+++ b/core/src/services/memory/backend.rs
@@ -26,7 +26,7 @@ use crate::raw::adapters::kv;
 use crate::raw::*;
 use crate::*;
 
-/// In memory service support. (HashMap Based)
+/// In memory service support. (BTreeMap Based)
 ///
 /// # Capabilities
 ///


### PR DESCRIPTION
As seen in [https://github.com/apache/incubator-opendal/blob/aa8b9e52801947c1799a5efa7107c14e94ec300a/core/src/services/memory/backend.rs#L80](https://github.com/apache/incubator-opendal/blob/aa8b9e52801947c1799a5efa7107c14e94ec300a/core/src/services/memory/backend.rs#L80) It is implemented based on BTreeMap, rather than HashMap.

And Most key values are paths. Will it become better to use TrieTreeMap?