### PR TITLE
refactor: Polish Writer API by merging append and write together

### DIFF
--- a/core/src/layers/concurrent_limit.rs
+++ b/core/src/layers/concurrent_limit.rs
@@ -316,10 +316,6 @@ impl<R: oio::Write> oio::Write for ConcurrentLimitWrapper<R> {
         self.inner.write(bs).await
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        self.inner.append(bs).await
-    }
-
     async fn abort(&mut self) -> Result<()> {
         self.inner.abort().await
     }
@@ -332,10 +328,6 @@ impl<R: oio::Write> oio::Write for ConcurrentLimitWrapper<R> {
 impl<R: oio::BlockingWrite> oio::BlockingWrite for ConcurrentLimitWrapper<R> {
     fn write(&mut self, bs: Bytes) -> Result<()> {
         self.inner.write(bs)
-    }
-
-    fn append(&mut self, bs: Bytes) -> Result<()> {
-        self.inner.append(bs)
     }
 
     fn close(&mut self) -> Result<()> {

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -411,14 +411,6 @@ impl<T: oio::Write> oio::Write for ErrorContextWrapper<T> {
         })
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        self.inner.append(bs).await.map_err(|err| {
-            err.with_operation(WriteOperation::Append)
-                .with_context("service", self.scheme)
-                .with_context("path", &self.path)
-        })
-    }
-
     async fn abort(&mut self) -> Result<()> {
         self.inner.abort().await.map_err(|err| {
             err.with_operation(WriteOperation::Append)
@@ -440,14 +432,6 @@ impl<T: oio::BlockingWrite> oio::BlockingWrite for ErrorContextWrapper<T> {
     fn write(&mut self, bs: Bytes) -> Result<()> {
         self.inner.write(bs).map_err(|err| {
             err.with_operation(WriteOperation::BlockingWrite)
-                .with_context("service", self.scheme)
-                .with_context("path", &self.path)
-        })
-    }
-
-    fn append(&mut self, bs: Bytes) -> Result<()> {
-        self.inner.append(bs).map_err(|err| {
-            err.with_operation(WriteOperation::BlockingAppend)
                 .with_context("service", self.scheme)
                 .with_context("path", &self.path)
         })

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -1386,39 +1386,6 @@ impl<W: oio::Write> oio::Write for LoggingWriter<W> {
         }
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let size = bs.len();
-        match self.inner.append(bs).await {
-            Ok(_) => {
-                self.written += size as u64;
-                trace!(
-                    target: LOGGING_TARGET,
-                    "service={} operation={} path={} written={} -> data write {}B",
-                    self.scheme,
-                    WriteOperation::Append,
-                    self.path,
-                    self.written,
-                    size
-                );
-                Ok(())
-            }
-            Err(err) => {
-                if let Some(lvl) = self.failure_level {
-                    log!(
-                        target: LOGGING_TARGET,
-                        lvl,
-                        "service={} operation={} path={} written={} -> data write failed: {err:?}",
-                        self.scheme,
-                        WriteOperation::Append,
-                        self.path,
-                        self.written,
-                    )
-                }
-                Err(err)
-            }
-        }
-    }
-
     async fn abort(&mut self) -> Result<()> {
         match self.inner.abort().await {
             Ok(_) => {
@@ -1495,39 +1462,6 @@ impl<W: oio::BlockingWrite> oio::BlockingWrite for LoggingWriter<W> {
                         "service={} operation={} path={} written={} -> data write failed: {err:?}",
                         self.scheme,
                         WriteOperation::BlockingWrite,
-                        self.path,
-                        self.written,
-                    )
-                }
-                Err(err)
-            }
-        }
-    }
-
-    fn append(&mut self, bs: Bytes) -> Result<()> {
-        let size = bs.len();
-        match self.inner.append(bs) {
-            Ok(_) => {
-                self.written += size as u64;
-                trace!(
-                    target: LOGGING_TARGET,
-                    "service={} operation={} path={} written={} -> data write {}B",
-                    self.scheme,
-                    WriteOperation::BlockingAppend,
-                    self.path,
-                    self.written,
-                    size
-                );
-                Ok(())
-            }
-            Err(err) => {
-                if let Some(lvl) = self.failure_level {
-                    log!(
-                        target: LOGGING_TARGET,
-                        lvl,
-                        "service={} operation={} path={} written={} -> data write failed: {err:?}",
-                        self.scheme,
-                        WriteOperation::BlockingAppend,
                         self.path,
                         self.written,
                     )

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -925,18 +925,6 @@ impl<R: oio::Write> oio::Write for MetricWrapper<R> {
             })
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let size = bs.len();
-        self.inner
-            .append(bs)
-            .await
-            .map(|_| self.bytes += size as u64)
-            .map_err(|err| {
-                self.handle.increment_errors_total(self.op, err.kind());
-                err
-            })
-    }
-
     async fn abort(&mut self) -> Result<()> {
         self.inner.abort().await.map_err(|err| {
             self.handle.increment_errors_total(self.op, err.kind());
@@ -957,17 +945,6 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for MetricWrapper<R> {
         let size = bs.len();
         self.inner
             .write(bs)
-            .map(|_| self.bytes += size as u64)
-            .map_err(|err| {
-                self.handle.increment_errors_total(self.op, err.kind());
-                err
-            })
-    }
-
-    fn append(&mut self, bs: Bytes) -> Result<()> {
-        let size = bs.len();
-        self.inner
-            .append(bs)
             .map(|_| self.bytes += size as u64)
             .map_err(|err| {
                 self.handle.increment_errors_total(self.op, err.kind());

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -337,16 +337,6 @@ impl<R: oio::Write> oio::Write for MinitraceWrapper<R> {
             .await
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        self.inner
-            .append(bs)
-            .in_span(Span::enter_with_parent(
-                WriteOperation::Append.into_static(),
-                &self.span,
-            ))
-            .await
-    }
-
     async fn abort(&mut self) -> Result<()> {
         self.inner
             .abort()
@@ -373,12 +363,6 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for MinitraceWrapper<R> {
         let _span =
             Span::enter_with_parent(WriteOperation::BlockingWrite.into_static(), &self.span);
         self.inner.write(bs)
-    }
-
-    fn append(&mut self, bs: Bytes) -> Result<()> {
-        let _span =
-            Span::enter_with_parent(WriteOperation::BlockingAppend.into_static(), &self.span);
-        self.inner.append(bs)
     }
 
     fn close(&mut self) -> Result<()> {

--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -339,10 +339,6 @@ impl<R: oio::Write> oio::Write for OtelTraceWrapper<R> {
         self.inner.write(bs).await
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        self.inner.append(bs).await
-    }
-
     async fn abort(&mut self) -> Result<()> {
         self.inner.abort().await
     }
@@ -355,10 +351,6 @@ impl<R: oio::Write> oio::Write for OtelTraceWrapper<R> {
 impl<R: oio::BlockingWrite> oio::BlockingWrite for OtelTraceWrapper<R> {
     fn write(&mut self, bs: Bytes) -> Result<()> {
         self.inner.write(bs)
-    }
-
-    fn append(&mut self, bs: Bytes) -> Result<()> {
-        self.inner.append(bs)
     }
 
     fn close(&mut self) -> Result<()> {

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -720,23 +720,6 @@ impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
             })
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let size = bs.len();
-        self.inner
-            .append(bs)
-            .await
-            .map(|_| {
-                self.stats
-                    .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::Write.into_static()])
-                    .observe(size as f64)
-            })
-            .map_err(|err| {
-                self.stats.increment_errors_total(self.op, err.kind());
-                err
-            })
-    }
-
     async fn abort(&mut self) -> Result<()> {
         self.inner.abort().await.map_err(|err| {
             self.stats.increment_errors_total(self.op, err.kind());
@@ -757,22 +740,6 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for PrometheusMetricWrapper<R> {
         let size = bs.len();
         self.inner
             .write(bs)
-            .map(|_| {
-                self.stats
-                    .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::BlockingWrite.into_static()])
-                    .observe(size as f64)
-            })
-            .map_err(|err| {
-                self.stats.increment_errors_total(self.op, err.kind());
-                err
-            })
-    }
-
-    fn append(&mut self, bs: Bytes) -> Result<()> {
-        let size = bs.len();
-        self.inner
-            .append(bs)
             .map(|_| {
                 self.stats
                     .bytes_total

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -348,14 +348,6 @@ impl<R: oio::Write> oio::Write for TracingWrapper<R> {
         parent = &self.span,
         level = "trace",
         skip_all)]
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        self.inner.append(bs).await
-    }
-
-    #[tracing::instrument(
-        parent = &self.span,
-        level = "trace",
-        skip_all)]
     async fn abort(&mut self) -> Result<()> {
         self.inner.abort().await
     }
@@ -376,14 +368,6 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for TracingWrapper<R> {
         skip_all)]
     fn write(&mut self, bs: Bytes) -> Result<()> {
         self.inner.write(bs)
-    }
-
-    #[tracing::instrument(
-        parent = &self.span,
-        level = "trace",
-        skip_all)]
-    fn append(&mut self, bs: Bytes) -> Result<()> {
-        self.inner.append(bs)
     }
 
     #[tracing::instrument(

--- a/core/src/raw/oio/cursor.rs
+++ b/core/src/raw/oio/cursor.rs
@@ -148,6 +148,12 @@ pub struct VectorCursor {
     size: usize,
 }
 
+impl Default for VectorCursor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl VectorCursor {
     /// Create a new vector cursor.
     pub fn new() -> Self {

--- a/core/src/raw/oio/cursor.rs
+++ b/core/src/raw/oio/cursor.rs
@@ -182,7 +182,7 @@ impl VectorCursor {
     /// Pop a bytes from vector cursor.
     pub fn pop(&mut self) {
         let bs = self.inner.pop_back();
-        self.size -= bs.expect("poped bytes must exist").len()
+        self.size -= bs.expect("pop bytes must exist").len()
     }
 
     /// Clear the entire vector.
@@ -299,7 +299,6 @@ mod tests {
         assert_eq!(vc.peak_exact(1), Bytes::from("h"));
         assert_eq!(vc.peak_exact(1), Bytes::from("h"));
         assert_eq!(vc.peak_exact(4), Bytes::from("hell"));
-        assert_eq!(vc.peak_exact(6), Bytes::from("hellow"));
         assert_eq!(vc.peak_exact(10), Bytes::from("helloworld"));
 
         vc.take(1);

--- a/core/src/raw/oio/mod.rs
+++ b/core/src/raw/oio/mod.rs
@@ -43,6 +43,7 @@ pub use write::Writer;
 
 mod cursor;
 pub use cursor::Cursor;
+pub use cursor::VectorCursor;
 
 mod into_streamable;
 pub use into_streamable::into_streamable_reader;

--- a/core/src/raw/oio/write.rs
+++ b/core/src/raw/oio/write.rs
@@ -99,9 +99,6 @@ pub trait Write: Unpin + Send + Sync {
     /// Please make sure `write` is safe to re-enter.
     async fn write(&mut self, bs: Bytes) -> Result<()>;
 
-    /// Append bytes to the writer.
-    async fn append(&mut self, bs: Bytes) -> Result<()>;
-
     /// Abort the pending writer.
     async fn abort(&mut self) -> Result<()>;
 
@@ -115,15 +112,6 @@ impl Write for () {
         let _ = bs;
 
         unimplemented!("write is required to be implemented for oio::Write")
-    }
-
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let _ = bs;
-
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "output writer doesn't support append",
-        ))
     }
 
     async fn abort(&mut self) -> Result<()> {
@@ -149,10 +137,6 @@ impl<T: Write + ?Sized> Write for Box<T> {
         (**self).write(bs).await
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        (**self).append(bs).await
-    }
-
     async fn abort(&mut self) -> Result<()> {
         (**self).abort().await
     }
@@ -170,9 +154,6 @@ pub trait BlockingWrite: Send + Sync + 'static {
     /// Write whole content at once.
     fn write(&mut self, bs: Bytes) -> Result<()>;
 
-    /// Append content at tailing.
-    fn append(&mut self, bs: Bytes) -> Result<()>;
-
     /// Close the writer and make sure all data has been flushed.
     fn close(&mut self) -> Result<()>;
 }
@@ -182,15 +163,6 @@ impl BlockingWrite for () {
         let _ = bs;
 
         unimplemented!("write is required to be implemented for oio::BlockingWrite")
-    }
-
-    fn append(&mut self, bs: Bytes) -> Result<()> {
-        let _ = bs;
-
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "output writer doesn't support append",
-        ))
     }
 
     fn close(&mut self) -> Result<()> {
@@ -206,10 +178,6 @@ impl BlockingWrite for () {
 impl<T: BlockingWrite + ?Sized> BlockingWrite for Box<T> {
     fn write(&mut self, bs: Bytes) -> Result<()> {
         (**self).write(bs)
-    }
-
-    fn append(&mut self, bs: Bytes) -> Result<()> {
-        (**self).append(bs)
     }
 
     fn close(&mut self) -> Result<()> {

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -497,10 +497,10 @@ impl Accessor for AzblobBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.append() {
+        if args.content_length().is_none() {
             return Err(Error::new(
                 ErrorKind::Unsupported,
-                "append write is not supported",
+                "write without content length is not supported",
             ));
         }
 

--- a/core/src/services/azblob/writer.rs
+++ b/core/src/services/azblob/writer.rs
@@ -65,15 +65,6 @@ impl oio::Write for AzblobWriter {
         }
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let _ = bs;
-
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "output writer doesn't support append",
-        ))
-    }
-
     async fn abort(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/azdfs/backend.rs
+++ b/core/src/services/azdfs/backend.rs
@@ -354,10 +354,10 @@ impl Accessor for AzdfsBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.append() {
+        if args.content_length().is_none() {
             return Err(Error::new(
                 ErrorKind::Unsupported,
-                "append write is not supported",
+                "write without content length is not supported",
             ));
         }
 

--- a/core/src/services/azdfs/writer.rs
+++ b/core/src/services/azdfs/writer.rs
@@ -87,15 +87,6 @@ impl oio::Write for AzdfsWriter {
         }
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let _ = bs;
-
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "output writer doesn't support append",
-        ))
-    }
-
     async fn abort(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/fs/writer.rs
+++ b/core/src/services/fs/writer.rs
@@ -54,17 +54,6 @@ impl oio::Write for FsWriter<tokio::fs::File> {
     /// File could be partial written, so we will seek to start to make sure
     /// we write the same content.
     async fn write(&mut self, bs: Bytes) -> Result<()> {
-        self.f.rewind().await.map_err(parse_io_error)?;
-        self.f.write_all(&bs).await.map_err(parse_io_error)?;
-
-        Ok(())
-    }
-
-    /// # Notes
-    ///
-    /// File could be partial written, so we will seek to start to make sure
-    /// we write the same content.
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
         self.f
             .seek(SeekFrom::Start(self.pos))
             .await
@@ -101,17 +90,6 @@ impl oio::BlockingWrite for FsWriter<std::fs::File> {
     /// File could be partial written, so we will seek to start to make sure
     /// we write the same content.
     fn write(&mut self, bs: Bytes) -> Result<()> {
-        self.f.rewind().map_err(parse_io_error)?;
-        self.f.write_all(&bs).map_err(parse_io_error)?;
-
-        Ok(())
-    }
-
-    /// # Notes
-    ///
-    /// File could be partial written, so we will seek to start to make sure
-    /// we write the same content.
-    fn append(&mut self, bs: Bytes) -> Result<()> {
         self.f
             .seek(SeekFrom::Start(self.pos))
             .map_err(parse_io_error)?;

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -388,10 +388,10 @@ impl Accessor for FtpBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.append() {
+        if args.content_length().is_none() {
             return Err(Error::new(
                 ErrorKind::Unsupported,
-                "append write is not supported",
+                "write without content length is not supported",
             ));
         }
 

--- a/core/src/services/ftp/writer.rs
+++ b/core/src/services/ftp/writer.rs
@@ -53,15 +53,6 @@ impl oio::Write for FtpWriter {
         Ok(())
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let _ = bs;
-
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "output writer doesn't support append",
-        ))
-    }
-
     async fn abort(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -410,32 +410,9 @@ impl Accessor for GcsBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        let upload_location = if args.append() {
-            let resp = self.core.gcs_initiate_resumable_upload(path).await?;
-            let status = resp.status();
-
-            match status {
-                StatusCode::OK => {
-                    let bs = parse_location(resp.headers())
-                        .expect("Failed to retrieve location of resumable upload");
-                    if let Some(location) = bs {
-                        Some(String::from(location))
-                    } else {
-                        return Err(Error::new(
-                            ErrorKind::NotFound,
-                            "location is not in the response header",
-                        ));
-                    }
-                }
-                _ => return Err(parse_error(resp).await?),
-            }
-        } else {
-            None
-        };
-
         Ok((
             RpWrite::default(),
-            GcsWriter::new(self.core.clone(), args, path.to_string(), upload_location),
+            GcsWriter::new(self.core.clone(), path, args),
         ))
     }
 

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -322,7 +322,7 @@ impl GcsCore {
         &self,
         location: &str,
         size: u64,
-        written_bytes: u64,
+        written: u64,
         is_last_part: bool,
         body: AsyncBody,
     ) -> Result<Request<AsyncBody>> {
@@ -331,12 +331,12 @@ impl GcsCore {
         let range_header = if is_last_part {
             format!(
                 "bytes {}-{}/{}",
-                written_bytes,
-                written_bytes + size - 1,
-                written_bytes + size
+                written,
+                written + size - 1,
+                written + size
             )
         } else {
-            format!("bytes {}-{}/*", written_bytes, written_bytes + size - 1)
+            format!("bytes {}-{}/*", written, written + size - 1)
         };
 
         req = req

--- a/core/src/services/gcs/writer.rs
+++ b/core/src/services/gcs/writer.rs
@@ -155,7 +155,7 @@ impl oio::Write for GcsWriter {
             return Ok(());
         }
 
-        let bs = self.buffer.peak(self.buffer_size);
+        let bs = self.buffer.peak_exact(self.buffer_size);
 
         match self.write_part(location, bs).await {
             Ok(_) => {
@@ -184,7 +184,7 @@ impl oio::Write for GcsWriter {
             return Ok(());
         };
 
-        let bs = self.buffer.peak(self.buffer.len());
+        let bs = self.buffer.peak_exact(self.buffer.len());
 
         let resp = self
             .core

--- a/core/src/services/gcs/writer.rs
+++ b/core/src/services/gcs/writer.rs
@@ -29,37 +29,40 @@ use crate::*;
 
 pub struct GcsWriter {
     core: Arc<GcsCore>,
-
-    op: OpWrite,
     path: String,
+    op: OpWrite,
+
     location: Option<String>,
-    written_bytes: u64,
-    is_last_part_written: bool,
-    last: Option<Bytes>,
+    written: u64,
+    buffer: oio::VectorCursor,
+    buffer_size: usize,
 }
 
 impl GcsWriter {
-    pub fn new(
-        core: Arc<GcsCore>,
-        op: OpWrite,
-        path: String,
-        upload_location: Option<String>,
-    ) -> Self {
+    pub fn new(core: Arc<GcsCore>, path: &str, op: OpWrite) -> Self {
         GcsWriter {
             core,
+            path: path.to_string(),
             op,
-            path,
-            location: upload_location,
-            written_bytes: 0,
-            is_last_part_written: false,
-            last: None,
+
+            location: None,
+            written: 0,
+            buffer: oio::VectorCursor::new(),
+            // The chunk size should be a multiple of 256 KiB
+            // (256 x 1024 bytes), unless it's the last chunk
+            // that completes the upload.
+            //
+            // Larger chunk sizes typically make uploads faster,
+            // but note that there's a tradeoff between speed and
+            // memory usage. It's recommended that you use at least
+            // 8 MiB for the chunk size.
+            //
+            // TODO: allow this value to be configured.
+            buffer_size: 8 * 1024 * 1024,
         }
     }
-}
 
-#[async_trait]
-impl oio::Write for GcsWriter {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
+    async fn write_oneshot(&self, bs: Bytes) -> Result<()> {
         let mut req = self.core.gcs_insert_object_request(
             &percent_encode_path(&self.path),
             Some(bs.len()),
@@ -82,80 +85,123 @@ impl oio::Write for GcsWriter {
         }
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let location = if let Some(location) = &self.location {
-            location
-        } else {
-            return Ok(());
-        };
+    async fn initiate_upload(&self) -> Result<String> {
+        let resp = self.core.gcs_initiate_resumable_upload(&self.path).await?;
+        let status = resp.status();
 
-        let result = if let Some(last) = &self.last {
-            let bytes_to_upload = last.slice(0..last.len());
-            let part_size = bytes_to_upload.len() as u64;
-            let is_last_part = part_size % (256 * 1024) != 0;
-            let mut req = self.core.gcs_upload_in_resumable_upload(
-                location,
-                part_size,
-                self.written_bytes,
-                is_last_part,
-                AsyncBody::Bytes(bytes_to_upload),
-            )?;
-
-            self.core.sign(&mut req).await?;
-
-            let resp = self.core.send(req).await?;
-
-            let status = resp.status();
-
-            match status {
-                StatusCode::OK | StatusCode::PERMANENT_REDIRECT => {
-                    if is_last_part {
-                        self.is_last_part_written = true
-                    } else {
-                        self.written_bytes += part_size;
-                    }
-                    Ok(())
+        match status {
+            StatusCode::OK => {
+                let bs = parse_location(resp.headers())?;
+                if let Some(location) = bs {
+                    Ok(location.to_string())
+                } else {
+                    Err(Error::new(
+                        ErrorKind::Unexpected,
+                        "location is not in the response header",
+                    ))
                 }
-                _ => Err(parse_error(resp).await?),
             }
-        } else {
-            Ok(())
-        };
-
-        self.last = Some(bs.slice(0..bs.len()));
-        return result;
+            _ => Err(parse_error(resp).await?),
+        }
     }
 
+    async fn write_part(&self, location: &str, bs: Bytes) -> Result<()> {
+        let mut req = self.core.gcs_upload_in_resumable_upload(
+            location,
+            bs.len() as u64,
+            self.written,
+            false,
+            AsyncBody::Bytes(bs),
+        )?;
+
+        self.core.sign(&mut req).await?;
+
+        let resp = self.core.send(req).await?;
+
+        let status = resp.status();
+        match status {
+            StatusCode::OK | StatusCode::PERMANENT_REDIRECT => Ok(()),
+            _ => Err(parse_error(resp).await?),
+        }
+    }
+}
+
+#[async_trait]
+impl oio::Write for GcsWriter {
+    async fn write(&mut self, bs: Bytes) -> Result<()> {
+        let location = match &self.location {
+            Some(location) => location,
+            None => {
+                if self.op.content_length().unwrap_or_default() == bs.len() as u64
+                    && self.written == 0
+                {
+                    return self.write_oneshot(bs).await;
+                } else {
+                    let location = self.initiate_upload().await?;
+                    self.location = Some(location.clone());
+                    self.location.as_deref().unwrap()
+                }
+            }
+        };
+
+        // Ignore empty bytes
+        if bs.len() == 0 {
+            return Ok(());
+        }
+
+        self.buffer.push(bs);
+        // Return directly if the buffer is not full
+        if self.buffer.len() <= self.buffer_size {
+            return Ok(());
+        }
+
+        let bs = self.buffer.peak(self.buffer_size);
+
+        match self.write_part(location, bs).await {
+            Ok(_) => {
+                self.buffer.take(self.buffer_size);
+                self.written += self.buffer_size as u64;
+                Ok(())
+            }
+            Err(e) => {
+                // If the upload fails, we should pop the given bs to make sure
+                // write is re-enter safe.
+                self.buffer.pop();
+                Err(e)
+            }
+        }
+    }
+
+    async fn append(&mut self, bs: Bytes) -> Result<()> {
+        self.write(bs).await
+    }
+
+    // TODO: we can cancel the upload by sending a DELETE request to the location
     async fn abort(&mut self) -> Result<()> {
         Ok(())
     }
 
     async fn close(&mut self) -> Result<()> {
-        if self.is_last_part_written {
-            return Ok(());
-        }
-
         let location = if let Some(location) = &self.location {
             location
         } else {
             return Ok(());
         };
 
-        let bs = self
-            .last
-            .as_ref()
-            .expect("failed to get the previously uploaded part");
+        let bs = self.buffer.peak(self.buffer.len());
 
         let resp = self
             .core
-            .gcs_complete_resumable_upload(location, self.written_bytes, bs.slice(0..bs.len()))
+            .gcs_complete_resumable_upload(location, self.written, bs)
             .await?;
 
         let status = resp.status();
-
         match status {
             StatusCode::OK => {
                 resp.into_body().consume().await?;
+
+                self.location = None;
+                self.buffer.clear();
                 Ok(())
             }
             _ => Err(parse_error(resp).await?),

--- a/core/src/services/gcs/writer.rs
+++ b/core/src/services/gcs/writer.rs
@@ -138,14 +138,14 @@ impl oio::Write for GcsWriter {
                     return self.write_oneshot(bs).await;
                 } else {
                     let location = self.initiate_upload().await?;
-                    self.location = Some(location.clone());
+                    self.location = Some(location);
                     self.location.as_deref().unwrap()
                 }
             }
         };
 
         // Ignore empty bytes
-        if bs.len() == 0 {
+        if bs.is_empty() {
             return Ok(());
         }
 
@@ -170,10 +170,6 @@ impl oio::Write for GcsWriter {
                 Err(e)
             }
         }
-    }
-
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        self.write(bs).await
     }
 
     // TODO: we can cancel the upload by sending a DELETE request to the location

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -391,10 +391,10 @@ impl Accessor for GhacBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.append() {
+        if args.content_length().is_none() {
             return Err(Error::new(
                 ErrorKind::Unsupported,
-                "append write is not supported",
+                "write without content length is not supported",
             ));
         }
 

--- a/core/src/services/ghac/writer.rs
+++ b/core/src/services/ghac/writer.rs
@@ -62,15 +62,6 @@ impl oio::Write for GhacWriter {
         }
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let _ = bs;
-
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "output writer doesn't support append",
-        ))
-    }
-
     async fn abort(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/hdfs/writer.rs
+++ b/core/src/services/hdfs/writer.rs
@@ -47,20 +47,6 @@ impl oio::Write for HdfsWriter<hdrs::AsyncFile> {
     /// we write the same content.
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         self.f
-            .seek(SeekFrom::Start(0))
-            .await
-            .map_err(parse_io_error)?;
-        self.f.write_all(&bs).await.map_err(parse_io_error)?;
-
-        Ok(())
-    }
-
-    /// # Notes
-    ///
-    /// File could be partial written, so we will seek to start to make sure
-    /// we write the same content.
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        self.f
             .seek(SeekFrom::Start(self.pos))
             .await
             .map_err(parse_io_error)?;
@@ -90,17 +76,6 @@ impl oio::BlockingWrite for HdfsWriter<hdrs::File> {
     /// File could be partial written, so we will seek to start to make sure
     /// we write the same content.
     fn write(&mut self, bs: Bytes) -> Result<()> {
-        self.f.rewind().map_err(parse_io_error)?;
-        self.f.write_all(&bs).map_err(parse_io_error)?;
-
-        Ok(())
-    }
-
-    /// # Notes
-    ///
-    /// File could be partial written, so we will seek to start to make sure
-    /// we write the same content.
-    fn append(&mut self, bs: Bytes) -> Result<()> {
         self.f
             .seek(SeekFrom::Start(self.pos))
             .map_err(parse_io_error)?;

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -110,10 +110,10 @@ impl Accessor for IpmfsBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.append() {
+        if args.content_length().is_none() {
             return Err(Error::new(
                 ErrorKind::Unsupported,
-                "append write is not supported",
+                "write without content length is not supported",
             ));
         }
 

--- a/core/src/services/ipmfs/writer.rs
+++ b/core/src/services/ipmfs/writer.rs
@@ -55,15 +55,6 @@ impl oio::Write for IpmfsWriter {
         }
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let _ = bs;
-
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "output writer doesn't support append",
-        ))
-    }
-
     async fn abort(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -315,9 +315,9 @@ impl Accessor for ObsBackend {
     }
 
     async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
-        let mut req =
-            self.core
-                .obs_put_object_request(path, Some(0), None, None, AsyncBody::Empty)?;
+        let mut req = self
+            .core
+            .obs_put_object_request(path, Some(0), None, AsyncBody::Empty)?;
 
         self.core.sign(&mut req).await?;
 
@@ -352,10 +352,10 @@ impl Accessor for ObsBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.append() {
+        if args.content_length().is_none() {
             return Err(Error::new(
                 ErrorKind::Unsupported,
-                "append write is not supported",
+                "write without content length is not supported",
             ));
         }
 

--- a/core/src/services/obs/core.rs
+++ b/core/src/services/obs/core.rs
@@ -116,7 +116,6 @@ impl ObsCore {
         path: &str,
         size: Option<usize>,
         content_type: Option<&str>,
-        if_match: Option<&str>,
         body: AsyncBody,
     ) -> Result<Request<AsyncBody>> {
         let p = build_abs_path(&self.root, path);
@@ -124,10 +123,6 @@ impl ObsCore {
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
         let mut req = Request::put(&url);
-
-        if let Some(if_match) = if_match {
-            req = req.header(IF_MATCH, if_match);
-        }
 
         if let Some(size) = size {
             req = req.header(CONTENT_LENGTH, size)

--- a/core/src/services/obs/writer.rs
+++ b/core/src/services/obs/writer.rs
@@ -47,7 +47,6 @@ impl oio::Write for ObsWriter {
             &self.path,
             Some(bs.len()),
             self.op.content_type(),
-            self.op.if_match(),
             AsyncBody::Bytes(bs),
         )?;
 

--- a/core/src/services/obs/writer.rs
+++ b/core/src/services/obs/writer.rs
@@ -65,15 +65,6 @@ impl oio::Write for ObsWriter {
         }
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let _ = bs;
-
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "output writer doesn't support append",
-        ))
-    }
-
     async fn abort(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -407,25 +407,9 @@ impl Accessor for OssBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        let upload_id = if args.append() {
-            let resp = self.core.oss_initiate_upload(path, &args).await?;
-            match resp.status() {
-                StatusCode::OK => {
-                    let bs = resp.into_body().bytes().await?;
-                    let result: InitiateMultipartUploadResult =
-                        quick_xml::de::from_reader(bs.reader())
-                            .map_err(new_xml_deserialize_error)?;
-                    Some(result.upload_id)
-                }
-                _ => return Err(parse_error(resp).await?),
-            }
-        } else {
-            None
-        };
-
         Ok((
             RpWrite::default(),
-            OssWriter::new(self.core.clone(), args, path.to_string(), upload_id),
+            OssWriter::new(self.core.clone(), &path, args),
         ))
     }
 

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -409,7 +409,7 @@ impl Accessor for OssBackend {
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         Ok((
             RpWrite::default(),
-            OssWriter::new(self.core.clone(), &path, args),
+            OssWriter::new(self.core.clone(), path, args),
         ))
     }
 

--- a/core/src/services/oss/writer.rs
+++ b/core/src/services/oss/writer.rs
@@ -94,7 +94,7 @@ impl OssWriter {
                     quick_xml::de::from_reader(bs.reader()).map_err(new_xml_deserialize_error)?;
                 Ok(result.upload_id)
             }
-            _ => return Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp).await?),
         }
     }
 
@@ -144,14 +144,14 @@ impl oio::Write for OssWriter {
                     return self.write_oneshot(bs).await;
                 } else {
                     let upload_id = self.initiate_upload().await?;
-                    self.upload_id = Some(upload_id.clone());
+                    self.upload_id = Some(upload_id);
                     self.upload_id.as_deref().unwrap()
                 }
             }
         };
 
         // Ignore empty bytes
-        if bs.len() == 0 {
+        if bs.is_empty() {
             return Ok(());
         }
 
@@ -176,10 +176,6 @@ impl oio::Write for OssWriter {
                 Err(e)
             }
         }
-    }
-
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        todo!()
     }
 
     // TODO: we can cancel the upload by sending an abort request.

--- a/core/src/services/oss/writer.rs
+++ b/core/src/services/oss/writer.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use http::StatusCode;
 
 use super::core::*;
@@ -33,24 +33,33 @@ pub struct OssWriter {
     op: OpWrite,
     path: String,
     upload_id: Option<String>,
+
     parts: Vec<MultipartUploadPart>,
+    buffer: oio::VectorCursor,
+    buffer_size: usize,
 }
 
 impl OssWriter {
-    pub fn new(core: Arc<OssCore>, op: OpWrite, path: String, upload_id: Option<String>) -> Self {
+    pub fn new(core: Arc<OssCore>, path: &str, op: OpWrite) -> Self {
         OssWriter {
             core,
+            path: path.to_string(),
             op,
-            path,
-            upload_id,
+
+            upload_id: None,
             parts: vec![],
+            buffer: oio::VectorCursor::new(),
+            // The part size must be 5 MiB to 5 GiB. There is no minimum
+            // size limit on the last part of your multipart upload.
+            //
+            // We pick the default value as 8 MiB for better thoughput.
+            //
+            // TODO: allow this value to be configured.
+            buffer_size: 8 * 1024 * 1024,
         }
     }
-}
 
-#[async_trait]
-impl oio::Write for OssWriter {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
+    async fn write_oneshot(&self, bs: Bytes) -> Result<()> {
         let mut req = self.core.oss_put_object_request(
             &self.path,
             Some(bs.len()),
@@ -76,10 +85,20 @@ impl oio::Write for OssWriter {
         }
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let upload_id = self.upload_id.as_ref().expect(
-            "Writer doesn't have upload id, but users trying to call append, must be buggy",
-        );
+    async fn initiate_upload(&self) -> Result<String> {
+        let resp = self.core.oss_initiate_upload(&self.path, &self.op).await?;
+        match resp.status() {
+            StatusCode::OK => {
+                let bs = resp.into_body().bytes().await?;
+                let result: InitiateMultipartUploadResult =
+                    quick_xml::de::from_reader(bs.reader()).map_err(new_xml_deserialize_error)?;
+                Ok(result.upload_id)
+            }
+            _ => return Err(parse_error(resp).await?),
+        }
+    }
+
+    async fn write_part(&self, upload_id: &str, bs: Bytes) -> Result<MultipartUploadPart> {
         // Aliyun OSS requires part number must between [1..=10000]
         let part_number = self.parts.len() + 1;
         let mut req = self
@@ -108,13 +127,62 @@ impl oio::Write for OssWriter {
                     })?
                     .to_string();
                 resp.into_body().consume().await?;
-                self.parts.push(MultipartUploadPart { part_number, etag });
-                Ok(())
+                Ok(MultipartUploadPart { part_number, etag })
             }
             _ => Err(parse_error(resp).await?),
         }
     }
+}
 
+#[async_trait]
+impl oio::Write for OssWriter {
+    async fn write(&mut self, bs: Bytes) -> Result<()> {
+        let upload_id = match &self.upload_id {
+            Some(upload_id) => upload_id,
+            None => {
+                if self.op.content_length().unwrap_or_default() == bs.len() as u64 {
+                    return self.write_oneshot(bs).await;
+                } else {
+                    let upload_id = self.initiate_upload().await?;
+                    self.upload_id = Some(upload_id.clone());
+                    self.upload_id.as_deref().unwrap()
+                }
+            }
+        };
+
+        // Ignore empty bytes
+        if bs.len() == 0 {
+            return Ok(());
+        }
+
+        self.buffer.push(bs);
+        // Return directly if the buffer is not full
+        if self.buffer.len() <= self.buffer_size {
+            return Ok(());
+        }
+
+        let bs = self.buffer.peak(self.buffer_size);
+
+        match self.write_part(upload_id, bs).await {
+            Ok(part) => {
+                self.buffer.take(self.buffer_size);
+                self.parts.push(part);
+                Ok(())
+            }
+            Err(e) => {
+                // If the upload fails, we should pop the given bs to make sure
+                // write is re-enter safe.
+                self.buffer.pop();
+                Err(e)
+            }
+        }
+    }
+
+    async fn append(&mut self, bs: Bytes) -> Result<()> {
+        todo!()
+    }
+
+    // TODO: we can cancel the upload by sending an abort request.
     async fn abort(&mut self) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -961,7 +961,7 @@ impl Accessor for S3Backend {
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         Ok((
             RpWrite::default(),
-            S3Writer::new(self.core.clone(), &path, args),
+            S3Writer::new(self.core.clone(), path, args),
         ))
     }
 

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -489,7 +489,6 @@ impl S3Core {
         content_type: Option<&str>,
         content_disposition: Option<&str>,
         cache_control: Option<&str>,
-        if_match: Option<&str>,
     ) -> Result<Response<IncomingAsyncBody>> {
         let p = build_abs_path(&self.root, path);
 
@@ -507,10 +506,6 @@ impl S3Core {
 
         if let Some(cache_control) = cache_control {
             req = req.header(CACHE_CONTROL, cache_control)
-        }
-
-        if let Some(if_match) = if_match {
-            req = req.header(IF_MATCH, if_match)
         }
 
         // Set storage class header

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -29,6 +29,7 @@ use http::header::CACHE_CONTROL;
 use http::header::CONTENT_DISPOSITION;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
+use http::header::IF_MATCH;
 use http::header::IF_NONE_MATCH;
 use http::HeaderValue;
 use http::Request;
@@ -206,6 +207,7 @@ impl S3Core {
         &self,
         path: &str,
         if_none_match: Option<&str>,
+        if_match: Option<&str>,
     ) -> Result<Request<AsyncBody>> {
         let p = build_abs_path(&self.root, path);
 
@@ -217,6 +219,10 @@ impl S3Core {
 
         if let Some(if_none_match) = if_none_match {
             req = req.header(IF_NONE_MATCH, if_none_match);
+        }
+
+        if let Some(if_match) = if_match {
+            req = req.header(IF_MATCH, if_match);
         }
 
         let req = req
@@ -233,6 +239,7 @@ impl S3Core {
         override_content_disposition: Option<&str>,
         override_cache_control: Option<&str>,
         if_none_match: Option<&str>,
+        if_match: Option<&str>,
     ) -> Result<Request<AsyncBody>> {
         let p = build_abs_path(&self.root, path);
 
@@ -269,6 +276,9 @@ impl S3Core {
             req = req.header(IF_NONE_MATCH, if_none_match);
         }
 
+        if let Some(if_match) = if_match {
+            req = req.header(IF_MATCH, if_match);
+        }
         // Set SSE headers.
         // TODO: how will this work with presign?
         req = self.insert_sse_headers(req, false);
@@ -285,8 +295,10 @@ impl S3Core {
         path: &str,
         range: BytesRange,
         if_none_match: Option<&str>,
+        if_match: Option<&str>,
     ) -> Result<Response<IncomingAsyncBody>> {
-        let mut req = self.s3_get_object_request(path, range, None, None, if_none_match)?;
+        let mut req =
+            self.s3_get_object_request(path, range, None, None, if_none_match, if_match)?;
 
         self.sign(&mut req).await?;
 
@@ -342,8 +354,9 @@ impl S3Core {
         &self,
         path: &str,
         if_none_match: Option<&str>,
+        if_match: Option<&str>,
     ) -> Result<Response<IncomingAsyncBody>> {
-        let mut req = self.s3_head_object_request(path, if_none_match)?;
+        let mut req = self.s3_head_object_request(path, if_none_match, if_match)?;
 
         self.sign(&mut req).await?;
 
@@ -476,6 +489,7 @@ impl S3Core {
         content_type: Option<&str>,
         content_disposition: Option<&str>,
         cache_control: Option<&str>,
+        if_match: Option<&str>,
     ) -> Result<Response<IncomingAsyncBody>> {
         let p = build_abs_path(&self.root, path);
 
@@ -493,6 +507,10 @@ impl S3Core {
 
         if let Some(cache_control) = cache_control {
             req = req.header(CACHE_CONTROL, cache_control)
+        }
+
+        if let Some(if_match) = if_match {
+            req = req.header(IF_MATCH, if_match)
         }
 
         // Set storage class header

--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use http::StatusCode;
 
 use super::core::*;
@@ -32,32 +32,34 @@ pub struct S3Writer {
 
     op: OpWrite,
     path: String,
-
     upload_id: Option<String>,
+
     parts: Vec<CompleteMultipartUploadRequestPart>,
+    buffer: oio::VectorCursor,
+    buffer_size: usize,
 }
 
 impl S3Writer {
-    pub fn new(core: Arc<S3Core>, op: OpWrite, path: String, upload_id: Option<String>) -> Self {
+    pub fn new(core: Arc<S3Core>, path: &str, op: OpWrite) -> Self {
         S3Writer {
             core,
-
+            path: path.to_string(),
             op,
-            path,
-            upload_id,
+
+            upload_id: None,
             parts: vec![],
+            buffer: oio::VectorCursor::new(),
+            // The part size must be 5 MiB to 5 GiB. There is no minimum
+            // size limit on the last part of your multipart upload.
+            //
+            // We pick the default value as 8 MiB for better thoughput.
+            //
+            // TODO: allow this value to be configured.
+            buffer_size: 8 * 1024 * 1024,
         }
     }
-}
 
-#[async_trait]
-impl oio::Write for S3Writer {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        debug_assert!(
-            self.upload_id.is_none(),
-            "Writer initiated with upload id, but users trying to call write, must be buggy"
-        );
-
+    async fn write_oneshot(&self, bs: Bytes) -> Result<()> {
         let mut req = self.core.s3_put_object_request(
             &self.path,
             Some(bs.len()),
@@ -82,10 +84,37 @@ impl oio::Write for S3Writer {
         }
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let upload_id = self.upload_id.as_ref().expect(
-            "Writer doesn't have upload id, but users trying to call append, must be buggy",
-        );
+    async fn initiate_upload(&self) -> Result<String> {
+        let resp = self
+            .core
+            .s3_initiate_multipart_upload(
+                &self.path,
+                self.op.content_type(),
+                self.op.content_disposition(),
+                self.op.cache_control(),
+            )
+            .await?;
+
+        let status = resp.status();
+
+        match status {
+            StatusCode::OK => {
+                let bs = resp.into_body().bytes().await?;
+
+                let result: InitiateMultipartUploadResult =
+                    quick_xml::de::from_reader(bs.reader()).map_err(new_xml_deserialize_error)?;
+
+                Ok(result.upload_id)
+            }
+            _ => return Err(parse_error(resp).await?),
+        }
+    }
+
+    async fn write_part(
+        &self,
+        upload_id: &str,
+        bs: Bytes,
+    ) -> Result<CompleteMultipartUploadRequestPart> {
         // AWS S3 requires part number must between [1..=10000]
         let part_number = self.parts.len() + 1;
 
@@ -116,13 +145,59 @@ impl oio::Write for S3Writer {
 
                 resp.into_body().consume().await?;
 
-                self.parts
-                    .push(CompleteMultipartUploadRequestPart { part_number, etag });
-
-                Ok(())
+                Ok(CompleteMultipartUploadRequestPart { part_number, etag })
             }
             _ => Err(parse_error(resp).await?),
         }
+    }
+}
+
+#[async_trait]
+impl oio::Write for S3Writer {
+    async fn write(&mut self, bs: Bytes) -> Result<()> {
+        let upload_id = match &self.upload_id {
+            Some(upload_id) => upload_id,
+            None => {
+                if self.op.content_length().unwrap_or_default() == bs.len() as u64 {
+                    return self.write_oneshot(bs).await;
+                } else {
+                    let upload_id = self.initiate_upload().await?;
+                    self.upload_id = Some(upload_id.clone());
+                    self.upload_id.as_deref().unwrap()
+                }
+            }
+        };
+
+        // Ignore empty bytes
+        if bs.len() == 0 {
+            return Ok(());
+        }
+
+        self.buffer.push(bs);
+        // Return directly if the buffer is not full
+        if self.buffer.len() <= self.buffer_size {
+            return Ok(());
+        }
+
+        let bs = self.buffer.peak(self.buffer_size);
+
+        match self.write_part(upload_id, bs).await {
+            Ok(part) => {
+                self.buffer.take(self.buffer_size);
+                self.parts.push(part);
+                Ok(())
+            }
+            Err(e) => {
+                // If the upload fails, we should pop the given bs to make sure
+                // write is re-enter safe.
+                self.buffer.pop();
+                Err(e)
+            }
+        }
+    }
+
+    async fn append(&mut self, bs: Bytes) -> Result<()> {
+        todo!()
     }
 
     async fn abort(&mut self) -> Result<()> {

--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -106,7 +106,7 @@ impl S3Writer {
 
                 Ok(result.upload_id)
             }
-            _ => return Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp).await?),
         }
     }
 
@@ -162,14 +162,14 @@ impl oio::Write for S3Writer {
                     return self.write_oneshot(bs).await;
                 } else {
                     let upload_id = self.initiate_upload().await?;
-                    self.upload_id = Some(upload_id.clone());
+                    self.upload_id = Some(upload_id);
                     self.upload_id.as_deref().unwrap()
                 }
             }
         };
 
         // Ignore empty bytes
-        if bs.len() == 0 {
+        if bs.is_empty() {
             return Ok(());
         }
 
@@ -194,10 +194,6 @@ impl oio::Write for S3Writer {
                 Err(e)
             }
         }
-    }
-
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        todo!()
     }
 
     async fn abort(&mut self) -> Result<()> {

--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -179,11 +179,12 @@ impl oio::Write for S3Writer {
             return Ok(());
         }
 
-        let bs = self.buffer.peak(self.buffer_size);
+        let bs = self.buffer.peak_at_least(self.buffer_size);
+        let size = bs.len();
 
         match self.write_part(upload_id, bs).await {
             Ok(part) => {
-                self.buffer.take(self.buffer_size);
+                self.buffer.take(size);
                 self.parts.push(part);
                 Ok(())
             }
@@ -223,6 +224,21 @@ impl oio::Write for S3Writer {
         } else {
             return Ok(());
         };
+
+        // Make sure internal buffer has been flushed.
+        if !self.buffer.is_empty() {
+            let bs = self.buffer.peak_exact(self.buffer.len());
+
+            match self.write_part(upload_id, bs).await {
+                Ok(part) => {
+                    self.buffer.clear();
+                    self.parts.push(part);
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
 
         let resp = self
             .core

--- a/core/src/services/wasabi/backend.rs
+++ b/core/src/services/wasabi/backend.rs
@@ -951,7 +951,7 @@ impl Accessor for WasabiBackend {
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         Ok((
             RpWrite::default(),
-            WasabiWriter::new(self.core.clone(), args, path.to_string(), None),
+            WasabiWriter::new(self.core.clone(), args, path.to_string()),
         ))
     }
 

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -300,10 +300,10 @@ impl Accessor for WebdavBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.append() {
+        if args.content_length().is_none() {
             return Err(Error::new(
                 ErrorKind::Unsupported,
-                "append write is not supported",
+                "write without content length is not supported",
             ));
         }
 

--- a/core/src/services/webdav/writer.rs
+++ b/core/src/services/webdav/writer.rs
@@ -63,15 +63,6 @@ impl oio::Write for WebdavWriter {
         }
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let _ = bs;
-
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "output writer doesn't support append",
-        ))
-    }
-
     async fn abort(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -519,10 +519,10 @@ impl Accessor for WebhdfsBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.append() {
+        if args.content_length().is_none() {
             return Err(Error::new(
                 ErrorKind::Unsupported,
-                "append write is not supported",
+                "write without content length is not supported",
             ));
         }
 

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -63,15 +63,6 @@ impl oio::Write for WebhdfsWriter {
         }
     }
 
-    async fn append(&mut self, bs: Bytes) -> Result<()> {
-        let _ = bs;
-
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "output writer doesn't support append",
-        ))
-    }
-
     async fn abort(&mut self) -> Result<()> {
         Ok(())
     }

--- a/core/src/types/operator/blocking_operator.rs
+++ b/core/src/types/operator/blocking_operator.rs
@@ -626,8 +626,8 @@ impl BlockingOperator {
     ///
     /// # fn test(op: BlockingOperator) -> Result<()> {
     /// let mut w = op.writer("path/to/file")?;
-    /// w.append(vec![0; 4096])?;
-    /// w.append(vec![1; 4096])?;
+    /// w.write(vec![0; 4096])?;
+    /// w.write(vec![1; 4096])?;
     /// w.close()?;
     /// # Ok(())
     /// # }

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -775,8 +775,8 @@ impl Operator {
     /// # #[tokio::main]
     /// # async fn test(op: Operator) -> Result<()> {
     /// let mut w = op.writer("path/to/file").await?;
-    /// w.append(vec![0; 4096]).await?;
-    /// w.append(vec![1; 4096]).await?;
+    /// w.write(vec![0; 4096]).await?;
+    /// w.write(vec![1; 4096]).await?;
     /// w.close().await?;
     /// # Ok(())
     /// # }
@@ -805,8 +805,8 @@ impl Operator {
     /// # async fn test(op: Operator) -> Result<()> {
     /// let args = OpWrite::new().with_content_type("application/octet-stream");
     /// let mut w = op.writer_with("path/to/file", args).await?;
-    /// w.append(vec![0; 4096]).await?;
-    /// w.append(vec![1; 4096]).await?;
+    /// w.write(vec![0; 4096]).await?;
+    /// w.write(vec![1; 4096]).await?;
     /// w.close().await?;
     /// # Ok(())
     /// # }

--- a/core/src/types/ops.rs
+++ b/core/src/types/ops.rs
@@ -320,12 +320,10 @@ impl OpStat {
 /// Args for `write` operation.
 #[derive(Debug, Clone, Default)]
 pub struct OpWrite {
-    append: bool,
-
+    content_length: Option<u64>,
     content_type: Option<String>,
     content_disposition: Option<String>,
     cache_control: Option<String>,
-    if_match: Option<String>,
 }
 
 impl OpWrite {
@@ -336,13 +334,20 @@ impl OpWrite {
         Self::default()
     }
 
-    pub(crate) fn with_append(mut self) -> Self {
-        self.append = true;
-        self
+    /// Get the content length from op.
+    ///
+    /// The content length is the total length of the data to be written.
+    pub fn content_length(&self) -> Option<u64> {
+        self.content_length
     }
 
-    pub(crate) fn append(&self) -> bool {
-        self.append
+    /// Set the content length of op.
+    ///
+    /// If the content length is not set, the content length will be
+    /// calculated automatically by buffering part of data.
+    pub fn with_content_length(mut self, content_length: u64) -> Self {
+        self.content_length = Some(content_length);
+        self
     }
 
     /// Get the content type from option
@@ -376,17 +381,6 @@ impl OpWrite {
     pub fn with_cache_control(mut self, cache_control: &str) -> Self {
         self.cache_control = Some(cache_control.to_string());
         self
-    }
-
-    /// Set the If-Match of the option
-    pub fn with_if_match(mut self, if_match: &str) -> Self {
-        self.if_match = Some(if_match.to_string());
-        self
-    }
-
-    /// Get If-Match from option
-    pub fn if_match(&self) -> Option<&str> {
-        self.if_match.as_deref()
     }
 }
 

--- a/core/src/types/writer.rs
+++ b/core/src/types/writer.rs
@@ -66,7 +66,7 @@ impl Writer {
             w.write(bs.into()).await
         } else {
             unreachable!(
-                "writer state invalid while abort, expect Idle, actual {}",
+                "writer state invalid while write, expect Idle, actual {}",
                 self.state
             );
         }
@@ -264,6 +264,11 @@ impl BlockingWriter {
         let (_, w) = acc.blocking_write(path, op)?;
 
         Ok(BlockingWriter { inner: w })
+    }
+
+    /// Write into inner writer.
+    pub fn write(&mut self, bs: impl Into<Bytes>) -> Result<()> {
+        self.inner.write(bs.into())
     }
 
     /// Close the writer and make sure all data have been stored.

--- a/core/src/types/writer.rs
+++ b/core/src/types/writer.rs
@@ -52,7 +52,7 @@ impl Writer {
     ///
     /// We don't want to expose those details to users so keep this function
     /// in crate only.
-    pub(crate) async fn create_dir(acc: FusedAccessor, path: &str, op: OpWrite) -> Result<Self> {
+    pub(crate) async fn create(acc: FusedAccessor, path: &str, op: OpWrite) -> Result<Self> {
         let (_, w) = acc.write(path, op).await?;
 
         Ok(Writer {
@@ -198,7 +198,7 @@ impl BlockingWriter {
     ///
     /// We don't want to expose those details to users so keep this function
     /// in crate only.
-    pub(crate) fn create_dir(acc: FusedAccessor, path: &str, op: OpWrite) -> Result<Self> {
+    pub(crate) fn create(acc: FusedAccessor, path: &str, op: OpWrite) -> Result<Self> {
         let (_, w) = acc.blocking_write(path, op)?;
 
         Ok(BlockingWriter { inner: w })

--- a/core/tests/behavior/utils.rs
+++ b/core/tests/behavior/utils.rs
@@ -25,6 +25,7 @@ use log::debug;
 use opendal::layers::LoggingLayer;
 use opendal::layers::RetryLayer;
 use opendal::*;
+use rand::distributions::uniform::SampleRange;
 use rand::prelude::*;
 use sha2::Digest;
 use sha2::Sha256;
@@ -82,6 +83,16 @@ pub fn gen_bytes() -> (Vec<u8>, usize) {
     let mut rng = thread_rng();
 
     let size = rng.gen_range(1..4 * 1024 * 1024);
+    let mut content = vec![0; size];
+    rng.fill_bytes(&mut content);
+
+    (content, size)
+}
+
+pub fn gen_bytes_with_range(range: impl SampleRange<usize>) -> (Vec<u8>, usize) {
+    let mut rng = thread_rng();
+
+    let size = rng.gen_range(range);
     let mut content = vec![0; size];
     rng.fill_bytes(&mut content);
 

--- a/core/tests/behavior/write.rs
+++ b/core/tests/behavior/write.rs
@@ -592,7 +592,7 @@ pub async fn test_abort_writer(op: Operator) -> Result<()> {
         }
     };
 
-    if let Err(e) = writer.append(content).await {
+    if let Err(e) = writer.write(content).await {
         assert_eq!(e.kind(), ErrorKind::Unsupported);
         return Ok(());
     }
@@ -700,8 +700,8 @@ pub async fn test_append(op: Operator) -> Result<()> {
         }
         Err(err) => return Err(err.into()),
     };
-    w.append(content_a.clone()).await?;
-    w.append(content_b.clone()).await?;
+    w.write(content_a.clone()).await?;
+    w.write(content_b.clone()).await?;
     w.close().await?;
 
     let meta = op.stat(&path).await.expect("stat must succeed");

--- a/core/tests/behavior/write.rs
+++ b/core/tests/behavior/write.rs
@@ -744,7 +744,7 @@ pub async fn test_writer_futures_copy(op: Operator) -> Result<()> {
     w.close().await?;
 
     let meta = op.stat(&path).await.expect("stat must succeed");
-    assert_eq!(meta.content_length(), (size * 2) as u64);
+    assert_eq!(meta.content_length(), size as u64);
 
     let bs = op.read(&path).await?;
     assert_eq!(bs.len(), size, "read size");


### PR DESCRIPTION
This PR introduces the following changes:

- Remove `append` from `OpWrite`: this arg is confusing.
- Add `content_length` in `OpWrite` so that services can handle sized and unsized input by themselves

After all these changes, users only need to use `write` instead of `append`.

---

This change will make our writer's behavior more easy to understand.