### PR TITLE
refactor: Allow reusing the same operator to speed up tests

### DIFF
--- a/.github/workflows/service_test_http.yml
+++ b/.github/workflows/service_test_http.yml
@@ -66,6 +66,7 @@ jobs:
           RUST_LOG: debug
           OPENDAL_HTTP_TEST: on
           OPENDAL_HTTP_ENDPOINT: http://127.0.0.1:8080
+          OPENDAL_DISABLE_RANDOM_ROOT: true
 
   caddy:
     runs-on: ${{ matrix.os }}
@@ -102,3 +103,4 @@ jobs:
           RUST_LOG: debug
           OPENDAL_HTTP_TEST: on
           OPENDAL_HTTP_ENDPOINT: http://127.0.0.1:8080
+          OPENDAL_DISABLE_RANDOM_ROOT: true

--- a/.github/workflows/service_test_ipfs.yml
+++ b/.github/workflows/service_test_ipfs.yml
@@ -63,6 +63,8 @@ jobs:
           OPENDAL_IPFS_TEST: on
           OPENDAL_IPFS_ROOT: /ipfs/QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ/
           OPENDAL_IPFS_ENDPOINT: "http://127.0.0.1:8080"
+          OPENDAL_DISABLE_RANDOM_ROOT: true
+
 #  # ipfs.io can't pass our test by now, we should address them in the future.
 #  ipfs-io:
 #    runs-on: ubuntu-latest

--- a/core/src/raw/http_util/body.rs
+++ b/core/src/raw/http_util/body.rs
@@ -146,11 +146,13 @@ impl IncomingAsyncBody {
             Ordering::Less => Err(Error::new(
                 ErrorKind::ContentIncomplete,
                 &format!("reader got too less data, expect: {expect}, actual: {actual}"),
-            )),
+            )
+            .set_temporary()),
             Ordering::Greater => Err(Error::new(
                 ErrorKind::ContentTruncated,
                 &format!("reader got too much data, expect: {expect}, actual: {actual}"),
-            )),
+            )
+            .set_temporary()),
         }
     }
 }

--- a/core/src/services/redis/backend.rs
+++ b/core/src/services/redis/backend.rs
@@ -356,6 +356,8 @@ impl kv::Adapter for Adapter {
 
 impl From<RedisError> for Error {
     fn from(e: RedisError) -> Self {
-        Error::new(ErrorKind::Unexpected, e.category()).set_source(e)
+        Error::new(ErrorKind::Unexpected, e.category())
+            .set_source(e)
+            .set_temporary()
     }
 }

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -648,6 +648,10 @@ impl WebdavBackend {
     }
 
     async fn ensure_parent_path(&self, path: &str) -> Result<()> {
+        if path == "/" {
+            return Ok(());
+        }
+
         // create dir recursively, split path by `/` and create each dir except the last one
         let abs_path = build_abs_path(&self.root, path);
         let abs_path = abs_path.as_str();

--- a/core/src/services/webdav/pager.rs
+++ b/core/src/services/webdav/pager.rs
@@ -54,12 +54,13 @@ impl oio::Page for WebdavPager {
             .into_iter()
             .filter_map(|de| {
                 let path = de.href;
-                let normalized_path = if self.root != path {
-                    build_rel_path(&self.root, &path)
-                } else {
-                    path
-                };
 
+                // Ignore the root path itself.
+                if self.root == path {
+                    return None;
+                }
+
+                let normalized_path = build_rel_path(&self.root, &path);
                 if normalized_path == self.path {
                     // WebDav server may return the current path as an entry.
                     return None;

--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -17,6 +17,8 @@
 
 use std::fmt::Debug;
 
+use crate::raw::Operation;
+
 /// Capability is used to describe what operations are supported
 /// by current Operator.
 ///
@@ -135,37 +137,37 @@ impl Debug for Capability {
         let mut d = f.debug_tuple("Capability");
 
         if self.read {
-            d.field(&"READ");
+            d.field(&Operation::Read);
         }
         if self.stat {
-            d.field(&"STAT");
+            d.field(&Operation::Stat);
         }
         if self.write {
-            d.field(&"WRITE");
+            d.field(&Operation::Write);
         }
         if self.create_dir {
-            d.field(&"CREATE_DIR");
+            d.field(&Operation::CreateDir);
         }
         if self.delete {
-            d.field(&"DELETE");
+            d.field(&Operation::Delete);
         }
         if self.list {
-            d.field(&"LIST");
+            d.field(&Operation::List);
         }
         if self.scan {
-            d.field(&"SCAN");
+            d.field(&Operation::Scan);
         }
         if self.copy {
-            d.field(&"COPY");
+            d.field(&Operation::Copy);
         }
         if self.rename {
-            d.field(&"RENAME");
+            d.field(&Operation::Rename);
         }
         if self.presign {
-            d.field(&"PRESIGN");
+            d.field(&Operation::Presign);
         }
         if self.batch {
-            d.field(&"BATCH");
+            d.field(&Operation::Batch);
         }
         if self.blocking {
             d.field(&"BLOCKING");

--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::fmt::Debug;
+
 /// Capability is used to describe what operations are supported
 /// by current Operator.
 ///
@@ -42,7 +44,7 @@
 /// - Operation with variants should be named like `read_can_seek`.
 /// - Operation with arguments should be named like `read_with_range`.
 /// - Operation with limtations should be named like `batch_max_operations`.
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Default)]
 pub struct Capability {
     /// If operator supports read natively, it will be true.
     pub read: bool,
@@ -124,4 +126,49 @@ pub struct Capability {
 
     /// If operator supports blocking natively, it will be true.
     pub blocking: bool,
+}
+
+impl Debug for Capability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_tuple("Capability");
+
+        if self.read {
+            d.field(&"READ");
+        }
+        if self.stat {
+            d.field(&"STAT");
+        }
+        if self.write {
+            d.field(&"WRITE");
+        }
+        if self.create_dir {
+            d.field(&"CREATE_DIR");
+        }
+        if self.delete {
+            d.field(&"DELETE");
+        }
+        if self.list {
+            d.field(&"LIST");
+        }
+        if self.scan {
+            d.field(&"SCAN");
+        }
+        if self.copy {
+            d.field(&"COPY");
+        }
+        if self.rename {
+            d.field(&"RENAME");
+        }
+        if self.presign {
+            d.field(&"PRESIGN");
+        }
+        if self.batch {
+            d.field(&"BATCH");
+        }
+        if self.blocking {
+            d.field(&"BLOCKING");
+        }
+
+        d.finish()
+    }
 }

--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -17,8 +17,6 @@
 
 use std::fmt::Debug;
 
-use crate::raw::Operation;
-
 /// Capability is used to describe what operations are supported
 /// by current Operator.
 ///
@@ -134,45 +132,45 @@ pub struct Capability {
 
 impl Debug for Capability {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_tuple("Capability");
+        let mut s = vec![];
 
         if self.read {
-            d.field(&Operation::Read);
+            s.push("Read");
         }
         if self.stat {
-            d.field(&Operation::Stat);
+            s.push("Stat");
         }
         if self.write {
-            d.field(&Operation::Write);
+            s.push("Write");
         }
         if self.create_dir {
-            d.field(&Operation::CreateDir);
+            s.push("CreateDir");
         }
         if self.delete {
-            d.field(&Operation::Delete);
+            s.push("Delete");
         }
         if self.list {
-            d.field(&Operation::List);
+            s.push("List");
         }
         if self.scan {
-            d.field(&Operation::Scan);
+            s.push("Scan");
         }
         if self.copy {
-            d.field(&Operation::Copy);
+            s.push("Copy");
         }
         if self.rename {
-            d.field(&Operation::Rename);
+            s.push("Rename");
         }
         if self.presign {
-            d.field(&Operation::Presign);
+            s.push("Presign");
         }
         if self.batch {
-            d.field(&Operation::Batch);
+            s.push("Batch");
         }
         if self.blocking {
-            d.field(&"BLOCKING");
+            s.push("Blocking");
         }
 
-        d.finish()
+        write!(f, "{{ {} }}", s.join(" | "))
     }
 }

--- a/core/tests/behavior/blocking_copy.rs
+++ b/core/tests/behavior/blocking_copy.rs
@@ -30,31 +30,28 @@ use super::utils::*;
 macro_rules! behavior_blocking_copy_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
-            mod [<services_ $service:lower _blocking_copy>] {
+            $(
+                #[test]
                 $(
-                    #[test]
-                    $(
-                        #[$meta]
-                    )*
-                    fn [< $test >]() -> anyhow::Result<()> {
-                        let op = $crate::utils::init_service::<opendal::services::$service>(true);
-                        match op {
-                            Some(op) if op.info().can_read()
-                                && op.info().can_write()
-                                && op.info().can_copy()
-                                && op.info().can_blocking() => $crate::blocking_copy::$test(op.blocking()),
-                            Some(_) => {
-                                log::warn!("service {} doesn't support blocking_copy, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            },
-                            None => {
-                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            }
+                    #[$meta]
+                )*
+                fn [<blocking_copy_ $test >]() -> anyhow::Result<()> {
+                    match OPERATOR.as_ref() {
+                        Some(op) if op.info().can_read()
+                            && op.info().can_write()
+                            && op.info().can_copy()
+                            && op.info().can_blocking() => $crate::blocking_copy::$test(op.blocking()),
+                        Some(_) => {
+                            log::warn!("service {} doesn't support blocking_copy, ignored", opendal::Scheme::$service);
+                            Ok(())
+                        },
+                        None => {
+                            log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                            Ok(())
                         }
                     }
-                )*
-            }
+                }
+            )*
         }
     };
 }

--- a/core/tests/behavior/blocking_list.rs
+++ b/core/tests/behavior/blocking_list.rs
@@ -34,30 +34,27 @@ use super::utils::*;
 macro_rules! behavior_blocking_list_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
-            mod [<services_ $service:lower _blocking_list>] {
+            $(
+                #[test]
                 $(
-                    #[test]
-                    $(
-                        #[$meta]
-                    )*
-                    fn [< $test >]() -> anyhow::Result<()> {
-                        let op = $crate::utils::init_service::<opendal::services::$service>(true);
-                        match op {
-                            Some(op) if op.info().can_read()
-                                && op.info().can_write()
-                                && op.info().can_blocking() && (op.info().can_list()||op.info().can_scan()) => $crate::blocking_list::$test(op.blocking()),
-                            Some(_) => {
-                                log::warn!("service {} doesn't support blocking_list, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            },
-                            None => {
-                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            }
+                    #[$meta]
+                )*
+                fn [<blocking_list_ $test >]() -> anyhow::Result<()> {
+                    match OPERATOR.as_ref() {
+                        Some(op) if op.info().can_read()
+                            && op.info().can_write()
+                            && op.info().can_blocking() && (op.info().can_list()||op.info().can_scan()) => $crate::blocking_list::$test(op.blocking()),
+                        Some(_) => {
+                            log::warn!("service {} doesn't support blocking_list, ignored", opendal::Scheme::$service);
+                            Ok(())
+                        },
+                        None => {
+                            log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                            Ok(())
                         }
                     }
-                )*
-            }
+                }
+            )*
         }
     };
 }

--- a/core/tests/behavior/blocking_list.rs
+++ b/core/tests/behavior/blocking_list.rs
@@ -76,13 +76,14 @@ macro_rules! behavior_blocking_list_tests {
 
 /// List dir should return newly created file.
 pub fn test_list_dir(op: BlockingOperator) -> Result<()> {
-    let path = uuid::Uuid::new_v4().to_string();
+    let parent = uuid::Uuid::new_v4().to_string();
+    let path = format!("{parent}/{}", uuid::Uuid::new_v4().to_string());
     debug!("Generate a random file: {}", &path);
     let (content, size) = gen_bytes();
 
     op.write(&path, content).expect("write must succeed");
 
-    let obs = op.list("/")?;
+    let obs = op.list(&format!("{parent}/"))?;
     let mut found = false;
     for de in obs {
         let de = de?;

--- a/core/tests/behavior/blocking_list.rs
+++ b/core/tests/behavior/blocking_list.rs
@@ -132,7 +132,7 @@ pub fn test_scan(op: BlockingOperator) -> Result<()> {
         }
     }
 
-    let w = op.scan("x/")?;
+    let w = op.scan(&format!("{parent}/x/"))?;
     let actual = w
         .collect::<Vec<_>>()
         .into_iter()

--- a/core/tests/behavior/blocking_list.rs
+++ b/core/tests/behavior/blocking_list.rs
@@ -77,7 +77,7 @@ macro_rules! behavior_blocking_list_tests {
 /// List dir should return newly created file.
 pub fn test_list_dir(op: BlockingOperator) -> Result<()> {
     let parent = uuid::Uuid::new_v4().to_string();
-    let path = format!("{parent}/{}", uuid::Uuid::new_v4().to_string());
+    let path = format!("{parent}/{}", uuid::Uuid::new_v4());
     debug!("Generate a random file: {}", &path);
     let (content, size) = gen_bytes();
 

--- a/core/tests/behavior/blocking_read.rs
+++ b/core/tests/behavior/blocking_read.rs
@@ -30,30 +30,27 @@ use sha2::Sha256;
 macro_rules! behavior_blocking_read_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
-            mod [<services_ $service:lower _blocking_read>] {
+            $(
+                #[test]
                 $(
-                    #[test]
-                    $(
-                        #[$meta]
-                    )*
-                    fn [< $test >]() -> anyhow::Result<()> {
-                        let op = $crate::utils::init_service::<opendal::services::$service>(true);
-                        match op {
-                            Some(op) if op.info().can_read()
-                                && !op.info().can_write()
-                                && op.info().can_blocking() => $crate::blocking_read::$test(op.blocking()),
-                            Some(_) => {
-                                log::warn!("service {} doesn't support blocking_read, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            },
-                            None => {
-                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            }
+                    #[$meta]
+                )*
+                fn [<blocking_read_ $test >]() -> anyhow::Result<()> {
+                    match OPERATOR.as_ref() {
+                        Some(op) if op.info().can_read()
+                            && !op.info().can_write()
+                            && op.info().can_blocking() => $crate::blocking_read::$test(op.blocking()),
+                        Some(_) => {
+                            log::warn!("service {} doesn't support blocking_read, ignored", opendal::Scheme::$service);
+                            Ok(())
+                        },
+                        None => {
+                            log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                            Ok(())
                         }
                     }
-                )*
-            }
+                }
+            )*
         }
     };
 }

--- a/core/tests/behavior/blocking_rename.rs
+++ b/core/tests/behavior/blocking_rename.rs
@@ -30,31 +30,28 @@ use super::utils::*;
 macro_rules! behavior_blocking_rename_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
-            mod [<services_ $service:lower _blocking_rename>] {
+            $(
+                #[test]
                 $(
-                    #[test]
-                    $(
-                        #[$meta]
-                    )*
-                    fn [< $test >]() -> anyhow::Result<()> {
-                        let op = $crate::utils::init_service::<opendal::services::$service>(true);
-                        match op {
-                            Some(op) if op.info().can_read()
-                                && op.info().can_write()
-                                && op.info().can_rename()
-                                && op.info().can_blocking() => $crate::blocking_rename::$test(op.blocking()),
-                            Some(_) => {
-                                log::warn!("service {} doesn't support blocking_rename, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            },
-                            None => {
-                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            }
+                    #[$meta]
+                )*
+                fn [<blocking_rename_ $test >]() -> anyhow::Result<()> {
+                    match OPERATOR.as_ref() {
+                        Some(op) if op.info().can_read()
+                            && op.info().can_write()
+                            && op.info().can_rename()
+                            && op.info().can_blocking() => $crate::blocking_rename::$test(op.blocking()),
+                        Some(_) => {
+                            log::warn!("service {} doesn't support blocking_rename, ignored", opendal::Scheme::$service);
+                            Ok(())
+                        },
+                        None => {
+                            log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                            Ok(())
                         }
                     }
-                )*
-            }
+                }
+            )*
         }
     };
 }

--- a/core/tests/behavior/blocking_write.rs
+++ b/core/tests/behavior/blocking_write.rs
@@ -36,30 +36,27 @@ use super::utils::*;
 macro_rules! behavior_blocking_write_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
-            mod [<services_ $service:lower _blocking_write>] {
+            $(
+                #[test]
                 $(
-                    #[test]
-                    $(
-                        #[$meta]
-                    )*
-                    fn [< $test >]() -> anyhow::Result<()> {
-                        let op = $crate::utils::init_service::<opendal::services::$service>(true);
-                        match op {
-                            Some(op) if op.info().can_read()
-                                && op.info().can_write()
-                                && op.info().can_blocking() => $crate::blocking_write::$test(op.blocking()),
-                            Some(_) => {
-                                log::warn!("service {} doesn't support blocking_write, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            },
-                            None => {
-                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            }
+                    #[$meta]
+                )*
+                fn [<blocking_write_ $test >]() -> anyhow::Result<()> {
+                    match OPERATOR.as_ref() {
+                        Some(op) if op.info().can_read()
+                            && op.info().can_write()
+                            && op.info().can_blocking() => $crate::blocking_write::$test(op.blocking()),
+                        Some(_) => {
+                            log::warn!("service {} doesn't support blocking_write, ignored", opendal::Scheme::$service);
+                            Ok(())
+                        },
+                        None => {
+                            log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                            Ok(())
                         }
                     }
-                )*
-            }
+                }
+            )*
         }
     };
 }

--- a/core/tests/behavior/copy.rs
+++ b/core/tests/behavior/copy.rs
@@ -29,30 +29,27 @@ use super::utils::*;
 macro_rules! behavior_copy_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
-            mod [<services_ $service:lower _copy>] {
+            $(
+                #[tokio::test]
                 $(
-                    #[tokio::test]
-                    $(
-                        #[$meta]
-                    )*
-                    async fn [< $test >]() -> anyhow::Result<()> {
-                        let op = $crate::utils::init_service::<opendal::services::$service>(true);
-                        match op {
-                            Some(op) if op.info().can_read()
-                              && op.info().can_write()
-                              && op.info().can_copy() => $crate::copy::$test(op).await,
-                            Some(_) => {
-                                log::warn!("service {} doesn't support copy, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            },
-                            None => {
-                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            }
+                    #[$meta]
+                )*
+                async fn [<copy_ $test >]() -> anyhow::Result<()> {
+                    match OPERATOR.as_ref() {
+                        Some(op) if op.info().can_read()
+                            && op.info().can_write()
+                            && op.info().can_copy() => $crate::copy::$test(op.clone()).await,
+                        Some(_) => {
+                            log::warn!("service {} doesn't support copy, ignored", opendal::Scheme::$service);
+                            Ok(())
+                        },
+                        None => {
+                            log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                            Ok(())
                         }
                     }
-                )*
-            }
+                }
+            )*
         }
     };
 }

--- a/core/tests/behavior/copy.rs
+++ b/core/tests/behavior/copy.rs
@@ -30,15 +30,15 @@ macro_rules! behavior_copy_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
             $(
-                #[tokio::test]
+                #[test]
                 $(
                     #[$meta]
                 )*
-                async fn [<copy_ $test >]() -> anyhow::Result<()> {
+                fn [<copy_ $test >]() -> anyhow::Result<()> {
                     match OPERATOR.as_ref() {
                         Some(op) if op.info().can_read()
                             && op.info().can_write()
-                            && op.info().can_copy() => $crate::copy::$test(op.clone()).await,
+                            && op.info().can_copy() => RUNTIME.block_on($crate::copy::$test(op.clone())),
                         Some(_) => {
                             log::warn!("service {} doesn't support copy, ignored", opendal::Scheme::$service);
                             Ok(())

--- a/core/tests/behavior/list.rs
+++ b/core/tests/behavior/list.rs
@@ -96,7 +96,7 @@ pub async fn test_check(op: Operator) -> Result<()> {
 /// List dir should return newly created file.
 pub async fn test_list_dir(op: Operator) -> Result<()> {
     let parent = uuid::Uuid::new_v4().to_string();
-    let path = format!("{parent}/{}", uuid::Uuid::new_v4().to_string());
+    let path = format!("{parent}/{}", uuid::Uuid::new_v4());
     debug!("Generate a random file: {}", &path);
     let (content, size) = gen_bytes();
 

--- a/core/tests/behavior/list.rs
+++ b/core/tests/behavior/list.rs
@@ -95,13 +95,14 @@ pub async fn test_check(op: Operator) -> Result<()> {
 
 /// List dir should return newly created file.
 pub async fn test_list_dir(op: Operator) -> Result<()> {
-    let path = uuid::Uuid::new_v4().to_string();
+    let parent = uuid::Uuid::new_v4().to_string();
+    let path = format!("{parent}/{}", uuid::Uuid::new_v4().to_string());
     debug!("Generate a random file: {}", &path);
     let (content, size) = gen_bytes();
 
     op.write(&path, content).await.expect("write must succeed");
 
-    let mut obs = op.list("/").await?;
+    let mut obs = op.list(&format!("{parent}/")).await?;
     let mut found = false;
     while let Some(de) = obs.try_next().await? {
         let meta = op.stat(de.path()).await?;

--- a/core/tests/behavior/list.rs
+++ b/core/tests/behavior/list.rs
@@ -286,11 +286,8 @@ pub async fn test_scan_root(op: Operator) -> Result<()> {
         .map(|v| v.path().to_string())
         .collect::<HashSet<_>>();
 
-    assert!(
-        actual.is_empty(),
-        "empty root should return empty, but got {:?}",
-        actual
-    );
+    assert!(!actual.contains("/"), "empty root should return itself");
+    assert!(!actual.contains(""), "empty root should return empty");
     Ok(())
 }
 

--- a/core/tests/behavior/list.rs
+++ b/core/tests/behavior/list.rs
@@ -38,16 +38,16 @@ macro_rules! behavior_list_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
             $(
-                #[tokio::test]
+                #[test]
                 $(
                     #[$meta]
                 )*
-                async fn [<list_ $test >]() -> anyhow::Result<()> {
+                fn [<list_ $test >]() -> anyhow::Result<()> {
                     match OPERATOR.as_ref() {
                         Some(op) if op.info().can_read()
                             && op.info().can_write()
                             && (op.info().can_list()
-                                || op.info().can_scan()) => $crate::list::$test(op.clone()).await,
+                                || op.info().can_scan()) => RUNTIME.block_on($crate::list::$test(op.clone())),
                         Some(_) => {
                             log::warn!("service {} doesn't support list, ignored", opendal::Scheme::$service);
                             Ok(())

--- a/core/tests/behavior/list.rs
+++ b/core/tests/behavior/list.rs
@@ -37,31 +37,28 @@ use super::utils::*;
 macro_rules! behavior_list_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
-            mod [<services_ $service:lower _list>] {
+            $(
+                #[tokio::test]
                 $(
-                    #[tokio::test]
-                    $(
-                        #[$meta]
-                    )*
-                    async fn [< $test >]() -> anyhow::Result<()> {
-                        let op = $crate::utils::init_service::<opendal::services::$service>(true);
-                        match op {
-                            Some(op) if op.info().can_read()
-                                && op.info().can_write()
-                                && (op.info().can_list()
-                                    || op.info().can_scan()) => $crate::list::$test(op).await,
-                            Some(_) => {
-                                log::warn!("service {} doesn't support list, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            },
-                            None => {
-                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            }
+                    #[$meta]
+                )*
+                async fn [<list_ $test >]() -> anyhow::Result<()> {
+                    match OPERATOR.as_ref() {
+                        Some(op) if op.info().can_read()
+                            && op.info().can_write()
+                            && (op.info().can_list()
+                                || op.info().can_scan()) => $crate::list::$test(op.clone()).await,
+                        Some(_) => {
+                            log::warn!("service {} doesn't support list, ignored", opendal::Scheme::$service);
+                            Ok(())
+                        },
+                        None => {
+                            log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                            Ok(())
                         }
                     }
-                )*
-            }
+                }
+            )*
         }
     };
 }

--- a/core/tests/behavior/list_only.rs
+++ b/core/tests/behavior/list_only.rs
@@ -35,7 +35,7 @@ macro_rules! behavior_list_only_test {
                     #[$meta]
                 )*
                 async fn [<list_only_ $test >]() -> anyhow::Result<()> {
-                    match READ_ONLY_OPERATOR.as_ref() {
+                    match OPERATOR.as_ref() {
                         Some(op) if op.info().can_list() && !op.info().can_write() => $crate::list_only::$test(op.clone()).await,
                         Some(_) => {
                             log::warn!("service {} doesn't support list, ignored", opendal::Scheme::$service);

--- a/core/tests/behavior/list_only.rs
+++ b/core/tests/behavior/list_only.rs
@@ -30,13 +30,13 @@ macro_rules! behavior_list_only_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
             $(
-                #[tokio::test]
+                #[test]
                 $(
                     #[$meta]
                 )*
-                async fn [<list_only_ $test >]() -> anyhow::Result<()> {
+                fn [<list_only_ $test >]() -> anyhow::Result<()> {
                     match OPERATOR.as_ref() {
-                        Some(op) if op.info().can_list() && !op.info().can_write() => $crate::list_only::$test(op.clone()).await,
+                        Some(op) if op.info().can_list() && !op.info().can_write() => RUNTIME.block_on($crate::list_only::$test(op.clone())),
                         Some(_) => {
                             log::warn!("service {} doesn't support list, ignored", opendal::Scheme::$service);
                             Ok(())

--- a/core/tests/behavior/list_only.rs
+++ b/core/tests/behavior/list_only.rs
@@ -29,28 +29,25 @@ use opendal::Operator;
 macro_rules! behavior_list_only_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
-            mod [<services_ $service:lower _list_only>] {
+            $(
+                #[tokio::test]
                 $(
-                    #[tokio::test]
-                    $(
-                        #[$meta]
-                    )*
-                    async fn [< $test >]() -> anyhow::Result<()> {
-                        let op = $crate::utils::init_service::<opendal::services::$service>(false);
-                        match op {
-                            Some(op) if op.info().can_list() && !op.info().can_write() => $crate::list_only::$test(op).await,
-                            Some(_) => {
-                                log::warn!("service {} doesn't support list, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            },
-                            None => {
-                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            }
+                    #[$meta]
+                )*
+                async fn [<list_only_ $test >]() -> anyhow::Result<()> {
+                    match READ_ONLY_OPERATOR.as_ref() {
+                        Some(op) if op.info().can_list() && !op.info().can_write() => $crate::list_only::$test(op.clone()).await,
+                        Some(_) => {
+                            log::warn!("service {} doesn't support list, ignored", opendal::Scheme::$service);
+                            Ok(())
+                        },
+                        None => {
+                            log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                            Ok(())
                         }
                     }
-                )*
-            }
+                }
+            )*
         }
     };
 }

--- a/core/tests/behavior/main.rs
+++ b/core/tests/behavior/main.rs
@@ -46,32 +46,43 @@ mod utils;
 /// Update function list while changed.
 macro_rules! behavior_tests {
     ($($service:ident),*) => {
-        $(
-            // can_read && !can_write
-            behavior_read_tests!($service);
-            // can_read && !can_write && can_blocking
-            behavior_blocking_read_tests!($service);
-            // can_read && can_write
-            behavior_write_tests!($service);
-            // can_read && can_write && can_blocking
-            behavior_blocking_write_tests!($service);
-            // can_read && can_write && can_copy
-            behavior_copy_tests!($service);
-            // can read && can_write && can_blocking && can_copy
-            behavior_blocking_copy_tests!($service);
-            // can_read && can_write && can_move
-            behavior_rename_tests!($service);
-            // can_read && can_write && can_blocking && can_move
-            behavior_blocking_rename_tests!($service);
-            // can_read && can_write && can_list
-            behavior_list_tests!($service);
-            // can_read && can_write && can_presign
-            behavior_presign_tests!($service);
-            // can_read && can_write && can_blocking && can_list
-            behavior_blocking_list_tests!($service);
-            // can_list && !can_write
-            behavior_list_only_tests!($service);
-        )*
+        paste::item! {
+            $(
+                mod [<services_ $service:lower>] {
+                    static OPERATOR: once_cell::sync::Lazy<Option<opendal::Operator>> = once_cell::sync::Lazy::new(||
+                        $crate::utils::init_service::<opendal::services::$service>(true)
+                    );
+                    static READ_ONLY_OPERATOR: once_cell::sync::Lazy<Option<opendal::Operator>> = once_cell::sync::Lazy::new(||
+                        $crate::utils::init_service::<opendal::services::$service>(false)
+                    );
+
+                    // can_read && !can_write
+                    behavior_read_tests!($service);
+                    // can_read && !can_write && can_blocking
+                    behavior_blocking_read_tests!($service);
+                    // can_read && can_write
+                    behavior_write_tests!($service);
+                    // can_read && can_write && can_blocking
+                    behavior_blocking_write_tests!($service);
+                    // can_read && can_write && can_copy
+                    behavior_copy_tests!($service);
+                    // can read && can_write && can_blocking && can_copy
+                    behavior_blocking_copy_tests!($service);
+                    // can_read && can_write && can_move
+                    behavior_rename_tests!($service);
+                    // can_read && can_write && can_blocking && can_move
+                    behavior_blocking_rename_tests!($service);
+                    // can_read && can_write && can_list
+                    behavior_list_tests!($service);
+                    // can_read && can_write && can_presign
+                    behavior_presign_tests!($service);
+                    // can_read && can_write && can_blocking && can_list
+                    behavior_blocking_list_tests!($service);
+                    // can_list && !can_write
+                    behavior_list_only_tests!($service);
+                }
+         )*
+        }
     };
 }
 

--- a/core/tests/behavior/main.rs
+++ b/core/tests/behavior/main.rs
@@ -50,10 +50,7 @@ macro_rules! behavior_tests {
             $(
                 mod [<services_ $service:lower>] {
                     static OPERATOR: once_cell::sync::Lazy<Option<opendal::Operator>> = once_cell::sync::Lazy::new(||
-                        $crate::utils::init_service::<opendal::services::$service>(true)
-                    );
-                    static READ_ONLY_OPERATOR: once_cell::sync::Lazy<Option<opendal::Operator>> = once_cell::sync::Lazy::new(||
-                        $crate::utils::init_service::<opendal::services::$service>(false)
+                        $crate::utils::init_service::<opendal::services::$service>()
                     );
 
                     // can_read && !can_write

--- a/core/tests/behavior/main.rs
+++ b/core/tests/behavior/main.rs
@@ -49,6 +49,12 @@ macro_rules! behavior_tests {
         paste::item! {
             $(
                 mod [<services_ $service:lower>] {
+                    static RUNTIME: once_cell::sync::Lazy<tokio::runtime::Runtime> = once_cell::sync::Lazy::new(|| {
+                       tokio::runtime::Builder::new_multi_thread()
+                            .enable_all()
+                            .build()
+                            .unwrap()
+                    });
                     static OPERATOR: once_cell::sync::Lazy<Option<opendal::Operator>> = once_cell::sync::Lazy::new(||
                         $crate::utils::init_service::<opendal::services::$service>()
                     );

--- a/core/tests/behavior/main.rs
+++ b/core/tests/behavior/main.rs
@@ -49,13 +49,15 @@ macro_rules! behavior_tests {
         paste::item! {
             $(
                 mod [<services_ $service:lower>] {
-                    static RUNTIME: once_cell::sync::Lazy<tokio::runtime::Runtime> = once_cell::sync::Lazy::new(|| {
+                    use once_cell::sync::Lazy;
+
+                    static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
                        tokio::runtime::Builder::new_multi_thread()
                             .enable_all()
                             .build()
                             .unwrap()
                     });
-                    static OPERATOR: once_cell::sync::Lazy<Option<opendal::Operator>> = once_cell::sync::Lazy::new(||
+                    static OPERATOR: Lazy<Option<opendal::Operator>> = Lazy::new(||
                         $crate::utils::init_service::<opendal::services::$service>()
                     );
 

--- a/core/tests/behavior/presign.rs
+++ b/core/tests/behavior/presign.rs
@@ -38,13 +38,13 @@ macro_rules! behavior_presign_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
             $(
-                #[tokio::test]
+                #[test]
                 $(
                     #[$meta]
                 )*
-                async fn [<presign_ $test >]() -> anyhow::Result<()> {
+                fn [<presign_ $test >]() -> anyhow::Result<()> {
                     match OPERATOR.as_ref() {
-                        Some(op) if op.info().can_read() && op.info().can_write() && op.info().can_presign() => $crate::presign::$test(op.clone()).await,
+                        Some(op) if op.info().can_read() && op.info().can_write() && op.info().can_presign() => RUNTIME.block_on($crate::presign::$test(op.clone())),
                         Some(_) => {
                             log::warn!("service {} doesn't support presign, ignored", opendal::Scheme::$service);
                             Ok(())

--- a/core/tests/behavior/presign.rs
+++ b/core/tests/behavior/presign.rs
@@ -37,28 +37,25 @@ use super::utils::*;
 macro_rules! behavior_presign_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
-            mod [<services_ $service:lower _presign>] {
+            $(
+                #[tokio::test]
                 $(
-                    #[tokio::test]
-                    $(
-                        #[$meta]
-                    )*
-                    async fn [< $test >]() -> anyhow::Result<()> {
-                        let op = $crate::utils::init_service::<opendal::services::$service>(true);
-                        match op {
-                            Some(op) if op.info().can_read() && op.info().can_write() && op.info().can_presign() => $crate::presign::$test(op).await,
-                            Some(_) => {
-                                log::warn!("service {} doesn't support presign, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            },
-                            None => {
-                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            }
+                    #[$meta]
+                )*
+                async fn [<presign_ $test >]() -> anyhow::Result<()> {
+                    match OPERATOR.as_ref() {
+                        Some(op) if op.info().can_read() && op.info().can_write() && op.info().can_presign() => $crate::presign::$test(op.clone()).await,
+                        Some(_) => {
+                            log::warn!("service {} doesn't support presign, ignored", opendal::Scheme::$service);
+                            Ok(())
+                        },
+                        None => {
+                            log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                            Ok(())
                         }
                     }
-                )*
-            }
+                }
+            )*
         }
     };
 }

--- a/core/tests/behavior/read_only.rs
+++ b/core/tests/behavior/read_only.rs
@@ -36,7 +36,7 @@ macro_rules! behavior_read_test {
                     #[$meta]
                 )*
                 async fn [<read_only_ $test >]() -> anyhow::Result<()> {
-                    match READ_ONLY_OPERATOR.as_ref() {
+                    match OPERATOR.as_ref() {
                         Some(op) if op.info().can_read() && !op.info().can_write() => $crate::read_only::$test(op.clone()).await,
                         Some(_) => {
                             log::warn!("service {} doesn't support read_only, ignored", opendal::Scheme::$service);

--- a/core/tests/behavior/read_only.rs
+++ b/core/tests/behavior/read_only.rs
@@ -31,13 +31,13 @@ macro_rules! behavior_read_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
             $(
-                #[tokio::test]
+                #[test]
                 $(
                     #[$meta]
                 )*
-                async fn [<read_only_ $test >]() -> anyhow::Result<()> {
+                fn [<read_only_ $test >]() -> anyhow::Result<()> {
                     match OPERATOR.as_ref() {
-                        Some(op) if op.info().can_read() && !op.info().can_write() => $crate::read_only::$test(op.clone()).await,
+                        Some(op) if op.info().can_read() && !op.info().can_write() => RUNTIME.block_on($crate::read_only::$test(op.clone())),
                         Some(_) => {
                             log::warn!("service {} doesn't support read_only, ignored", opendal::Scheme::$service);
                             Ok(())

--- a/core/tests/behavior/read_only.rs
+++ b/core/tests/behavior/read_only.rs
@@ -30,28 +30,25 @@ use sha2::Sha256;
 macro_rules! behavior_read_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
-            mod [<services_ $service:lower _read_only>] {
+            $(
+                #[tokio::test]
                 $(
-                    #[tokio::test]
-                    $(
-                        #[$meta]
-                    )*
-                    async fn [< $test >]() -> anyhow::Result<()> {
-                        let op = $crate::utils::init_service::<opendal::services::$service>(false);
-                        match op {
-                            Some(op) if op.info().can_read() && !op.info().can_write() => $crate::read_only::$test(op).await,
-                            Some(_) => {
-                                log::warn!("service {} doesn't support read_only, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            },
-                            None => {
-                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            }
+                    #[$meta]
+                )*
+                async fn [<read_only_ $test >]() -> anyhow::Result<()> {
+                    match READ_ONLY_OPERATOR.as_ref() {
+                        Some(op) if op.info().can_read() && !op.info().can_write() => $crate::read_only::$test(op.clone()).await,
+                        Some(_) => {
+                            log::warn!("service {} doesn't support read_only, ignored", opendal::Scheme::$service);
+                            Ok(())
+                        },
+                        None => {
+                            log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                            Ok(())
                         }
                     }
-                )*
-            }
+                }
+            )*
         }
     };
 }

--- a/core/tests/behavior/rename.rs
+++ b/core/tests/behavior/rename.rs
@@ -30,15 +30,15 @@ macro_rules! behavior_rename_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
             $(
-                #[tokio::test]
+                #[test]
                 $(
                     #[$meta]
                 )*
-                async fn [<rename_ $test >]() -> anyhow::Result<()> {
+                fn [<rename_ $test >]() -> anyhow::Result<()> {
                     match OPERATOR.as_ref() {
                         Some(op) if op.info().can_read()
                             && op.info().can_write()
-                            && op.info().can_rename() => $crate::rename::$test(op.clone()).await,
+                            && op.info().can_rename() => RUNTIME.block_on($crate::rename::$test(op.clone())),
                         Some(_) => {
                             log::warn!("service {} doesn't support rename, ignored", opendal::Scheme::$service);
                             Ok(())

--- a/core/tests/behavior/rename.rs
+++ b/core/tests/behavior/rename.rs
@@ -29,30 +29,27 @@ use super::utils::*;
 macro_rules! behavior_rename_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
-            mod [<services_ $service:lower _rename>] {
+            $(
+                #[tokio::test]
                 $(
-                    #[tokio::test]
-                    $(
-                        #[$meta]
-                    )*
-                    async fn [< $test >]() -> anyhow::Result<()> {
-                        let op = $crate::utils::init_service::<opendal::services::$service>(true);
-                        match op {
-                            Some(op) if op.info().can_read()
-                              && op.info().can_write()
-                              && op.info().can_rename() => $crate::rename::$test(op).await,
-                            Some(_) => {
-                                log::warn!("service {} doesn't support rename, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            },
-                            None => {
-                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            }
+                    #[$meta]
+                )*
+                async fn [<rename_ $test >]() -> anyhow::Result<()> {
+                    match OPERATOR.as_ref() {
+                        Some(op) if op.info().can_read()
+                            && op.info().can_write()
+                            && op.info().can_rename() => $crate::rename::$test(op.clone()).await,
+                        Some(_) => {
+                            log::warn!("service {} doesn't support rename, ignored", opendal::Scheme::$service);
+                            Ok(())
+                        },
+                        None => {
+                            log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                            Ok(())
                         }
                     }
-                )*
-            }
+                }
+            )*
         }
     };
 }

--- a/core/tests/behavior/utils.rs
+++ b/core/tests/behavior/utils.rs
@@ -34,7 +34,7 @@ use sha2::Sha256;
 ///
 /// - If `opendal_{schema}_test` is on, construct a new Operator with given root.
 /// - Else, returns a `None` to represent no valid config for operator.
-pub fn init_service<B: Builder>(random_root: bool) -> Option<Operator> {
+pub fn init_service<B: Builder>() -> Option<Operator> {
     let _ = env_logger::builder().is_test(true).try_init();
     let _ = dotenvy::dotenv();
 
@@ -54,7 +54,9 @@ pub fn init_service<B: Builder>(random_root: bool) -> Option<Operator> {
         return None;
     }
 
-    if random_root {
+    // Use random root unless OPENDAL_DISABLE_RANDOM_ROOT is set to true.
+    let disable_random_root = env::var("OPENDAL_DISABLE_RANDOM_ROOT").unwrap_or_default() == "true";
+    if !disable_random_root {
         let root = format!(
             "{}{}/",
             cfg.get("root").cloned().unwrap_or_else(|| "/".to_string()),

--- a/core/tests/behavior/write.rs
+++ b/core/tests/behavior/write.rs
@@ -36,28 +36,25 @@ use super::utils::*;
 macro_rules! behavior_write_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
-            mod [<services_ $service:lower _write>] {
+            $(
+                #[tokio::test]
                 $(
-                    #[tokio::test]
-                    $(
-                        #[$meta]
-                    )*
-                    async fn [< $test >]() -> anyhow::Result<()> {
-                        let op = $crate::utils::init_service::<opendal::services::$service>(true);
-                        match op {
-                            Some(op) if op.info().can_read() && op.info().can_write() => $crate::write::$test(op).await,
-                            Some(_) => {
-                                log::warn!("service {} doesn't support write, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            },
-                            None => {
-                                log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
-                                Ok(())
-                            }
+                    #[$meta]
+                )*
+                async fn [<write_ $test >]() -> anyhow::Result<()> {
+                    match OPERATOR.as_ref() {
+                        Some(op) if op.info().can_read() && op.info().can_write() => $crate::write::$test(op.clone()).await,
+                        Some(_) => {
+                            log::warn!("service {} doesn't support write, ignored", opendal::Scheme::$service);
+                            Ok(())
+                        },
+                        None => {
+                            log::warn!("service {} not initiated, ignored", opendal::Scheme::$service);
+                            Ok(())
                         }
                     }
-                )*
-            }
+                }
+            )*
         }
     };
 }

--- a/core/tests/behavior/write.rs
+++ b/core/tests/behavior/write.rs
@@ -41,13 +41,13 @@ macro_rules! behavior_write_test {
     ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
         paste::item! {
             $(
-                #[tokio::test]
+                #[test]
                 $(
                     #[$meta]
                 )*
-                async fn [<write_ $test >]() -> anyhow::Result<()> {
+                fn [<write_ $test >]() -> anyhow::Result<()> {
                     match OPERATOR.as_ref() {
-                        Some(op) if op.info().can_read() && op.info().can_write() => $crate::write::$test(op.clone()).await,
+                        Some(op) if op.info().can_read() && op.info().can_write() => RUNTIME.block_on($crate::write::$test(op.clone())),
                         Some(_) => {
                             log::warn!("service {} doesn't support write, ignored", opendal::Scheme::$service);
                             Ok(())


### PR DESCRIPTION
This PR refactor the behavior tests to allow using the same operator.