### PR TITLE
feat(core): test for read_with_override_content_composition

### DIFF
--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -452,16 +452,20 @@ impl Accessor for AzblobBackend {
             .set_root(&self.core.root)
             .set_name(&self.core.container)
             .set_capability(Capability {
+                stat: true,
+                stat_with_if_match: true,
+                stat_with_if_none_match: true,
+
                 read: true,
                 read_can_next: true,
                 read_with_if_match: true,
                 read_with_if_none_match: true,
-                stat: true,
-                stat_with_if_match: true,
-                stat_with_if_none_match: true,
+                read_with_override_content_disposition: true,
+
                 write: true,
                 write_with_content_type: true,
                 write_with_cache_control: true,
+
                 delete: true,
                 create_dir: true,
                 list: true,

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -912,8 +912,16 @@ impl Accessor for S3Backend {
             .set_root(&self.core.root)
             .set_name(&self.core.bucket)
             .set_capability(Capability {
+                stat: true,
+                stat_with_if_match: true,
+                stat_with_if_none_match: true,
+
                 read: true,
                 read_can_next: true,
+                read_with_if_match: true,
+                read_with_if_none_match: true,
+                read_with_override_content_disposition: true,
+
                 write: true,
                 list: true,
                 scan: true,
@@ -951,7 +959,13 @@ impl Accessor for S3Backend {
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let resp = self
             .core
-            .s3_get_object(path, args.range(), args.if_none_match(), args.if_match())
+            .s3_get_object(
+                path,
+                args.range(),
+                args.if_none_match(),
+                args.if_match(),
+                args.override_content_disposition(),
+            )
             .await?;
 
         let status = resp.status();

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -296,9 +296,16 @@ impl S3Core {
         range: BytesRange,
         if_none_match: Option<&str>,
         if_match: Option<&str>,
+        override_content_disposition: Option<&str>,
     ) -> Result<Response<IncomingAsyncBody>> {
-        let mut req =
-            self.s3_get_object_request(path, range, None, None, if_none_match, if_match)?;
+        let mut req = self.s3_get_object_request(
+            path,
+            range,
+            override_content_disposition,
+            None,
+            if_none_match,
+            if_match,
+        )?;
 
         self.sign(&mut req).await?;
 

--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -44,6 +44,13 @@
 /// - Operation with limtations should be named like `batch_max_operations`.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Capability {
+    /// If operator supports stat natively, it will be true.
+    pub stat: bool,
+    /// If operator supports stat with if match natively, it will be true.
+    pub stat_with_if_match: bool,
+    /// If operator supports stat with if none match natively, it will be true.
+    pub stat_with_if_none_match: bool,
+
     /// If operator supports read natively, it will be true.
     pub read: bool,
     /// If operator supports seek on returning reader natively, it will
@@ -62,13 +69,6 @@ pub struct Capability {
     pub read_with_override_cache_control: bool,
     /// if operator supports read with override content disposition natively, it will be true.
     pub read_with_override_content_disposition: bool,
-
-    /// If operator supports stat natively, it will be true.
-    pub stat: bool,
-    /// If operator supports stat with if match natively, it will be true.
-    pub stat_with_if_match: bool,
-    /// If operator supports stat with if none match natively, it will be true.
-    pub stat_with_if_none_match: bool,
 
     /// If operator supports write natively, it will be true.
     pub write: bool,

--- a/core/src/types/operator/metadata.rs
+++ b/core/src/types/operator/metadata.rs
@@ -47,6 +47,11 @@ impl OperatorInfo {
         self.0.name()
     }
 
+    /// Get [`Capability`] of operator.
+    pub fn capability(&self) -> Capability {
+        self.0.capability()
+    }
+
     /// Check if current backend supports [`Accessor::read`] or not.
     pub fn can_read(&self) -> bool {
         self.0.capability().read


### PR DESCRIPTION
It's an experimental draft of read_with_some_headers. Do not merge.

Seems that we don't have a way to check the response headers now.

cc @Xuanwo 