### PR TITLE
refactor: Rename `Create` to `CreateDir` for its behavior changed

### DIFF
--- a/core/src/docs/internals/accessor.rs
+++ b/core/src/docs/internals/accessor.rs
@@ -54,7 +54,7 @@
 //!
 //! ```ignore
 //! pub trait Accessor {
-//!     async fn create(&self, path: &str) -> Result<()>;
+//!     async fn create_dir(&self, path: &str) -> Result<()>;
 //! }
 //! ```
 //!

--- a/core/src/layers/concurrent_limit.rs
+++ b/core/src/layers/concurrent_limit.rs
@@ -94,14 +94,14 @@ impl<A: Accessor> LayeredAccessor for ConcurrentLimitAccessor<A> {
         &self.inner
     }
 
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         let _permit = self
             .semaphore
             .acquire()
             .await
             .expect("semaphore must be valid");
 
-        self.inner.create(path, args).await
+        self.inner.create_dir(path, args).await
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
@@ -190,13 +190,13 @@ impl<A: Accessor> LayeredAccessor for ConcurrentLimitAccessor<A> {
         self.inner.batch(args).await
     }
 
-    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         let _permit = self
             .semaphore
             .try_acquire()
             .expect("semaphore must be valid");
 
-        self.inner.blocking_create(path, args)
+        self.inner.blocking_create_dir(path, args)
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -82,11 +82,11 @@ impl<A: Accessor> LayeredAccessor for ErrorContextAccessor<A> {
         self.meta.clone()
     }
 
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         self.inner
-            .create(path, args)
+            .create_dir(path, args)
             .map_err(|err| {
-                err.with_operation(Operation::Create)
+                err.with_operation(Operation::CreateDir)
                     .with_context("service", self.meta.scheme())
                     .with_context("path", path)
             })
@@ -236,9 +236,9 @@ impl<A: Accessor> LayeredAccessor for ErrorContextAccessor<A> {
             .await
     }
 
-    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        self.inner.blocking_create(path, args).map_err(|err| {
-            err.with_operation(Operation::BlockingCreate)
+    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        self.inner.blocking_create_dir(path, args).map_err(|err| {
+            err.with_operation(Operation::BlockingCreateDir)
                 .with_context("service", self.meta.scheme())
                 .with_context("path", path)
         })

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -198,24 +198,24 @@ impl<A: Accessor> LayeredAccessor for LoggingAccessor<A> {
         result
     }
 
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         debug!(
             target: LOGGING_TARGET,
             "service={} operation={} path={} -> started",
             self.scheme,
-            Operation::Create,
+            Operation::CreateDir,
             path
         );
 
         self.inner
-            .create(path, args)
+            .create_dir(path, args)
             .await
             .map(|v| {
                 debug!(
                     target: LOGGING_TARGET,
                     "service={} operation={} path={} -> finished",
                     self.scheme,
-                    Operation::Create,
+                    Operation::CreateDir,
                     path
                 );
                 v
@@ -227,7 +227,7 @@ impl<A: Accessor> LayeredAccessor for LoggingAccessor<A> {
                         lvl,
                         "service={} operation={} path={} -> {}: {err:?}",
                         self.scheme,
-                        Operation::Create,
+                        Operation::CreateDir,
                         path,
                         self.err_status(&err)
                     )
@@ -654,23 +654,23 @@ impl<A: Accessor> LayeredAccessor for LoggingAccessor<A> {
             .await
     }
 
-    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         debug!(
             target: LOGGING_TARGET,
             "service={} operation={} path={} -> started",
             self.scheme,
-            Operation::BlockingCreate,
+            Operation::BlockingCreateDir,
             path
         );
 
         self.inner
-            .blocking_create(path, args)
+            .blocking_create_dir(path, args)
             .map(|v| {
                 debug!(
                     target: LOGGING_TARGET,
                     "service={} operation={} path={} -> finished",
                     self.scheme,
-                    Operation::BlockingCreate,
+                    Operation::BlockingCreateDir,
                     path
                 );
                 v
@@ -682,7 +682,7 @@ impl<A: Accessor> LayeredAccessor for LoggingAccessor<A> {
                         lvl,
                         "service={} operation={} path={} -> {}: {err:?}",
                         self.scheme,
-                        Operation::BlockingCreate,
+                        Operation::BlockingCreateDir,
                         path,
                         self.err_status(&err)
                     );

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -213,12 +213,12 @@ impl MetricsHandler {
             requests_total_create: register_counter!(
                 METRIC_REQUESTS_TOTAL,
                 LABEL_SERVICE => service,
-                LABEL_OPERATION => Operation::Create.into_static(),
+                LABEL_OPERATION => Operation::CreateDir.into_static(),
             ),
             requests_duration_seconds_create: register_histogram!(
                 METRIC_REQUESTS_DURATION_SECONDS,
                 LABEL_SERVICE => service,
-                LABEL_OPERATION => Operation::Create.into_static(),
+                LABEL_OPERATION => Operation::CreateDir.into_static(),
             ),
 
             requests_total_read: register_counter!(
@@ -322,12 +322,12 @@ impl MetricsHandler {
             requests_total_blocking_create: register_counter!(
                 METRIC_REQUESTS_TOTAL,
                 LABEL_SERVICE => service,
-                LABEL_OPERATION => Operation::BlockingCreate.into_static(),
+                LABEL_OPERATION => Operation::BlockingCreateDir.into_static(),
             ),
             requests_duration_seconds_blocking_create: register_histogram!(
                 METRIC_REQUESTS_DURATION_SECONDS,
                 LABEL_SERVICE => service,
-                LABEL_OPERATION => Operation::BlockingCreate.into_static(),
+                LABEL_OPERATION => Operation::BlockingCreateDir.into_static(),
             ),
 
             requests_total_blocking_read: register_counter!(
@@ -460,13 +460,13 @@ impl<A: Accessor> LayeredAccessor for MetricsAccessor<A> {
         result
     }
 
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         self.handle.requests_total_create.increment(1);
 
         let start = Instant::now();
 
         self.inner
-            .create(path, args)
+            .create_dir(path, args)
             .map(|v| {
                 let dur = start.elapsed().as_secs_f64();
 
@@ -474,7 +474,7 @@ impl<A: Accessor> LayeredAccessor for MetricsAccessor<A> {
 
                 v.map_err(|e| {
                     self.handle
-                        .increment_errors_total(Operation::Create, e.kind());
+                        .increment_errors_total(Operation::CreateDir, e.kind());
                     e
                 })
             })
@@ -646,11 +646,11 @@ impl<A: Accessor> LayeredAccessor for MetricsAccessor<A> {
         })
     }
 
-    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         self.handle.requests_total_blocking_create.increment(1);
 
         let start = Instant::now();
-        let result = self.inner.blocking_create(path, args);
+        let result = self.inner.blocking_create_dir(path, args);
         let dur = start.elapsed().as_secs_f64();
 
         self.handle
@@ -659,7 +659,7 @@ impl<A: Accessor> LayeredAccessor for MetricsAccessor<A> {
 
         result.map_err(|e| {
             self.handle
-                .increment_errors_total(Operation::BlockingCreate, e.kind());
+                .increment_errors_total(Operation::BlockingCreateDir, e.kind());
             e
         })
     }

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -146,8 +146,8 @@ impl<A: Accessor> LayeredAccessor for MinitraceAccessor<A> {
     }
 
     #[trace("create", enter_on_poll = true)]
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        self.inner.create(path, args).await
+    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        self.inner.create_dir(path, args).await
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
@@ -203,8 +203,8 @@ impl<A: Accessor> LayeredAccessor for MinitraceAccessor<A> {
     }
 
     #[trace("blocking_create")]
-    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        self.inner.blocking_create(path, args)
+    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        self.inner.blocking_create_dir(path, args)
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -201,7 +201,7 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
         &self.inner
     }
 
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         self.stats
             .requests_total
             .with_label_values(&[&self.scheme])
@@ -210,14 +210,14 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Create.into_static()])
+            .with_label_values(&[&self.scheme, Operation::CreateDir.into_static()])
             .start_timer();
-        let create_res = self.inner.create(path, args).await;
+        let create_res = self.inner.create_dir(path, args).await;
 
         timer.observe_duration();
         create_res.map_err(|e| {
             self.stats
-                .increment_errors_total(Operation::Create, e.kind());
+                .increment_errors_total(Operation::CreateDir, e.kind());
             e
         })
     }
@@ -428,24 +428,24 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
         })
     }
 
-    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         self.stats
             .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingCreate.into_static()])
+            .with_label_values(&[&self.scheme, Operation::BlockingCreateDir.into_static()])
             .inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::BlockingCreate.into_static()])
+            .with_label_values(&[&self.scheme, Operation::BlockingCreateDir.into_static()])
             .start_timer();
-        let result = self.inner.blocking_create(path, args);
+        let result = self.inner.blocking_create_dir(path, args);
 
         timer.observe_duration();
 
         result.map_err(|e| {
             self.stats
-                .increment_errors_total(Operation::BlockingCreate, e.kind());
+                .increment_errors_total(Operation::BlockingCreateDir, e.kind());
             e
         })
     }

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -168,15 +168,15 @@ impl<A: Accessor> LayeredAccessor for RetryAccessor<A> {
         &self.inner
     }
 
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        { || self.inner.create(path, args.clone()) }
+    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        { || self.inner.create_dir(path, args.clone()) }
             .retry(&self.builder)
             .when(|e| e.is_temporary())
             .notify(|err, dur| {
                 warn!(
                     target: "opendal::service",
                     "operation={} -> retry after {}s: error={:?}",
-                    Operation::Create, dur.as_secs_f64(), err)
+                    Operation::CreateDir, dur.as_secs_f64(), err)
             })
             .map(|v| v.map_err(|e| e.set_persistent()))
             .await
@@ -322,15 +322,15 @@ impl<A: Accessor> LayeredAccessor for RetryAccessor<A> {
             .await
     }
 
-    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        { || self.inner.blocking_create(path, args.clone()) }
+    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        { || self.inner.blocking_create_dir(path, args.clone()) }
             .retry(&self.builder)
             .when(|e| e.is_temporary())
             .notify(|err, dur| {
                 warn!(
                     target: "opendal::service",
                     "operation={} -> retry after {}s: error={:?}",
-                    Operation::BlockingCreate, dur.as_secs_f64(), err)
+                    Operation::BlockingCreateDir, dur.as_secs_f64(), err)
             })
             .call()
             .map_err(|e| e.set_persistent())

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -151,8 +151,8 @@ impl<A: Accessor> LayeredAccessor for TracingAccessor<A> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        self.inner.create(path, args).await
+    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        self.inner.create_dir(path, args).await
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -208,8 +208,8 @@ impl<A: Accessor> LayeredAccessor for TracingAccessor<A> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        self.inner.blocking_create(path, args)
+    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        self.inner.blocking_create_dir(path, args)
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -86,8 +86,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     ///
     /// - Input path MUST match with EntryMode, DON'T NEED to check mode.
     /// - Create on existing dir SHOULD succeed.
-    /// - Create on existing file SHOULD overwrite and truncate.
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         let (_, _) = (path, args);
 
         Err(Error::new(
@@ -256,7 +255,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     /// This operation is the blocking version of [`Accessor::create`]
     ///
     /// Require [`AccessorCapability::Write`] and [`AccessorCapability::Blocking`]
-    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         let (_, _) = (path, args);
 
         Err(Error::new(
@@ -417,8 +416,8 @@ impl<T: Accessor + ?Sized> Accessor for Arc<T> {
         self.as_ref().info()
     }
 
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        self.as_ref().create(path, args).await
+    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        self.as_ref().create_dir(path, args).await
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
@@ -457,8 +456,8 @@ impl<T: Accessor + ?Sized> Accessor for Arc<T> {
         self.as_ref().presign(path, args).await
     }
 
-    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        self.as_ref().blocking_create(path, args)
+    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        self.as_ref().blocking_create_dir(path, args)
     }
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
         self.as_ref().blocking_read(path, args)

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -68,13 +68,13 @@ impl<S: Adapter> Accessor for Backend<S> {
         am
     }
 
-    async fn create(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
         let p = build_abs_path(&self.root, path);
         self.kv.set(&p, &[]).await?;
         Ok(RpCreate::default())
     }
 
-    fn blocking_create(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
         let p = build_abs_path(&self.root, path);
         self.kv.blocking_set(&p, &[])?;
 

--- a/core/src/raw/layer.rs
+++ b/core/src/raw/layer.rs
@@ -151,8 +151,8 @@ pub trait LayeredAccessor: Send + Sync + Debug + Unpin + 'static {
         self.inner().info()
     }
 
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        self.inner().create(path, args).await
+    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        self.inner().create_dir(path, args).await
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)>;
@@ -187,8 +187,8 @@ pub trait LayeredAccessor: Send + Sync + Debug + Unpin + 'static {
         self.inner().presign(path, args).await
     }
 
-    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        self.inner().blocking_create(path, args)
+    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        self.inner().blocking_create_dir(path, args)
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)>;
@@ -229,8 +229,8 @@ impl<L: LayeredAccessor> Accessor for L {
         (self as &L).metadata()
     }
 
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        (self as &L).create(path, args).await
+    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        (self as &L).create_dir(path, args).await
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
@@ -273,8 +273,8 @@ impl<L: LayeredAccessor> Accessor for L {
         (self as &L).presign(path, args).await
     }
 
-    fn blocking_create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        (self as &L).blocking_create(path, args)
+    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+        (self as &L).blocking_create_dir(path, args)
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {

--- a/core/src/raw/operation.rs
+++ b/core/src/raw/operation.rs
@@ -25,8 +25,8 @@ pub enum Operation {
     /// Operation for [`crate::raw::Accessor::info`]
     #[default]
     Info,
-    /// Operation for [`crate::raw::Accessor::create`]
-    Create,
+    /// Operation for [`crate::raw::Accessor::create_dir`]
+    CreateDir,
     /// Operation for [`crate::raw::Accessor::read`]
     Read,
     /// Operation for [`crate::raw::Accessor::write`]
@@ -47,8 +47,8 @@ pub enum Operation {
     Batch,
     /// Operation for [`crate::raw::Accessor::presign`]
     Presign,
-    /// Operation for [`crate::raw::Accessor::blocking_create`]
-    BlockingCreate,
+    /// Operation for [`crate::raw::Accessor::blocking_create_dir`]
+    BlockingCreateDir,
     /// Operation for [`crate::raw::Accessor::blocking_read`]
     BlockingRead,
     /// Operation for [`crate::raw::Accessor::blocking_write`]
@@ -84,7 +84,7 @@ impl From<Operation> for &'static str {
     fn from(v: Operation) -> &'static str {
         match v {
             Operation::Info => "metadata",
-            Operation::Create => "create",
+            Operation::CreateDir => "create_dir",
             Operation::Read => "read",
             Operation::Write => "write",
             Operation::Copy => "copy",
@@ -95,7 +95,7 @@ impl From<Operation> for &'static str {
             Operation::Scan => "scan",
             Operation::Presign => "presign",
             Operation::Batch => "batch",
-            Operation::BlockingCreate => "blocking_create",
+            Operation::BlockingCreateDir => "blocking_create_dir",
             Operation::BlockingRead => "blocking_read",
             Operation::BlockingWrite => "blocking_write",
             Operation::BlockingCopy => "blocking_copy",

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -461,7 +461,7 @@ impl Accessor for AzblobBackend {
         am
     }
 
-    async fn create(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
         let mut req = self
             .core
             .azblob_put_blob_request(path, Some(0), None, AsyncBody::Empty)?;

--- a/core/src/services/azdfs/backend.rs
+++ b/core/src/services/azdfs/backend.rs
@@ -319,16 +319,10 @@ impl Accessor for AzdfsBackend {
         am
     }
 
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        let resource = match args.mode() {
-            EntryMode::FILE => "file",
-            EntryMode::DIR => "directory",
-            _ => unimplemented!("not supported object mode"),
-        };
-
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
         let mut req =
             self.core
-                .azdfs_create_request(path, resource, None, None, AsyncBody::Empty)?;
+                .azdfs_create_request(path, "directory", None, None, AsyncBody::Empty)?;
 
         self.core.sign(&mut req).await?;
 

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -323,8 +323,8 @@ impl Accessor for FtpBackend {
         am
     }
 
-    async fn create(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
-        let mut ftp_stream = self.ftp_connect(Operation::Create).await?;
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+        let mut ftp_stream = self.ftp_connect(Operation::CreateDir).await?;
 
         let paths: Vec<&str> = path.split_inclusive('/').collect();
 

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -381,7 +381,7 @@ impl Accessor for GcsBackend {
         am
     }
 
-    async fn create(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
         let mut req = self
             .core
             .gcs_insert_object_request(path, Some(0), None, AsyncBody::Empty)?;

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -305,7 +305,7 @@ impl Accessor for GhacBackend {
         am
     }
 
-    async fn create(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
         // ignore creation of dir.
         if path.ends_with('/') {
             return Ok(RpCreate::default());

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -81,12 +81,8 @@ impl Accessor for IpmfsBackend {
         am
     }
 
-    async fn create(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
-        let resp = match args.mode() {
-            EntryMode::DIR => self.ipmfs_mkdir(path).await?,
-            EntryMode::FILE => self.ipmfs_write(path, AsyncBody::Empty).await?,
-            _ => unreachable!(),
-        };
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+        let resp = self.ipmfs_mkdir(path).await?;
 
         let status = resp.status();
 

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -314,7 +314,7 @@ impl Accessor for ObsBackend {
         am
     }
 
-    async fn create(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
         let mut req = self
             .core
             .obs_put_object_request(path, Some(0), None, AsyncBody::Empty)?;

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -371,7 +371,7 @@ impl Accessor for OssBackend {
         am
     }
 
-    async fn create(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
         let resp = self
             .core
             .oss_put_object(path, None, None, None, None, AsyncBody::Empty)

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -921,7 +921,7 @@ impl Accessor for S3Backend {
         am
     }
 
-    async fn create(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
         let mut req =
             self.core
                 .s3_put_object_request(path, Some(0), None, None, None, AsyncBody::Empty)?;

--- a/core/src/services/wasabi/backend.rs
+++ b/core/src/services/wasabi/backend.rs
@@ -911,7 +911,7 @@ impl Accessor for WasabiBackend {
         am
     }
 
-    async fn create(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
         let mut req =
             self.core
                 .put_object_request(path, Some(0), None, None, None, AsyncBody::Empty)?;

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -278,7 +278,7 @@ impl Accessor for WebdavBackend {
         ma
     }
 
-    async fn create(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
         self.ensure_parent_path(path).await?;
 
         let abs_path = build_abs_path(&self.root, path);

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -444,7 +444,7 @@ impl WebhdfsBackend {
                 }
             }
             StatusCode::NOT_FOUND => {
-                self.create("/", OpCreate::new(EntryMode::DIR)).await?;
+                self.create_dir("/", OpCreate::new()).await?;
             }
             _ => return Err(parse_error(resp).await?),
         }
@@ -473,7 +473,7 @@ impl Accessor for WebhdfsBackend {
     }
 
     /// Create a file or directory
-    async fn create(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
         let req = self
             .webhdfs_create_object_request(path, Some(0), None, AsyncBody::Empty)
             .await?;

--- a/core/src/types/operator/blocking_operator.rs
+++ b/core/src/types/operator/blocking_operator.rs
@@ -303,8 +303,7 @@ impl BlockingOperator {
             .with_context("path", &path));
         }
 
-        self.inner()
-            .blocking_create(&path, OpCreate::new(EntryMode::DIR))?;
+        self.inner().blocking_create_dir(&path, OpCreate::new())?;
 
         Ok(())
     }
@@ -420,7 +419,7 @@ impl BlockingOperator {
 
         let op = OpRead::new().with_range(range.into());
 
-        BlockingReader::create(self.inner().clone(), &path, op)
+        BlockingReader::create_dir(self.inner().clone(), &path, op)
     }
 
     /// Write bytes into given path.
@@ -638,7 +637,7 @@ impl BlockingOperator {
         }
 
         let op = OpWrite::default().with_append();
-        BlockingWriter::create(self.inner().clone(), &path, op)
+        BlockingWriter::create_dir(self.inner().clone(), &path, op)
     }
 
     /// Delete given path.

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -390,9 +390,7 @@ impl Operator {
             .with_context("path", &path));
         }
 
-        self.inner()
-            .create(&path, OpCreate::new(EntryMode::DIR))
-            .await?;
+        self.inner().create_dir(&path, OpCreate::new()).await?;
 
         Ok(())
     }
@@ -606,7 +604,7 @@ impl Operator {
             );
         }
 
-        Reader::create(self.inner().clone(), &path, args).await
+        Reader::create_dir(self.inner().clone(), &path, args).await
     }
 
     /// Write bytes into path.
@@ -817,7 +815,7 @@ impl Operator {
             );
         }
 
-        Writer::create(self.inner().clone(), &path, args.with_append()).await
+        Writer::create_dir(self.inner().clone(), &path, args.with_append()).await
     }
 
     /// Write data with extra options.

--- a/core/src/types/ops.rs
+++ b/core/src/types/ops.rs
@@ -22,25 +22,17 @@
 use std::time::Duration;
 
 use crate::raw::*;
-use crate::*;
 
 /// Args for `create` operation.
 ///
 /// The path must be normalized.
 #[derive(Debug, Clone, Default)]
-pub struct OpCreate {
-    mode: EntryMode,
-}
+pub struct OpCreate {}
 
 impl OpCreate {
     /// Create a new `OpCreate`.
-    pub fn new(mode: EntryMode) -> Self {
-        Self { mode }
-    }
-
-    /// Get mode from option.
-    pub fn mode(&self) -> EntryMode {
-        self.mode
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/core/src/types/reader.rs
+++ b/core/src/types/reader.rs
@@ -67,7 +67,7 @@ impl Reader {
     ///
     /// We don't want to expose those details to users so keep this function
     /// in crate only.
-    pub(crate) async fn create(acc: FusedAccessor, path: &str, op: OpRead) -> Result<Self> {
+    pub(crate) async fn create_dir(acc: FusedAccessor, path: &str, op: OpRead) -> Result<Self> {
         let (_, r) = acc.read(path, op).await?;
 
         Ok(Reader {
@@ -192,7 +192,7 @@ impl BlockingReader {
     ///
     /// We don't want to expose those details to users so keep this function
     /// in crate only.
-    pub(crate) fn create(acc: FusedAccessor, path: &str, op: OpRead) -> Result<Self> {
+    pub(crate) fn create_dir(acc: FusedAccessor, path: &str, op: OpRead) -> Result<Self> {
         let acc_meta = acc.info();
 
         let r = if acc_meta.hints().contains(AccessorHint::ReadSeekable) {

--- a/core/src/types/writer.rs
+++ b/core/src/types/writer.rs
@@ -51,7 +51,7 @@ impl Writer {
     ///
     /// We don't want to expose those details to users so keep this function
     /// in crate only.
-    pub(crate) async fn create(acc: FusedAccessor, path: &str, op: OpWrite) -> Result<Self> {
+    pub(crate) async fn create_dir(acc: FusedAccessor, path: &str, op: OpWrite) -> Result<Self> {
         let (_, w) = acc.write(path, op).await?;
 
         Ok(Writer {
@@ -185,7 +185,7 @@ impl BlockingWriter {
     ///
     /// We don't want to expose those details to users so keep this function
     /// in crate only.
-    pub(crate) fn create(acc: FusedAccessor, path: &str, op: OpWrite) -> Result<Self> {
+    pub(crate) fn create_dir(acc: FusedAccessor, path: &str, op: OpWrite) -> Result<Self> {
         let (_, w) = acc.blocking_write(path, op)?;
 
         Ok(BlockingWriter { inner: w })


### PR DESCRIPTION
Remove the `create_file` support in recent releases, this PR changed the internal API of `create` to `create_dir` to better reflect it's behavior.