### PR TITLE
feat(services/s3): Add `start-after` support for list

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -927,6 +927,9 @@ impl Accessor for S3Backend {
                 write_without_content_length: true,
 
                 list: true,
+                list_with_limit: true,
+                list_with_start_after: true,
+
                 scan: true,
                 copy: true,
                 presign: true,
@@ -1042,14 +1045,20 @@ impl Accessor for S3Backend {
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
         Ok((
             RpList::default(),
-            S3Pager::new(self.core.clone(), path, "/", args.limit()),
+            S3Pager::new(
+                self.core.clone(),
+                path,
+                "/",
+                args.limit(),
+                args.start_after(),
+            ),
         ))
     }
 
     async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
         Ok((
             RpScan::default(),
-            S3Pager::new(self.core.clone(), path, "", args.limit()),
+            S3Pager::new(self.core.clone(), path, "", args.limit(), None),
         ))
     }
 

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -454,6 +454,7 @@ impl S3Core {
         continuation_token: &str,
         delimiter: &str,
         limit: Option<usize>,
+        start_after: Option<String>,
     ) -> Result<Response<IncomingAsyncBody>> {
         let p = build_abs_path(&self.root, path);
 
@@ -467,6 +468,11 @@ impl S3Core {
         }
         if let Some(limit) = limit {
             write!(url, "&max-keys={limit}").expect("write into string must succeed");
+        }
+        if let Some(start_after) = start_after {
+            let start_after = build_abs_path(&self.root, &start_after);
+            write!(url, "&start-after={}", percent_encode_path(&start_after))
+                .expect("write into string must succeed");
         }
         if !continuation_token.is_empty() {
             // AWS S3 could return continuation-token that contains `=`

--- a/core/src/services/s3/pager.rs
+++ b/core/src/services/s3/pager.rs
@@ -35,19 +35,27 @@ pub struct S3Pager {
     path: String,
     delimiter: String,
     limit: Option<usize>,
+    start_after: Option<String>,
 
     token: String,
     done: bool,
 }
 
 impl S3Pager {
-    pub fn new(core: Arc<S3Core>, path: &str, delimiter: &str, limit: Option<usize>) -> Self {
+    pub fn new(
+        core: Arc<S3Core>,
+        path: &str,
+        delimiter: &str,
+        limit: Option<usize>,
+        start_after: Option<&str>,
+    ) -> Self {
         Self {
             core,
 
             path: path.to_string(),
             delimiter: delimiter.to_string(),
             limit,
+            start_after: start_after.map(String::from),
 
             token: "".to_string(),
             done: false,
@@ -64,7 +72,13 @@ impl oio::Page for S3Pager {
 
         let resp = self
             .core
-            .s3_list_objects(&self.path, &self.token, &self.delimiter, self.limit)
+            .s3_list_objects(
+                &self.path,
+                &self.token,
+                &self.delimiter,
+                self.limit,
+                self.start_after.clone(),
+            )
             .await?;
 
         if resp.status() != http::StatusCode::OK {


### PR DESCRIPTION
Closes #2095

This PR introduces new features:
1. add `list_with_start_after` capability
2. add `test_list_with_start_after` test case
