### PR TITLE
feat: Add capability for operation's variant and args

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -74,7 +74,6 @@ layers-all = [
   "layers-prometheus",
   "layers-tracing",
   "layers-minitrace",
-  "layers-madsim",
 ]
 # Enable layers chaos support
 layers-chaos = ["dep:rand"]

--- a/core/src/docs/comparisons/vs_object_store.md
+++ b/core/src/docs/comparisons/vs_object_store.md
@@ -125,7 +125,7 @@ opendal supports:
 | obs     | Y               | N                                       |
 | s3      | Y               | Y                                       |
 
-opendal has an idea called [`AccessorCapability`][crate::raw::AccessorCapability], so it's services may have different capability sets. For example, opendal's `http` and `ipfs` are read only.
+opendal has an idea called [`Capability`][crate::Capability], so it's services may have different capability sets. For example, opendal's `http` and `ipfs` are read only.
 
 ### Features
 

--- a/core/src/docs/internals/accessor.rs
+++ b/core/src/docs/internals/accessor.rs
@@ -294,13 +294,14 @@
 //!     type BlockingPager = ();
 //!
 //!     fn metadata(&self) -> AccessorInfo {
-//!         use AccessorCapability::*;
-//!         use AccessorHint::*;
-//!
 //!         let mut am = AccessorInfo::default();
 //!         am.set_scheme(Scheme::Duck)
 //!             .set_root(&self.root)
-//!             .set_capability(Read);
+//!             .set_capability(
+//!                 Capability {
+//!                     read: true,
+//!                     ..Default::default()
+//!             });
 //!
 //!         am
 //!     }

--- a/core/src/docs/internals/accessor.rs
+++ b/core/src/docs/internals/accessor.rs
@@ -119,7 +119,7 @@
 //! - Most APIs accept `path` and `OpXxx`, and returns `RpXxx`.
 //! - Most APIs have `async` and `blocking` variants, they share the same semantics but may have different underlying implementations.
 //!
-//! [`Accessor`] can declare their capabilities via [`AccessorInfo`]'s `set_capabilities`:
+//! [`Accessor`] can declare their capabilities via [`AccessorInfo`]'s `set_capability`:
 //!
 //! ```ignore
 //! impl Accessor for MyBackend {
@@ -127,7 +127,7 @@
 //!        use AccessorCapability::*;
 //!
 //!        let mut am = AccessorInfo::default();
-//!        am.set_capabilities(Read | Write | List | Scan | Presign | Batch);
+//!        am.set_capability(Read | Write | List | Scan | Presign | Batch);
 //!
 //!         am
 //!     }
@@ -297,7 +297,7 @@
 //!         let mut am = AccessorInfo::default();
 //!         am.set_scheme(Scheme::Duck)
 //!             .set_root(&self.root)
-//!             .set_capabilities(Read);
+//!             .set_capability(Read);
 //!
 //!         am
 //!     }

--- a/core/src/docs/internals/accessor.rs
+++ b/core/src/docs/internals/accessor.rs
@@ -114,7 +114,7 @@
 //!
 //! Every API of [`Accessor`] follows the same style:
 //!
-//! - All APIs have a unique [`Operation`] and [`AccessorCapability`]
+//! - All APIs have a unique [`Operation`] and [`Capability`]
 //! - All APIs are orthogonal and do not overlap with each other
 //! - Most APIs accept `path` and `OpXxx`, and returns `RpXxx`.
 //! - Most APIs have `async` and `blocking` variants, they share the same semantics but may have different underlying implementations.
@@ -321,7 +321,7 @@
 //!
 //! [`Accessor`]: crate::raw::Accessor
 //! [`Operation`]: crate::raw::Operation
-//! [`AccessorCapability`]: crate::raw::AccessorCapability
+//! [`Capability`]: crate::Capability
 //! [`AccessorInfo`]: crate::raw::AccessorInfo
 //! [`Scheme`]: crate::Scheme
 //! [`Builder`]: crate::Builder

--- a/core/src/docs/internals/accessor.rs
+++ b/core/src/docs/internals/accessor.rs
@@ -124,10 +124,13 @@
 //! ```ignore
 //! impl Accessor for MyBackend {
 //!     fn metadata(&self) -> AccessorInfo {
-//!        use AccessorCapability::*;
-//!
-//!        let mut am = AccessorInfo::default();
-//!        am.set_capability(Read | Write | List | Scan | Presign | Batch);
+//!         let mut am = AccessorInfo::default();
+//!         am.set_capability(
+//!             Capability {
+//!                 read: true,
+//!                 write: true,
+//!                 ..Default::default()
+//!         });
 //!
 //!         am
 //!     }

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -152,10 +152,9 @@ impl<A: Accessor> CompleteReaderAccessor<A> {
         path: &str,
         args: OpRead,
     ) -> Result<(RpRead, CompleteReader<A, A::Reader>)> {
-        let (seekable, streamable) = (
-            self.meta.hints().contains(AccessorHint::ReadSeekable),
-            self.meta.hints().contains(AccessorHint::ReadStreamable),
-        );
+        let capability = self.meta.capability();
+        let seekable = capability.read_can_seek;
+        let streamable = capability.read_can_next;
 
         let range = args.range();
         let (rp, r) = self.inner.read(path, args).await?;
@@ -202,10 +201,9 @@ impl<A: Accessor> CompleteReaderAccessor<A> {
         path: &str,
         args: OpRead,
     ) -> Result<(RpRead, CompleteReader<A, A::BlockingReader>)> {
-        let (seekable, streamable) = (
-            self.meta.hints().contains(AccessorHint::ReadSeekable),
-            self.meta.hints().contains(AccessorHint::ReadStreamable),
-        );
+        let capability = self.meta.capability();
+        let seekable = capability.read_can_seek;
+        let streamable = capability.read_can_next;
 
         let (rp, r) = self.inner.blocking_read(path, args)?;
 
@@ -227,10 +225,8 @@ impl<A: Accessor> CompleteReaderAccessor<A> {
         path: &str,
         args: OpList,
     ) -> Result<(RpList, CompletePager<A, A::Pager>)> {
-        let (can_list, can_scan) = (
-            self.meta.capabilities().contains(AccessorCapability::List),
-            self.meta.capabilities().contains(AccessorCapability::Scan),
-        );
+        let capability = self.meta.capability();
+        let (can_list, can_scan) = (capability.list, capability.scan);
 
         if can_list {
             let (rp, p) = self.inner.list(path, args).await?;
@@ -253,10 +249,8 @@ impl<A: Accessor> CompleteReaderAccessor<A> {
         path: &str,
         args: OpList,
     ) -> Result<(RpList, CompletePager<A, A::BlockingPager>)> {
-        let (can_list, can_scan) = (
-            self.meta.capabilities().contains(AccessorCapability::List),
-            self.meta.capabilities().contains(AccessorCapability::Scan),
-        );
+        let capability = self.meta.capability();
+        let (can_list, can_scan) = (capability.list, capability.scan);
 
         if can_list {
             let (rp, p) = self.inner.blocking_list(path, args)?;
@@ -279,10 +273,8 @@ impl<A: Accessor> CompleteReaderAccessor<A> {
         path: &str,
         args: OpScan,
     ) -> Result<(RpScan, CompletePager<A, A::Pager>)> {
-        let (can_list, can_scan) = (
-            self.meta.capabilities().contains(AccessorCapability::List),
-            self.meta.capabilities().contains(AccessorCapability::Scan),
-        );
+        let capability = self.meta.capability();
+        let (can_list, can_scan) = (capability.list, capability.scan);
 
         if can_scan {
             let (rp, p) = self.inner.scan(path, args).await?;
@@ -304,10 +296,8 @@ impl<A: Accessor> CompleteReaderAccessor<A> {
         path: &str,
         args: OpScan,
     ) -> Result<(RpScan, CompletePager<A, A::BlockingPager>)> {
-        let (can_list, can_scan) = (
-            self.meta.capabilities().contains(AccessorCapability::List),
-            self.meta.capabilities().contains(AccessorCapability::Scan),
-        );
+        let capability = self.meta.capability();
+        let (can_list, can_scan) = (capability.list, capability.scan);
 
         if can_scan {
             let (rp, p) = self.inner.blocking_scan(path, args)?;

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -455,7 +455,7 @@ impl<T: oio::Write> oio::Write for ErrorContextWrapper<T> {
 
     async fn abort(&mut self) -> Result<()> {
         self.inner.abort().await.map_err(|err| {
-            err.with_operation(WriteOperation::Append)
+            err.with_operation(WriteOperation::Abort)
                 .with_context("service", self.scheme)
                 .with_context("path", &self.path)
         })

--- a/core/src/layers/immutable_index.rs
+++ b/core/src/layers/immutable_index.rs
@@ -149,10 +149,10 @@ impl<A: Accessor> LayeredAccessor for ImmutableIndexAccessor<A> {
     /// Add list capabilities for underlying storage services.
     fn metadata(&self) -> AccessorInfo {
         let mut meta = self.inner.info();
-        meta.set_capabilities(
-            meta.capabilities() | AccessorCapability::List | AccessorCapability::Scan,
-        );
-        meta.set_hints(meta.hints());
+
+        let cap = meta.capability_mut();
+        cap.list = true;
+        cap.scan = true;
 
         meta
     }

--- a/core/src/layers/madsim.rs
+++ b/core/src/layers/madsim.rs
@@ -134,7 +134,7 @@ impl LayeredAccessor for MadsimAccessor {
     fn metadata(&self) -> AccessorInfo {
         let mut info = AccessorInfo::default();
         info.set_name("madsim");
-        info.set_capabilities(AccessorCapability::Read | AccessorCapability::Write);
+        info.set_capability(AccessorCapability::Read | AccessorCapability::Write);
         info
     }
 

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -816,8 +816,11 @@ mod tests {
 
         fn info(&self) -> AccessorInfo {
             let mut am = AccessorInfo::default();
-            am.set_capabilities(AccessorCapability::List | AccessorCapability::Batch);
-            am.set_hints(AccessorHint::ReadStreamable);
+            am.set_capability(Capability {
+                list: true,
+                batch: true,
+                ..Default::default()
+            });
 
             am
         }

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -663,7 +663,7 @@ impl<R: oio::Write> oio::Write for RetryWrapper<R> {
                     Some(dur) => {
                         warn!(target: "opendal::service",
                               "operation={} path={} -> pager retry after {}s: error={:?}",
-                              WriteOperation::Append, self.path, dur.as_secs_f64(), e);
+                              WriteOperation::Abort, self.path, dur.as_secs_f64(), e);
                         tokio::time::sleep(dur).await;
                         continue;
                     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -81,7 +81,6 @@ mod tests {
     use std::mem::size_of;
 
     use super::*;
-    use crate::raw::*;
 
     /// This is not a real test case.
     ///
@@ -89,7 +88,6 @@ mod tests {
     /// unexpected struct/enum size change.
     #[test]
     fn assert_size() {
-        assert_eq!(104, size_of::<AccessorInfo>());
         assert_eq!(24, size_of::<Operator>());
         assert_eq!(216, size_of::<Entry>());
         assert_eq!(192, size_of::<Metadata>());

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -78,7 +78,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
 
     /// Invoke the `create` operation on the specified path
     ///
-    /// Require [`AccessorCapability::Write`]
+    /// Require [`Capability::create_dir`]
     ///
     /// # Behavior
     ///
@@ -96,7 +96,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     /// Invoke the `read` operation on the specified path, returns a
     /// [`Reader`][crate::Reader] if operate successful.
     ///
-    /// Require [`AccessorCapability::Read`]
+    /// Require [`Capability::read`]
     ///
     /// # Behavior
     ///
@@ -114,7 +114,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     /// Invoke the `write` operation on the specified path, returns a
     /// written size if operate successful.
     ///
-    /// Require [`AccessorCapability::Write`]
+    /// Require [`Capability::write`]
     ///
     /// # Behavior
     ///
@@ -130,7 +130,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
 
     /// Invoke the `copy` operation on the specified `from` path and `to` path.
     ///
-    /// Require [AccessorCapability::Copy]
+    /// Require [Capability::copy]
     ///
     /// # Behaviour
     ///
@@ -148,7 +148,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
 
     /// Invoke the `rename` operation on the specified `from` path and `to` path.
     ///
-    /// Require [AccessorCapability::Rename]
+    /// Require [Capability::rename]
     async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
         let (_, _, _) = (from, to, args);
 
@@ -160,7 +160,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
 
     /// Invoke the `stat` operation on the specified path.
     ///
-    /// Require [`AccessorCapability::Read`]
+    /// Require [`Capability::stat`]
     ///
     /// # Behavior
     ///
@@ -178,7 +178,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
 
     /// Invoke the `delete` operation on the specified path.
     ///
-    /// Require [`AccessorCapability::Write`]
+    /// Require [`Capability::delete`]
     ///
     /// # Behavior
     ///
@@ -195,7 +195,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
 
     /// Invoke the `list` operation on the specified path.
     ///
-    /// Require [`AccessorCapability::List`]
+    /// Require [`Capability::list`]
     ///
     /// # Behavior
     ///
@@ -212,7 +212,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
 
     /// Invoke the `scan` operation on the specified path.
     ///
-    /// Require [`AccessorCapability::Scan`]
+    /// Require [`Capability::scan`]
     async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
         let (_, _) = (path, args);
 
@@ -224,7 +224,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
 
     /// Invoke the `presign` operation on the specified path.
     ///
-    /// Require [`AccessorCapability::Presign`]
+    /// Require [`Capability::presign`]
     ///
     /// # Behavior
     ///
@@ -239,6 +239,8 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     }
 
     /// Invoke the `batch` operations.
+    ///
+    /// Require [`Capability::batch`]
     async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
         let _ = args;
 
@@ -250,9 +252,9 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
 
     /// Invoke the `blocking_create` operation on the specified path.
     ///
-    /// This operation is the blocking version of [`Accessor::create`]
+    /// This operation is the blocking version of [`Accessor::create_dir`]
     ///
-    /// Require [`AccessorCapability::Write`] and [`AccessorCapability::Blocking`]
+    /// Require [`Capability::create_dir`] and [`Capability::blocking`]
     fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
         let (_, _) = (path, args);
 
@@ -266,7 +268,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     ///
     /// This operation is the blocking version of [`Accessor::read`]
     ///
-    /// Require [`AccessorCapability::Read`] and [`AccessorCapability::Blocking`]
+    /// Require [`Capability::read`] and [`Capability::blocking`]
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
         let (_, _) = (path, args);
 
@@ -280,7 +282,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     ///
     /// This operation is the blocking version of [`Accessor::write`]
     ///
-    /// Require [`AccessorCapability::Write`] and [`AccessorCapability::Blocking`]
+    /// Require [`Capability::write`] and [`Capability::blocking`]
     fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
         let (_, _) = (path, args);
 
@@ -294,7 +296,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     ///
     /// This operation is the blocking version of [`Accessor::copy`]
     ///
-    /// Require [`AccessorCapability::Copy`] and [`AccessorCapability::Blocking`]
+    /// Require [`Capability::copy`] and [`Capability::blocking`]
     fn blocking_copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
         let (_, _, _) = (from, to, args);
 
@@ -308,7 +310,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     ///
     /// This operation is the blocking version of [`Accessor::rename`]
     ///
-    /// Require [`AccessorCapability::Rename`] and [`AccessorCapability::Blocking`]
+    /// Require [`Capability::rename`] and [`Capability::blocking`]
     fn blocking_rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
         let (_, _, _) = (from, to, args);
 
@@ -322,7 +324,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     ///
     /// This operation is the blocking version of [`Accessor::stat`]
     ///
-    /// Require [`AccessorCapability::Read`] and [`AccessorCapability::Blocking`]
+    /// Require [`Capability::stat`] and [`Capability::blocking`]
     fn blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
         let (_, _) = (path, args);
 
@@ -336,7 +338,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     ///
     /// This operation is the blocking version of [`Accessor::delete`]
     ///
-    /// Require [`AccessorCapability::Write`] and [`AccessorCapability::Blocking`]
+    /// Require [`Capability::write`] and [`Capability::blocking`]
     fn blocking_delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
         let (_, _) = (path, args);
 
@@ -350,7 +352,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     ///
     /// This operation is the blocking version of [`Accessor::list`]
     ///
-    /// Require [`AccessorCapability::List`] and [`AccessorCapability::Blocking`]
+    /// Require [`Capability::list`] and [`Capability::blocking`]
     ///
     /// # Behavior
     ///
@@ -366,7 +368,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
 
     /// Invoke the `blocking_scan` operation on the specified path.
     ///
-    /// Require [`AccessorCapability::Scan`] and [`AccessorCapability::Blocking`]
+    /// Require [`Capability::scan`] and [`Capability::blocking`]
     fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
         let (_, _) = (path, args);
 

--- a/core/src/raw/adapters/kv/api.rs
+++ b/core/src/raw/adapters/kv/api.rs
@@ -18,9 +18,9 @@
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use flagset::FlagSet;
 
 use crate::raw::*;
+use crate::Capability;
 use crate::Error;
 use crate::ErrorKind;
 use crate::Result;
@@ -135,20 +135,16 @@ pub trait Adapter: Send + Sync + Debug + Unpin + 'static {
 pub struct Metadata {
     scheme: Scheme,
     name: String,
-    capabilities: FlagSet<AccessorCapability>,
+    capabilities: Capability,
 }
 
 impl Metadata {
     /// Create a new KeyValueAccessorInfo.
-    pub fn new(
-        scheme: Scheme,
-        name: &str,
-        capabilities: impl Into<FlagSet<AccessorCapability>>,
-    ) -> Self {
+    pub fn new(scheme: Scheme, name: &str, capabilities: Capability) -> Self {
         Self {
             scheme,
             name: name.to_string(),
-            capabilities: capabilities.into(),
+            capabilities,
         }
     }
 
@@ -163,7 +159,7 @@ impl Metadata {
     }
 
     /// Get the capabilities.
-    pub fn capabilities(&self) -> FlagSet<AccessorCapability> {
+    pub fn capabilities(&self) -> Capability {
         self.capabilities
     }
 }
@@ -173,7 +169,7 @@ impl From<Metadata> for AccessorInfo {
         let mut am = AccessorInfo::default();
         am.set_name(m.name());
         am.set_scheme(m.scheme());
-        am.set_capabilities(m.capabilities());
+        am.set_capability(m.capabilities());
 
         am
     }

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -62,8 +62,19 @@ impl<S: Adapter> Accessor for Backend<S> {
 
     fn info(&self) -> AccessorInfo {
         let mut am: AccessorInfo = self.kv.metadata().into();
-        am.set_root(&self.root)
-            .set_hints(AccessorHint::ReadStreamable | AccessorHint::ReadSeekable);
+        am.set_root(&self.root);
+
+        let cap = am.capability_mut();
+        if cap.read {
+            cap.read_can_seek = true;
+            cap.read_can_next = true;
+            cap.stat = true;
+        }
+
+        if cap.write {
+            cap.create_dir = true;
+            cap.delete = true;
+        }
 
         am
     }

--- a/core/src/raw/mod.rs
+++ b/core/src/raw/mod.rs
@@ -28,8 +28,6 @@
 
 mod accessor;
 pub use accessor::Accessor;
-pub use accessor::AccessorCapability;
-pub use accessor::AccessorHint;
 pub use accessor::AccessorInfo;
 pub use accessor::FusedAccessor;
 

--- a/core/src/raw/oio/into_reader/by_range.rs
+++ b/core/src/raw/oio/into_reader/by_range.rs
@@ -323,7 +323,10 @@ mod tests {
 
         fn info(&self) -> AccessorInfo {
             let mut am = AccessorInfo::default();
-            am.set_capabilities(AccessorCapability::Read);
+            am.set_capability(Capability {
+                read: true,
+                ..Default::default()
+            });
 
             am
         }

--- a/core/src/raw/oio/to_flat_pager.rs
+++ b/core/src/raw/oio/to_flat_pager.rs
@@ -30,11 +30,11 @@ pub fn to_flat_pager<A: Accessor, P>(acc: A, path: &str, size: usize) -> ToFlatP
     {
         let meta = acc.info();
         debug_assert!(
-            !meta.capabilities().contains(AccessorCapability::Scan),
+            !meta.capability().scan,
             "service already supports scan, call to_flat_pager must be a mistake"
         );
         debug_assert!(
-            meta.capabilities().contains(AccessorCapability::List),
+            meta.capability().list,
             "service doesn't support list hierarchy, it must be a bug"
         );
     }
@@ -258,7 +258,7 @@ mod tests {
 
         fn info(&self) -> AccessorInfo {
             let mut am = AccessorInfo::default();
-            am.set_capabilities(AccessorCapability::List);
+            am.capability_mut().list = true;
 
             am
         }

--- a/core/src/raw/oio/write.rs
+++ b/core/src/raw/oio/write.rs
@@ -29,16 +29,12 @@ use crate::*;
 pub enum WriteOperation {
     /// Operation for [`Write::write`]
     Write,
-    /// Operation for [`Write::append`]
-    Append,
     /// Operation for [`Write::abort`]
     Abort,
     /// Operation for [`Write::close`]
     Close,
     /// Operation for [`BlockingWrite::write`]
     BlockingWrite,
-    /// Operation for [`BlockingWrite::append`]
-    BlockingAppend,
     /// Operation for [`BlockingWrite::close`]
     BlockingClose,
 }
@@ -62,11 +58,9 @@ impl From<WriteOperation> for &'static str {
 
         match v {
             Write => "Writer::write",
-            Append => "Writer::append",
             Abort => "Writer::abort",
             Close => "Writer::close",
             BlockingWrite => "BlockingWriter::write",
-            BlockingAppend => "BlockingWriter::append",
             BlockingClose => "BlockingWriter::close",
         }
     }

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -447,16 +447,30 @@ impl Accessor for AzblobBackend {
     type BlockingPager = ();
 
     fn info(&self) -> AccessorInfo {
-        use AccessorCapability::*;
-        use AccessorHint::*;
-
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Azblob)
             .set_root(&self.core.root)
             .set_name(&self.core.container)
-            .set_max_batch_operations(AZBLOB_BATCH_LIMIT)
-            .set_capabilities(Read | Write | List | Scan | Batch | Copy)
-            .set_hints(ReadStreamable);
+            .set_capability(Capability {
+                read: true,
+                read_can_next: true,
+                read_with_if_match: true,
+                read_with_if_none_match: true,
+                stat: true,
+                stat_with_if_match: true,
+                stat_with_if_none_match: true,
+                write: true,
+                write_with_content_type: true,
+                write_with_cache_control: true,
+                delete: true,
+                create_dir: true,
+                list: true,
+                scan: true,
+                copy: true,
+                batch: true,
+                batch_max_operations: Some(AZBLOB_BATCH_LIMIT),
+                ..Default::default()
+            });
 
         am
     }

--- a/core/src/services/azdfs/backend.rs
+++ b/core/src/services/azdfs/backend.rs
@@ -308,13 +308,14 @@ impl Accessor for AzdfsBackend {
         am.set_scheme(Scheme::Azdfs)
             .set_root(&self.core.root)
             .set_name(&self.core.filesystem)
-            .set_capabilities(
-                AccessorCapability::Read
-                    | AccessorCapability::Write
-                    | AccessorCapability::Rename
-                    | AccessorCapability::List,
-            )
-            .set_hints(AccessorHint::ReadStreamable);
+            .set_capability(Capability {
+                read: true,
+                read_can_next: true,
+                write: true,
+                rename: true,
+                list: true,
+                ..Default::default()
+            });
 
         am
     }

--- a/core/src/services/dashmap/backend.rs
+++ b/core/src/services/dashmap/backend.rs
@@ -22,7 +22,6 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 
 use crate::raw::adapters::kv;
-use crate::raw::*;
 use crate::*;
 
 /// [dashmap](https://github.com/xacrimon/dashmap) backend support.
@@ -84,7 +83,12 @@ impl kv::Adapter for Adapter {
         kv::Metadata::new(
             Scheme::Dashmap,
             &format!("{:?}", &self.inner as *const _),
-            AccessorCapability::Read | AccessorCapability::Write | AccessorCapability::Scan,
+            Capability {
+                read: true,
+                write: true,
+                scan: true,
+                ..Default::default()
+            },
         )
     }
 
@@ -136,6 +140,7 @@ impl kv::Adapter for Adapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::raw::*;
 
     #[test]
     fn test_accessor_metadata_name() {

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -300,15 +300,17 @@ impl Accessor for FsBackend {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Fs)
             .set_root(&self.root.to_string_lossy())
-            .set_capabilities(
-                AccessorCapability::Read
-                    | AccessorCapability::Write
-                    | AccessorCapability::Copy
-                    | AccessorCapability::Rename
-                    | AccessorCapability::List
-                    | AccessorCapability::Blocking,
-            )
-            .set_hints(AccessorHint::ReadSeekable);
+            .set_capability(Capability {
+                read: true,
+                read_can_seek: true,
+                write: true,
+                create_dir: true,
+                list: true,
+                copy: true,
+                rename: true,
+                blocking: true,
+                ..Default::default()
+            });
 
         am
     }

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -316,9 +316,12 @@ impl Accessor for FtpBackend {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Ftp)
             .set_root(&self.root)
-            .set_capabilities(
-                AccessorCapability::Read | AccessorCapability::Write | AccessorCapability::List,
-            );
+            .set_capability(Capability {
+                read: true,
+                write: true,
+                list: true,
+                ..Default::default()
+            });
 
         am
     }

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -369,15 +369,19 @@ impl Accessor for GcsBackend {
     type BlockingPager = ();
 
     fn info(&self) -> AccessorInfo {
-        use AccessorCapability::*;
-        use AccessorHint::*;
-
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Gcs)
             .set_root(&self.core.root)
             .set_name(&self.core.bucket)
-            .set_capabilities(Read | Write | List | Scan | Copy)
-            .set_hints(ReadStreamable);
+            .set_capability(Capability {
+                read: true,
+                read_can_next: true,
+                write: true,
+                list: true,
+                scan: true,
+                copy: true,
+                ..Default::default()
+            });
         am
     }
 

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -15,13 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::fmt::Write;
+
 use backon::ExponentialBuilder;
 use backon::Retryable;
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
+use bytes::BytesMut;
+use http::header::CONTENT_LENGTH;
+use http::header::CONTENT_RANGE;
 use http::header::CONTENT_TYPE;
 use http::header::IF_MATCH;
 use http::header::IF_NONE_MATCH;
-use http::header::{CONTENT_LENGTH, CONTENT_RANGE};
 use http::Request;
 use http::Response;
 use once_cell::sync::Lazy;
@@ -29,9 +35,6 @@ use reqsign::GoogleCredentialLoader;
 use reqsign::GoogleSigner;
 use reqsign::GoogleToken;
 use reqsign::GoogleTokenLoader;
-use std::fmt::Debug;
-use std::fmt::Formatter;
-use std::fmt::Write;
 
 use super::uri::percent_encode_path;
 use crate::raw::*;

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -300,8 +300,13 @@ impl Accessor for GhacBackend {
         am.set_scheme(Scheme::Ghac)
             .set_root(&self.root)
             .set_name(&self.version)
-            .set_capabilities(AccessorCapability::Read | AccessorCapability::Write)
-            .set_hints(AccessorHint::ReadStreamable);
+            .set_capability(Capability {
+                read: true,
+                read_can_next: true,
+                write: true,
+
+                ..Default::default()
+            });
         am
     }
 

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -232,13 +232,14 @@ impl Accessor for HdfsBackend {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Hdfs)
             .set_root(&self.root)
-            .set_capabilities(
-                AccessorCapability::Read
-                    | AccessorCapability::Write
-                    | AccessorCapability::List
-                    | AccessorCapability::Blocking,
-            )
-            .set_hints(AccessorHint::ReadSeekable);
+            .set_capability(Capability {
+                read: true,
+                read_can_seek: true,
+                write: true,
+                list: true,
+                blocking: true,
+                ..Default::default()
+            });
 
         am
     }

--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -258,8 +258,12 @@ impl Accessor for HttpBackend {
         let mut ma = AccessorInfo::default();
         ma.set_scheme(Scheme::Http)
             .set_root(&self.root)
-            .set_capabilities(AccessorCapability::Read)
-            .set_hints(AccessorHint::ReadStreamable);
+            .set_capability(Capability {
+                read: true,
+                read_can_next: true,
+
+                ..Default::default()
+            });
 
         ma
     }

--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -219,8 +219,13 @@ impl Accessor for IpfsBackend {
         let mut ma = AccessorInfo::default();
         ma.set_scheme(Scheme::Ipfs)
             .set_root(&self.root)
-            .set_capabilities(AccessorCapability::Read | AccessorCapability::List)
-            .set_hints(AccessorHint::ReadStreamable);
+            .set_capability(Capability {
+                read: true,
+                read_can_next: true,
+                list: true,
+
+                ..Default::default()
+            });
 
         ma
     }

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -73,10 +73,13 @@ impl Accessor for IpmfsBackend {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Ipmfs)
             .set_root(&self.root)
-            .set_capabilities(
-                AccessorCapability::Read | AccessorCapability::Write | AccessorCapability::List,
-            )
-            .set_hints(AccessorHint::ReadStreamable);
+            .set_capability(Capability {
+                read: true,
+                read_can_next: true,
+                write: true,
+
+                ..Default::default()
+            });
 
         am
     }

--- a/core/src/services/memcached/backend.rs
+++ b/core/src/services/memcached/backend.rs
@@ -231,7 +231,13 @@ impl kv::Adapter for Adapter {
         kv::Metadata::new(
             Scheme::Memcached,
             "memcached",
-            AccessorCapability::Read | AccessorCapability::Write,
+            Capability {
+                read: true,
+                write: true,
+                create_dir: true,
+
+                ..Default::default()
+            },
         )
     }
 

--- a/core/src/services/memory/backend.rs
+++ b/core/src/services/memory/backend.rs
@@ -23,7 +23,6 @@ use async_trait::async_trait;
 use parking_lot::Mutex;
 
 use crate::raw::adapters::kv;
-use crate::raw::*;
 use crate::*;
 
 /// In memory service support. (BTreeMap Based)
@@ -86,7 +85,14 @@ impl kv::Adapter for Adapter {
         kv::Metadata::new(
             Scheme::Memory,
             &format!("{:?}", &self.inner as *const _),
-            AccessorCapability::Read | AccessorCapability::Write | AccessorCapability::Scan,
+            Capability {
+                read: true,
+                write: true,
+                create_dir: true,
+                scan: true,
+
+                ..Default::default()
+            },
         )
     }
 
@@ -144,6 +150,7 @@ impl kv::Adapter for Adapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::raw::*;
 
     #[test]
     fn test_accessor_metadata_name() {

--- a/core/src/services/moka/backend.rs
+++ b/core/src/services/moka/backend.rs
@@ -25,7 +25,6 @@ use moka::sync::CacheBuilder;
 use moka::sync::SegmentedCache;
 
 use crate::raw::adapters::kv;
-use crate::raw::*;
 use crate::*;
 
 /// [moka](https://github.com/moka-rs/moka) backend support.
@@ -200,7 +199,12 @@ impl kv::Adapter for Adapter {
         kv::Metadata::new(
             Scheme::Moka,
             self.inner.name().unwrap_or("moka"),
-            AccessorCapability::Read | AccessorCapability::Write,
+            Capability {
+                read: true,
+                write: true,
+
+                ..Default::default()
+            },
         )
     }
 

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -301,15 +301,19 @@ impl Accessor for ObsBackend {
     type BlockingPager = ();
 
     fn info(&self) -> AccessorInfo {
-        use AccessorCapability::*;
-        use AccessorHint::*;
-
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Obs)
             .set_root(&self.core.root)
             .set_name(&self.core.bucket)
-            .set_capabilities(Read | Write | Copy | List | Scan)
-            .set_hints(ReadStreamable);
+            .set_capability(Capability {
+                read: true,
+                read_can_next: true,
+                write: true,
+                list: true,
+                scan: true,
+                copy: true,
+                ..Default::default()
+            });
 
         am
     }

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -359,16 +359,22 @@ impl Accessor for OssBackend {
     type BlockingPager = ();
 
     fn info(&self) -> AccessorInfo {
-        use AccessorCapability::*;
-        use AccessorHint::*;
-
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Oss)
             .set_root(&self.core.root)
             .set_name(&self.core.bucket)
-            .set_max_batch_operations(1000)
-            .set_capabilities(Read | Write | Copy | List | Scan | Presign | Batch)
-            .set_hints(ReadStreamable);
+            .set_capability(Capability {
+                read: true,
+                read_can_next: true,
+                write: true,
+                list: true,
+                scan: true,
+                copy: true,
+                presign: true,
+                batch: true,
+                batch_max_operations: Some(1000),
+                ..Default::default()
+            });
 
         am
     }

--- a/core/src/services/oss/writer.rs
+++ b/core/src/services/oss/writer.rs
@@ -18,7 +18,8 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::{Buf, Bytes};
+use bytes::Buf;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::*;

--- a/core/src/services/redis/backend.rs
+++ b/core/src/services/redis/backend.rs
@@ -316,7 +316,13 @@ impl kv::Adapter for Adapter {
         kv::Metadata::new(
             Scheme::Redis,
             &self.client.get_connection_info().addr.to_string(),
-            AccessorCapability::Read | AccessorCapability::Write,
+            Capability {
+                read: true,
+                write: true,
+                create_dir: true,
+
+                ..Default::default()
+            },
         )
     }
 

--- a/core/src/services/rocksdb/backend.rs
+++ b/core/src/services/rocksdb/backend.rs
@@ -24,7 +24,6 @@ use async_trait::async_trait;
 use rocksdb::DB;
 
 use crate::raw::adapters::kv;
-use crate::raw::*;
 use crate::Result;
 use crate::*;
 
@@ -160,7 +159,11 @@ impl kv::Adapter for Adapter {
         kv::Metadata::new(
             Scheme::Rocksdb,
             &self.db.path().to_string_lossy(),
-            AccessorCapability::Read | AccessorCapability::Write,
+            Capability {
+                read: true,
+                write: true,
+                ..Default::default()
+            },
         )
     }
 

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -907,16 +907,23 @@ impl Accessor for S3Backend {
     type BlockingPager = ();
 
     fn info(&self) -> AccessorInfo {
-        use AccessorCapability::*;
-        use AccessorHint::*;
-
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::S3)
             .set_root(&self.core.root)
             .set_name(&self.core.bucket)
-            .set_max_batch_operations(1000)
-            .set_capabilities(Read | Write | List | Scan | Presign | Batch | Copy)
-            .set_hints(ReadStreamable);
+            .set_capability(Capability {
+                read: true,
+                read_can_next: true,
+                write: true,
+                list: true,
+                scan: true,
+                copy: true,
+                presign: true,
+                batch: true,
+                batch_max_operations: Some(1000),
+
+                ..Default::default()
+            });
 
         am
     }

--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -18,7 +18,8 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::{Buf, Bytes};
+use bytes::Buf;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::*;

--- a/core/src/services/sled/backend.rs
+++ b/core/src/services/sled/backend.rs
@@ -22,7 +22,6 @@ use std::fmt::Formatter;
 use async_trait::async_trait;
 
 use crate::raw::adapters::kv;
-use crate::raw::*;
 use crate::Builder;
 use crate::Error;
 use crate::ErrorKind;
@@ -141,8 +140,17 @@ impl Debug for Adapter {
 #[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
-        use AccessorCapability::*;
-        kv::Metadata::new(Scheme::Sled, &self.datadir, Read | Write | Scan | Blocking)
+        kv::Metadata::new(
+            Scheme::Sled,
+            &self.datadir,
+            Capability {
+                read: true,
+                write: true,
+                scan: true,
+                blocking: true,
+                ..Default::default()
+            },
+        )
     }
 
     async fn get(&self, path: &str) -> Result<Option<Vec<u8>>> {

--- a/core/src/services/wasabi/backend.rs
+++ b/core/src/services/wasabi/backend.rs
@@ -897,16 +897,22 @@ impl Accessor for WasabiBackend {
     type BlockingPager = ();
 
     fn info(&self) -> AccessorInfo {
-        use AccessorCapability::*;
-        use AccessorHint::*;
-
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Wasabi)
             .set_root(&self.core.root)
             .set_name(&self.core.bucket)
-            .set_max_batch_operations(1000)
-            .set_capabilities(Read | Write | List | Scan | Presign | Batch | Copy | Rename)
-            .set_hints(ReadStreamable);
+            .set_capability(Capability {
+                read: true,
+                read_can_next: true,
+                write: true,
+                list: true,
+                scan: true,
+                copy: true,
+                presign: true,
+                batch: true,
+                rename: true,
+                ..Default::default()
+            });
 
         am
     }

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -266,14 +266,16 @@ impl Accessor for WebdavBackend {
         let mut ma = AccessorInfo::default();
         ma.set_scheme(Scheme::Webdav)
             .set_root(&self.root)
-            .set_capabilities(
-                AccessorCapability::Read
-                    | AccessorCapability::Write
-                    | AccessorCapability::Copy
-                    | AccessorCapability::Rename
-                    | AccessorCapability::List,
-            )
-            .set_hints(AccessorHint::ReadStreamable);
+            .set_capability(Capability {
+                read: true,
+                read_can_next: true,
+                write: true,
+                list: true,
+                scan: true,
+                copy: true,
+                rename: true,
+                ..Default::default()
+            });
 
         ma
     }

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -271,7 +271,6 @@ impl Accessor for WebdavBackend {
                 read_can_next: true,
                 write: true,
                 list: true,
-                scan: true,
                 copy: true,
                 rename: true,
                 ..Default::default()

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -465,10 +465,13 @@ impl Accessor for WebhdfsBackend {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Webhdfs)
             .set_root(&self.root)
-            .set_capabilities(
-                AccessorCapability::Read | AccessorCapability::Write | AccessorCapability::List,
-            )
-            .set_hints(AccessorHint::ReadStreamable);
+            .set_capability(Capability {
+                read: true,
+                read_can_next: true,
+                write: true,
+                list: true,
+                ..Default::default()
+            });
         am
     }
 

--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// Capability is used to describe what operations are supported
+/// by current Operator.
+///
+/// Via capability, we can know:
+///
+/// - Whether current Operator supports read or not.
+/// - Whether current Operator supports read with if match or not.
+/// - What's current Operator max supports batch operations count.
+///
+/// Add fields of Capabilities with be public and can be accessed directly.
+///
+/// # Notes
+///
+/// Capabilities reflects the native support for operations. It's possible
+/// that some operations are not supported by current Operator, but still
+/// can be used.
+///
+/// For examples, we will support `seek` and `next` for all readers
+/// returned by services.
+///
+/// # Naming Style
+///
+/// - Operation itself should be in lower case, like `read`, `write`.
+/// - Operation with sub operations should be named like `presign_read`.
+/// - Operation with variants should be named like `read_can_seek`.
+/// - Operation with arguments should be named like `read_with_range`.
+/// - Operation with limtations should be named like `batch_max_operations`.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Capability {
+    /// If operator supports read natively, it will be true.
+    pub read: bool,
+    /// If operator supports seek on returning reader natively, it will
+    /// be true.
+    pub read_can_seek: bool,
+    /// If operator supports next on returning reader natively, it will
+    /// be true.
+    pub read_can_next: bool,
+    /// If operator supports read with range natively, it will be true.
+    pub read_with_range: bool,
+    /// If operator supports read with if match natively, it will be true.
+    pub read_with_if_match: bool,
+    /// If operator supports read with if none match natively, it will be true.
+    pub read_with_if_none_match: bool,
+    /// if operator supports read with override cache control natively, it will be true.
+    pub read_with_override_cache_control: bool,
+    /// if operator supports read with override content disposition natively, it will be true.
+    pub read_with_override_content_disposition: bool,
+
+    /// If operator supports stat natively, it will be true.
+    pub stat: bool,
+    /// If operator supports stat with if match natively, it will be true.
+    pub stat_with_if_match: bool,
+    /// If operator supports stat with if none match natively, it will be true.
+    pub stat_with_if_none_match: bool,
+
+    /// If operator supports write natively, it will be true.
+    pub write: bool,
+    /// If operator supports write with without content length, it will
+    /// be true.
+    ///
+    /// This feature also be called as `Unsized` write or streaming write.
+    pub write_without_content_length: bool,
+    /// If operator supports write with content type natively, it will be true.
+    pub write_with_content_type: bool,
+    /// If operator supports write with content disposition natively, it will be true.
+    pub write_with_content_disposition: bool,
+    /// If operator supports write with cache control natively, it will be true.
+    pub write_with_cache_control: bool,
+
+    /// If operator supports create dir natively, it will be true.
+    pub create_dir: bool,
+
+    /// If operator supports delete natively, it will be true.
+    pub delete: bool,
+
+    /// If operator supports list natively, it will be true.
+    pub list: bool,
+    /// If backend supports list with limit, it will be true.
+    pub list_with_limit: bool,
+
+    /// If operator supports scan natively, it will be true.
+    pub scan: bool,
+    /// If backend supports scan with limit, it will be true.
+    pub scan_with_limit: bool,
+
+    /// If operator supports copy natively, it will be true.
+    pub copy: bool,
+
+    /// If operator supports rename natively, it will be true.
+    pub rename: bool,
+
+    /// If operator supports presign natively, it will be true.
+    pub presign: bool,
+    /// If operator supports presign read natively, it will be true.
+    pub presign_read: bool,
+    /// If operator supports presign stat natively, it will be true.
+    pub presign_stat: bool,
+    /// If operator supports presign write natively, it will be true.
+    pub presign_write: bool,
+
+    /// If operator supports batch natively, it will be true.
+    pub batch: bool,
+    /// If operator supports batch delete natively, it will be true.
+    pub batch_delete: bool,
+    /// The max operations that operator supports in batch.
+    pub batch_max_operations: Option<usize>,
+
+    /// If operator supports blocking natively, it will be true.
+    pub blocking: bool,
+}

--- a/core/src/types/mod.rs
+++ b/core/src/types/mod.rs
@@ -54,4 +54,7 @@ pub use error::Result;
 mod scheme;
 pub use scheme::Scheme;
 
+mod capability;
+pub use capability::Capability;
+
 pub mod ops;

--- a/core/src/types/operator/blocking_operator.rs
+++ b/core/src/types/operator/blocking_operator.rs
@@ -70,7 +70,11 @@ impl BlockingOperator {
     /// # Note
     /// default batch limit is 1000.
     pub(crate) fn from_inner(accessor: FusedAccessor) -> Self {
-        let limit = accessor.info().max_batch_operations().unwrap_or(1000);
+        let limit = accessor
+            .info()
+            .capability()
+            .batch_max_operations
+            .unwrap_or(1000);
         Self { accessor, limit }
     }
 
@@ -419,7 +423,7 @@ impl BlockingOperator {
 
         let op = OpRead::new().with_range(range.into());
 
-        BlockingReader::create_dir(self.inner().clone(), &path, op)
+        BlockingReader::create(self.inner().clone(), &path, op)
     }
 
     /// Write bytes into given path.

--- a/core/src/types/operator/metadata.rs
+++ b/core/src/types/operator/metadata.rs
@@ -49,46 +49,46 @@ impl OperatorInfo {
 
     /// Check if current backend supports [`Accessor::read`] or not.
     pub fn can_read(&self) -> bool {
-        self.0.capabilities().contains(AccessorCapability::Read)
+        self.0.capability().read
     }
 
     /// Check if current backend supports [`Accessor::write`] or not.
     pub fn can_write(&self) -> bool {
-        self.0.capabilities().contains(AccessorCapability::Write)
+        self.0.capability().write
     }
 
     /// Check if current backend supports [`Accessor::copy`] or not.
     pub fn can_copy(&self) -> bool {
-        self.0.capabilities().contains(AccessorCapability::Copy)
+        self.0.capability().copy
     }
 
     /// Check if current backend supports [`Accessor::rename`] or not.
     pub fn can_rename(&self) -> bool {
-        self.0.capabilities().contains(AccessorCapability::Rename)
+        self.0.capability().rename
     }
 
     /// Check if current backend supports [`Accessor::list`] or not.
     pub fn can_list(&self) -> bool {
-        self.0.capabilities().contains(AccessorCapability::List)
+        self.0.capability().list
     }
 
     /// Check if current backend supports [`Accessor::scan`] or not.
     pub fn can_scan(&self) -> bool {
-        self.0.capabilities().contains(AccessorCapability::Scan)
+        self.0.capability().scan
     }
 
     /// Check if current backend supports [`Accessor::presign`] or not.
     pub fn can_presign(&self) -> bool {
-        self.0.capabilities().contains(AccessorCapability::Presign)
+        self.0.capability().presign
     }
 
     /// Check if current backend supports batch operations or not.
     pub fn can_batch(&self) -> bool {
-        self.0.capabilities().contains(AccessorCapability::Batch)
+        self.0.capability().batch
     }
 
     /// Check if current backend supports blocking operations or not.
     pub fn can_blocking(&self) -> bool {
-        self.0.capabilities().contains(AccessorCapability::Blocking)
+        self.0.capability().blocking
     }
 }

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -73,7 +73,11 @@ impl Operator {
     }
 
     pub(crate) fn from_inner(accessor: FusedAccessor) -> Self {
-        let limit = accessor.info().max_batch_operations().unwrap_or(1000);
+        let limit = accessor
+            .info()
+            .capability()
+            .batch_max_operations
+            .unwrap_or(1000);
         Self { accessor, limit }
     }
 

--- a/core/src/types/ops.rs
+++ b/core/src/types/ops.rs
@@ -212,10 +212,10 @@ impl BatchOperation {
 #[derive(Debug, Clone, Default)]
 pub struct OpRead {
     br: BytesRange,
-    override_content_disposition: Option<String>,
-    override_cache_control: Option<String>,
     if_match: Option<String>,
     if_none_match: Option<String>,
+    override_cache_control: Option<String>,
+    override_content_disposition: Option<String>,
 }
 
 impl OpRead {

--- a/core/src/types/reader.rs
+++ b/core/src/types/reader.rs
@@ -192,10 +192,10 @@ impl BlockingReader {
     ///
     /// We don't want to expose those details to users so keep this function
     /// in crate only.
-    pub(crate) fn create_dir(acc: FusedAccessor, path: &str, op: OpRead) -> Result<Self> {
+    pub(crate) fn create(acc: FusedAccessor, path: &str, op: OpRead) -> Result<Self> {
         let acc_meta = acc.info();
 
-        let r = if acc_meta.hints().contains(AccessorHint::ReadSeekable) {
+        let r = if acc_meta.capability().read_can_seek {
             let (_, r) = acc.blocking_read(path, op)?;
             r
         } else {
@@ -205,7 +205,7 @@ impl BlockingReader {
             ));
         };
 
-        let r = if acc_meta.hints().contains(AccessorHint::ReadStreamable) {
+        let r = if acc_meta.capability().read_can_next {
             r
         } else {
             // Make this capacity configurable.


### PR DESCRIPTION
This PR adds capability for operation's variant and args, so that users can know:

- Whether current Operator supports read or not.
- Whether current Operator supports read with if match or not.
- What's current Operator max supports batch operations count.

There are some migration works need to do, we will start a new tracking issue for that.