### PR TITLE
feat(services/gcs): Add start-after support for list

### DIFF
--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -385,6 +385,8 @@ impl Accessor for GcsBackend {
                 write_without_content_length: true,
 
                 list: true,
+                list_with_limit: true,
+                list_with_start_after: true,
                 scan: true,
                 copy: true,
 
@@ -502,14 +504,20 @@ impl Accessor for GcsBackend {
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
         Ok((
             RpList::default(),
-            GcsPager::new(self.core.clone(), path, "/", args.limit()),
+            GcsPager::new(
+                self.core.clone(),
+                path,
+                "/",
+                args.limit(),
+                args.start_after(),
+            ),
         ))
     }
 
     async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
         Ok((
             RpScan::default(),
-            GcsPager::new(self.core.clone(), path, "", args.limit()),
+            GcsPager::new(self.core.clone(), path, "", args.limit(), None),
         ))
     }
 }

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -298,6 +298,7 @@ impl GcsCore {
         page_token: &str,
         delimiter: &str,
         limit: Option<usize>,
+        start_after: Option<String>,
     ) -> Result<Response<IncomingAsyncBody>> {
         let p = build_abs_path(&self.root, path);
 
@@ -313,6 +314,12 @@ impl GcsCore {
         if let Some(limit) = limit {
             write!(url, "&maxResults={limit}").expect("write into string must succeed");
         }
+        if let Some(start_after) = start_after {
+            let start_after = build_abs_path(&self.root, &start_after);
+            write!(url, "&startOffset={}", percent_encode_path(&start_after))
+                .expect("write into string must succeed");
+        }
+
         if !page_token.is_empty() {
             // NOTE:
             //

--- a/core/src/services/s3/pager.rs
+++ b/core/src/services/s3/pager.rs
@@ -35,6 +35,8 @@ pub struct S3Pager {
     path: String,
     delimiter: String,
     limit: Option<usize>,
+
+    /// Amazon S3 starts listing **after** this specified key
     start_after: Option<String>,
 
     token: String,


### PR DESCRIPTION
Closes #2106
This PR add a new feature for GCS:
- add `list_with_start_after` capability