### PR TITLE
feat: add behavioral test for Write::abort

### DIFF
--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -137,7 +137,8 @@ impl oio::Write for S3Writer {
             .s3_abort_multipart_upload(&self.path, upload_id)
             .await?;
         match resp.status() {
-            StatusCode::OK => {
+            // s3 returns code 204 if abort succeeds.
+            StatusCode::NO_CONTENT => {
                 resp.into_body().consume().await?;
                 Ok(())
             }

--- a/core/src/types/writer.rs
+++ b/core/src/types/writer.rs
@@ -28,6 +28,7 @@ use futures::AsyncWrite;
 use futures::FutureExt;
 
 use crate::ops::OpWrite;
+use crate::raw::oio::Write;
 use crate::raw::*;
 use crate::*;
 
@@ -70,6 +71,18 @@ impl Writer {
         } else {
             unreachable!(
                 "writer state invalid while append, expect Idle, actual {}",
+                self.state
+            );
+        }
+    }
+
+    /// Abort inner writer.
+    pub async fn abort(&mut self) -> Result<()> {
+        if let State::Idle(Some(w)) = &mut self.state {
+            w.abort().await
+        } else {
+            unreachable!(
+                "writer state invalid while abort, expect Idle, actual {}",
                 self.state
             );
         }


### PR DESCRIPTION
This PR:
- adds `abort` API for `opendal::types::writer::Writer`
- adds behavioral test for abort