### PR TITLE
feat(bindings/nodejs): publish support `--provenance`

### DIFF
--- a/.github/workflows/bindings_nodejs.yml
+++ b/.github/workflows/bindings_nodejs.yml
@@ -206,6 +206,8 @@ jobs:
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [macos, linux, windows]
+    permissions:
+      id-token: write
 
     # Notes: this defaults only apply on run tasks.
     defaults:
@@ -244,7 +246,7 @@ jobs:
       - name: Publish
         run: |
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-          npm publish --access public
+          npm publish --access public --provenance
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Use provenance for release.

- https://github.blog/2023-04-19-introducing-npm-package-provenance/
- https://docs.npmjs.com/generating-provenance-statements