### PR TITLE
feat: improve the readability of oli command line error output

### DIFF
--- a/bin/oli/src/bin/oli.rs
+++ b/bin/oli/src/bin/oli.rs
@@ -37,15 +37,19 @@ fn new_cmd(name: &'static str) -> Result<Command> {
     let d = config_dir().ok_or_else(|| anyhow!("unknown config dir"))?;
     let default_config_path = d.join("oli/config.toml").as_os_str().to_owned();
 
-    Ok(Command::new(name).version(env!("CARGO_PKG_VERSION")).arg(
-        Arg::new("config")
-            .long("config")
-            .help("Path to the config file")
-            .global(true)
-            .default_value(default_config_path)
-            .value_parser(value_parser!(PathBuf))
-            .required(false),
-    ))
+    Ok(Command::new(name)
+        .version(env!("CARGO_PKG_VERSION"))
+        .arg(
+            Arg::new("config")
+                .long("config")
+                .help("Path to the config file")
+                .global(true)
+                .default_value(default_config_path)
+                .value_parser(value_parser!(PathBuf))
+                .required(false),
+        )
+        .subcommand_required(true)
+        .arg_required_else_help(true))
 }
 
 #[tokio::main]


### PR DESCRIPTION
This PR just polish the output of oli command line when no subcommand was input.
Before:
```bash
# ./oli
Error: not handled
```
After:
```bash
# ./oli
OpenDAL Command Line Interface

Usage: oli [OPTIONS] <COMMAND>

Commands:
  cat   display object content
  cp    copy
  ls    ls
  rm    remove object
  stat  show object metadata
  help  Print this message or the help of the given subcommand(s)

Options:
      --config <config>  Path to the config file [default: /root/.config/oli/config.toml]
  -h, --help             Print help
  -V, --version          Print version
```