### PR TITLE
chore(bindings/c): commit formated h file

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -17,65 +17,66 @@
  * under the License.
  */
 
+
 #ifndef _OPENDAL_H
 #define _OPENDAL_H
 
-#include <stdbool.h>
-#include <stddef.h>
 #include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
 
 /*
  The error code for opendal APIs in C binding
  */
 typedef enum opendal_code {
-    /*
-     All is well
-     */
-    OPENDAL_OK,
-    /*
-     General error
-     */
-    OPENDAL_ERROR,
-    /*
-     returning it back. For example, s3 returns an internal service error.
-     */
-    OPENDAL_UNEXPECTED,
-    /*
-     Underlying service doesn't support this operation.
-     */
-    OPENDAL_UNSUPPORTED,
-    /*
-     The config for backend is invalid.
-     */
-    OPENDAL_CONFIG_INVALID,
-    /*
-     The given path is not found.
-     */
-    OPENDAL_NOT_FOUND,
-    /*
-     The given path doesn't have enough permission for this operation
-     */
-    OPENDAL_PERMISSION_DENIED,
-    /*
-     The given path is a directory.
-     */
-    OPENDAL_IS_A_DIRECTORY,
-    /*
-     The given path is not a directory.
-     */
-    OPENDAL_NOT_A_DIRECTORY,
-    /*
-     The given path already exists thus we failed to the specified operation on it.
-     */
-    OPENDAL_ALREADY_EXISTS,
-    /*
-     Requests that sent to this path is over the limit, please slow down.
-     */
-    OPENDAL_RATE_LIMITED,
-    /*
-     The given file paths are same.
-     */
-    OPENDAL_IS_SAME_FILE,
+  /*
+   All is well
+   */
+  OPENDAL_OK,
+  /*
+   General error
+   */
+  OPENDAL_ERROR,
+  /*
+   returning it back. For example, s3 returns an internal service error.
+   */
+  OPENDAL_UNEXPECTED,
+  /*
+   Underlying service doesn't support this operation.
+   */
+  OPENDAL_UNSUPPORTED,
+  /*
+   The config for backend is invalid.
+   */
+  OPENDAL_CONFIG_INVALID,
+  /*
+   The given path is not found.
+   */
+  OPENDAL_NOT_FOUND,
+  /*
+   The given path doesn't have enough permission for this operation
+   */
+  OPENDAL_PERMISSION_DENIED,
+  /*
+   The given path is a directory.
+   */
+  OPENDAL_IS_A_DIRECTORY,
+  /*
+   The given path is not a directory.
+   */
+  OPENDAL_NOT_A_DIRECTORY,
+  /*
+   The given path already exists thus we failed to the specified operation on it.
+   */
+  OPENDAL_ALREADY_EXISTS,
+  /*
+   Requests that sent to this path is over the limit, please slow down.
+   */
+  OPENDAL_RATE_LIMITED,
+  /*
+   The given file paths are same.
+   */
+  OPENDAL_IS_SAME_FILE,
 } opendal_code;
 
 /*
@@ -120,7 +121,7 @@ typedef struct BlockingOperator BlockingOperator;
  to check its validity by native boolean operator.
  e.g. you could check by (!ptr) on a [`opendal_operator_ptr`]
  */
-typedef const struct BlockingOperator* opendal_operator_ptr;
+typedef const struct BlockingOperator *opendal_operator_ptr;
 
 /*
  The [`opendal_bytes`] type is a C-compatible substitute for [`Vec`]
@@ -129,8 +130,8 @@ typedef const struct BlockingOperator* opendal_operator_ptr;
  to free the heap memory to avoid memory leak.
  */
 typedef struct opendal_bytes {
-    const uint8_t* data;
-    uintptr_t len;
+  const uint8_t *data;
+  uintptr_t len;
 } opendal_bytes;
 
 /*
@@ -140,8 +141,8 @@ typedef struct opendal_bytes {
  and the error code is NOT OPENDAL_OK.
  */
 typedef struct opendal_result_read {
-    struct opendal_bytes* data;
-    enum opendal_code code;
+  struct opendal_bytes *data;
+  enum opendal_code code;
 } opendal_result_read;
 
 /*
@@ -150,8 +151,8 @@ typedef struct opendal_result_read {
  corresponding error code.
  */
 typedef struct opendal_result_is_exist {
-    bool is_exist;
-    enum opendal_code code;
+  bool is_exist;
+  enum opendal_code code;
 } opendal_result_is_exist;
 
 #ifdef __cplusplus
@@ -169,7 +170,7 @@ extern "C" {
    the string.
  * The `scheme` points to NULL, this function simply returns you a null opendal_operator_ptr
  */
-opendal_operator_ptr opendal_operator_new(const char* scheme);
+opendal_operator_ptr opendal_operator_new(const char *scheme);
 
 /*
  Free the allocated operator pointed by [`opendal_operator_ptr`]
@@ -191,8 +192,8 @@ void opendal_operator_free(opendal_operator_ptr op_ptr);
  * If the `path` points to NULL, this function panics
  */
 enum opendal_code opendal_operator_blocking_write(opendal_operator_ptr op_ptr,
-    const char* path,
-    struct opendal_bytes bytes);
+                                                  const char *path,
+                                                  struct opendal_bytes bytes);
 
 /*
  Read the data out from path into a [`Bytes`] blockingly by operator, returns
@@ -210,7 +211,7 @@ enum opendal_code opendal_operator_blocking_write(opendal_operator_ptr op_ptr,
  * If the `path` points to NULL, this function panics
  */
 struct opendal_result_read opendal_operator_blocking_read(opendal_operator_ptr op_ptr,
-    const char* path);
+                                                          const char *path);
 
 /*
  Check whether the path exists.
@@ -231,12 +232,12 @@ struct opendal_result_read opendal_operator_blocking_read(opendal_operator_ptr o
  * If the `path` points to NULL, this function panics
  */
 struct opendal_result_is_exist opendal_operator_is_exist(opendal_operator_ptr op_ptr,
-    const char* path);
+                                                         const char *path);
 
 /*
  Frees the heap memory used by the [`opendal_bytes`]
  */
-void opendal_bytes_free(const struct opendal_bytes* self);
+void opendal_bytes_free(const struct opendal_bytes *self);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
close #2050 

Actually `cargo fmt` does not affect h files. 
It's just that the h file after the `clang-fmt` was not committed, so the change will happen as soon as it is compiled. 
This PR commits the h file after format.