### PR TITLE
chore: improve LoggingLayer docs and pub use log::Level

### DIFF
--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -45,6 +45,8 @@ use crate::*;
 ///   - `finished`: the operation is successful.
 ///   - `errored`: the operation returns an expected error like `NotFound`.
 ///   - `failed`: the operation returns an unexpected error.
+/// - The default log level while expected error happened is `Warn`.
+/// - The default log level while unexpected failure happened is `Error`.
 ///
 /// # Todo
 ///


### PR DESCRIPTION
Two small changes:

* Adds default log level to `LoggingLayer` docs, close #1820 
* Pub use `log::Level` in `layers::logging`. It can simplify the user's dependencies, they don't have to depend on the `log` crate directly when configuring `LoggingLayer`.



