### PR TITLE
ci: Use typos action to run it

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -41,7 +41,4 @@ jobs:
       FORCE_COLOR: 1
     steps:
       - uses: actions/checkout@v3
-      - run: curl -LsSf https://github.com/crate-ci/typos/releases/download/v1.13.24/typos-v1.13.24-x86_64-unknown-linux-musl.tar.gz | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
-
-      - name: do typos check with typos-cli
-        run: typos
+      - uses: crate-ci/typos@v1.14.8


### PR DESCRIPTION
1. use the official action to replace manually downloading and running it
2. upgrade to 1.14.8