### PR TITLE
feat(services/s3): Add if-match support

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -944,7 +944,7 @@ impl Accessor for S3Backend {
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let resp = self
             .core
-            .s3_get_object(path, args.range(), args.if_none_match())
+            .s3_get_object(path, args.range(), args.if_none_match(), args.if_match())
             .await?;
 
         let status = resp.status();
@@ -967,6 +967,7 @@ impl Accessor for S3Backend {
                     args.content_type(),
                     args.content_disposition(),
                     args.cache_control(),
+                    args.if_match(),
                 )
                 .await?;
 
@@ -1017,7 +1018,7 @@ impl Accessor for S3Backend {
             return Ok(RpStat::new(Metadata::new(EntryMode::DIR)));
         }
 
-        let resp = self.core.s3_head_object(path, args.if_none_match()).await?;
+        let resp = self.core.s3_head_object(path, args.if_none_match(), args.if_match()).await?;
 
         let status = resp.status();
 
@@ -1059,7 +1060,7 @@ impl Accessor for S3Backend {
         // We will not send this request out, just for signing.
         let mut req = match args.operation() {
             PresignOperation::Stat(v) => {
-                self.core.s3_head_object_request(path, v.if_none_match())?
+                self.core.s3_head_object_request(path, v.if_none_match(), v.if_match())?
             }
             PresignOperation::Read(v) => self.core.s3_get_object_request(
                 path,
@@ -1067,6 +1068,7 @@ impl Accessor for S3Backend {
                 v.override_content_disposition(),
                 v.override_cache_control(),
                 v.if_none_match(),
+                v.if_match(),
             )?,
             PresignOperation::Write(_) => {
                 self.core

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -1018,7 +1018,10 @@ impl Accessor for S3Backend {
             return Ok(RpStat::new(Metadata::new(EntryMode::DIR)));
         }
 
-        let resp = self.core.s3_head_object(path, args.if_none_match(), args.if_match()).await?;
+        let resp = self
+            .core
+            .s3_head_object(path, args.if_none_match(), args.if_match())
+            .await?;
 
         let status = resp.status();
 
@@ -1060,7 +1063,8 @@ impl Accessor for S3Backend {
         // We will not send this request out, just for signing.
         let mut req = match args.operation() {
             PresignOperation::Stat(v) => {
-                self.core.s3_head_object_request(path, v.if_none_match(), v.if_match())?
+                self.core
+                    .s3_head_object_request(path, v.if_none_match(), v.if_match())?
             }
             PresignOperation::Read(v) => self.core.s3_get_object_request(
                 path,

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -29,8 +29,8 @@ use http::header::CACHE_CONTROL;
 use http::header::CONTENT_DISPOSITION;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
-use http::header::IF_NONE_MATCH;
 use http::header::IF_MATCH;
+use http::header::IF_NONE_MATCH;
 use http::HeaderValue;
 use http::Request;
 use http::Response;
@@ -279,8 +279,6 @@ impl S3Core {
         if let Some(if_match) = if_match {
             req = req.header(IF_MATCH, if_match);
         }
-
-
         // Set SSE headers.
         // TODO: how will this work with presign?
         req = self.insert_sse_headers(req, false);


### PR DESCRIPTION
close #1972 

In the Amazon S3 API reference, it seems that the putObject operation does not require the if-match request header, so I did not add the if-match property in the s3/writer file (like in obs/writer). However, I may be wrong.