### PR TITLE
feat(core): Add `start-after` support for list

### DIFF
--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -94,6 +94,8 @@ pub struct Capability {
     pub list: bool,
     /// If backend supports list with limit, it will be true.
     pub list_with_limit: bool,
+    /// If backend supports list with start after, it will be true.
+    pub list_with_start_after: bool,
 
     /// If operator supports scan natively, it will be true.
     pub scan: bool,

--- a/core/src/types/ops.rs
+++ b/core/src/types/ops.rs
@@ -55,6 +55,10 @@ pub struct OpList {
     /// The limit passed to underlying service to specify the max results
     /// that could return.
     limit: Option<usize>,
+
+    /// The start_after passes to underlying service to specify the specified key
+    /// to start listing from.
+    start_after: Option<String>,
 }
 
 impl OpList {
@@ -72,6 +76,17 @@ impl OpList {
     /// Get the limit of list operation.
     pub fn limit(&self) -> Option<usize> {
         self.limit
+    }
+
+    /// Change the start_after of this list operation.
+    pub fn with_start_after(mut self, start_after: &str) -> Self {
+        self.start_after = Some(start_after.into());
+        self
+    }
+
+    /// Get the start_after of list operation.
+    pub fn start_after(&self) -> Option<&str> {
+        self.start_after.as_deref()
     }
 }
 


### PR DESCRIPTION
Closes #2069
This PR makes following changes:
1. added `start_after` argument for `OpList`.
2. added `list_with` method for `Operator`.
3. added `list_with_start_after` option for `Capability`.
