### PR TITLE
core: Add behavior test for read_with_if_match & stat_with_if_match

### DIFF
--- a/core/tests/behavior/write.rs
+++ b/core/tests/behavior/write.rs
@@ -80,6 +80,7 @@ macro_rules! behavior_write_tests {
                 test_stat_with_special_chars,
                 test_stat_not_cleaned_path,
                 test_stat_not_exist,
+                test_stat_with_if_match,
                 test_stat_root,
                 test_read_full,
                 test_read_range,
@@ -88,6 +89,7 @@ macro_rules! behavior_write_tests {
                 test_reader_from,
                 test_reader_tail,
                 test_read_not_exist,
+                test_read_with_if_match,
                 test_fuzz_range_reader,
                 test_fuzz_offset_reader,
                 test_fuzz_part_reader,
@@ -267,7 +269,7 @@ pub async fn test_stat_with_if_match(op: Operator) -> Result<()> {
     op_stat = op_stat.with_if_match("invalid_etag");
 
     let res = op.stat_with(&path, op_stat).await;
-    assert_eq!(res.is_err());
+    assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::PreconditionFailed);
 
     let mut op_stat = OpStat::default();
@@ -488,13 +490,16 @@ pub async fn test_read_with_if_match(op: Operator) -> Result<()> {
     op_if_match = op_if_match.with_if_match("invalid_etag");
 
     let res = op.read_with(&path, op_if_match).await;
-    assert_eq!(res.is_err());
+    assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::PreconditionFailed);
 
     let mut op_if_match = OpRead::default();
     op_if_match = op_if_match.with_if_match(meta.etag().expect("etag must exist"));
 
-    let bs = op.read_with(&path, op_if_match).await.expect("read must succeed");
+    let bs = op
+        .read_with(&path, op_if_match)
+        .await
+        .expect("read must succeed");
     assert_eq!(bs, content);
 
     op.delete(&path).await.expect("delete must succeed");

--- a/core/tests/behavior/write.rs
+++ b/core/tests/behavior/write.rs
@@ -21,7 +21,7 @@ use futures::AsyncSeekExt;
 use futures::StreamExt;
 use log::debug;
 use log::warn;
-use opendal::ops::OpRead;
+use opendal::ops::{OpRead, OpStat};
 use opendal::EntryMode;
 use opendal::ErrorKind;
 use opendal::Operator;
@@ -245,6 +245,41 @@ pub async fn test_stat_not_exist(op: Operator) -> Result<()> {
     Ok(())
 }
 
+/// Stat with if_match should succeed, else get a 412(PreconditionFailed) error.
+pub async fn test_stat_with_if_match(op: Operator) -> Result<()> {
+    if !op.info().capability().stat_with_if_match {
+        return Ok(());
+    }
+
+    let path = uuid::Uuid::new_v4().to_string();
+    debug!("Generate a random file: {}", &path);
+    let (content, size) = gen_bytes();
+
+    op.write(&path, content.clone())
+        .await
+        .expect("write must succeed");
+
+    let meta = op.stat(&path).await?;
+    assert_eq!(meta.mode(), EntryMode::FILE);
+    assert_eq!(meta.content_length(), size as u64);
+
+    let mut op_stat = OpStat::default();
+    op_stat = op_stat.with_if_match("invalid_etag");
+
+    let res = op.stat_with(&path, op_stat).await;
+    assert_eq!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::PreconditionFailed);
+
+    let mut op_stat = OpStat::default();
+    op_stat = op_stat.with_if_match(meta.etag().expect("etag must exist"));
+
+    let result = op.stat_with(&path, op_stat).await;
+    assert!(result.is_ok());
+
+    op.delete(&path).await.expect("delete must succeed");
+    Ok(())
+}
+
 /// Root should be able to stat and returns DIR.
 pub async fn test_stat_root(op: Operator) -> Result<()> {
     let meta = op.stat("").await?;
@@ -430,6 +465,39 @@ pub async fn test_read_not_exist(op: Operator) -> Result<()> {
     assert!(bs.is_err());
     assert_eq!(bs.unwrap_err().kind(), ErrorKind::NotFound);
 
+    Ok(())
+}
+
+// Read with if_match should match, else get a 412(Precondition Failed) error.
+pub async fn test_read_with_if_match(op: Operator) -> Result<()> {
+    if !op.info().capability().read_with_if_match {
+        return Ok(());
+    }
+
+    let path = uuid::Uuid::new_v4().to_string();
+    debug!("Generate a random file: {}", &path);
+    let (content, _) = gen_bytes();
+
+    op.write(&path, content.clone())
+        .await
+        .expect("write must succeed");
+
+    let meta = op.stat(&path).await?;
+
+    let mut op_if_match = OpRead::default();
+    op_if_match = op_if_match.with_if_match("invalid_etag");
+
+    let res = op.read_with(&path, op_if_match).await;
+    assert_eq!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::PreconditionFailed);
+
+    let mut op_if_match = OpRead::default();
+    op_if_match = op_if_match.with_if_match(meta.etag().expect("etag must exist"));
+
+    let bs = op.read_with(&path, op_if_match).await.expect("read must succeed");
+    assert_eq!(bs, content);
+
+    op.delete(&path).await.expect("delete must succeed");
     Ok(())
 }
 


### PR DESCRIPTION
`if_match` is one of the Precondition Header Fields. https://www.rfc-editor.org/rfc/rfc7232#section-3.1

#### How to test it?

This PR adds tests for the `read_if_match` and `stat_if_match` operations/capabilities, which use the `If-Match` request header to test whether an S3 object's version matches a given ETag.

The `If-Match` header allows clients to perform optimistic concurrency control by specifying the expected version of an object before performing a `read` or `stat` operation, and S3 will only return the object or its metadata if the actual version matches the expected version.