### PR TITLE
feat(java): connect rust async/await with java future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,9 @@ name = "opendal-java"
 version = "0.1.0"
 dependencies = [
  "jni",
+ "lazy_static",
  "opendal",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,8 @@ name = "opendal-java"
 version = "0.1.0"
 dependencies = [
  "jni",
- "lazy_static",
+ "num_cpus",
+ "once_cell",
  "opendal",
  "tokio",
 ]

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -34,3 +34,7 @@ doc = false
 [dependencies]
 jni = "0.21.1"
 opendal.workspace = true
+
+tokio = { version = "1", features = ["full"] }
+lazy_static = "1.4"
+

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -36,5 +36,7 @@ jni = "0.21.1"
 opendal.workspace = true
 
 tokio = { version = "1", features = ["full"] }
-lazy_static = "1.4"
+once_cell = "1.17.1"
+
+num_cpus = "1.15.0"
 

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -62,11 +62,8 @@ fn get_system_property(env: &mut JNIEnv, key: &str) -> Result<String, jni::error
 /// This function could be only called by java vm when load this lib.
 #[no_mangle]
 pub unsafe extern "system" fn JNI_OnLoad(vm: JavaVM, _: *mut c_void) -> jint {
-    let mut env = vm.get_env().unwrap();
-    let thread_count = match get_system_property(&mut env, "opendal.thread.count") {
-        Ok(count) => count.parse().unwrap_or(num_cpus::get()),
-        Err(_) => num_cpus::get(),
-    };
+    // TODO: make this configurable in the future
+    let thread_count = num_cpus::get();
 
     let java_vm = Arc::new(vm);
     let runtime = Builder::new_multi_thread()

--- a/bindings/java/src/main/java/org/apache/opendal/Operator.java
+++ b/bindings/java/src/main/java/org/apache/opendal/Operator.java
@@ -21,9 +21,8 @@
 package org.apache.opendal;
 
 import io.questdb.jar.jni.JarJniLoader;
-
 import java.util.Map;
-
+import java.util.concurrent.CompletableFuture;
 
 public class Operator {
 
@@ -39,9 +38,9 @@ public class Operator {
 
     static {
         JarJniLoader.loadLib(
-                Operator.class,
-                ORG_APACHE_OPENDAL_RUST_LIBS,
-                OPENDAL_JAVA);
+            Operator.class,
+            ORG_APACHE_OPENDAL_RUST_LIBS,
+            OPENDAL_JAVA);
     }
 
     private native long getOperator(String type, Map<String, String> params);
@@ -50,15 +49,22 @@ public class Operator {
 
     private native void write(long ptr, String fileName, String content);
 
+    private native void asyncWrite(long ptr, String fileName, String content, CompletableFuture<Boolean> future);
+
     private native String read(long ptr, String fileName);
 
     private native void delete(long ptr, String fileName);
 
     private native long stat(long ptr, String file);
 
-
     public void write(String fileName, String content) {
         write(this.ptr, fileName, content);
+    }
+
+    public CompletableFuture<Boolean> asyncWrite(String fileName, String content) {
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        asyncWrite(this.ptr, fileName, content, future);
+        return future;
     }
 
     public String read(String s) {

--- a/bindings/java/src/test/java/org/apache/opendal/AsyncStepsTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/AsyncStepsTest.java
@@ -22,17 +22,28 @@ package org.apache.opendal;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public class AsyncStepsTest {
 
+    Operator operator;
 
     @Given("A new OpenDAL Async Operator")
     public void a_new_open_dal_async_operator() {
+        Map<String, String> params = new HashMap<>();
+        params.put("root", "/tmp");
+        operator = new Operator("Memory", params);
     }
 
     @When("Async write path {string} with content {string}")
     public void async_write_path_test_with_content_hello_world(String fileName, String content) {
+        System.out.println("java: async write file " + fileName + " with content " + content);
+        CompletableFuture<Boolean> future = operator.asyncWrite(fileName, content);
+        System.out.println("java: start to wait for the future");
+        Boolean result = future.join();
+        System.out.println("java: get the result: " + result);
     }
 
     @Then("The async file {string} should exist")

--- a/bindings/java/src/test/java/org/apache/opendal/AsyncStepsTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/AsyncStepsTest.java
@@ -26,6 +26,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 public class AsyncStepsTest {
 
     Operator operator;
@@ -39,11 +41,9 @@ public class AsyncStepsTest {
 
     @When("Async write path {string} with content {string}")
     public void async_write_path_test_with_content_hello_world(String fileName, String content) {
-        System.out.println("java: async write file " + fileName + " with content " + content);
         CompletableFuture<Boolean> future = operator.asyncWrite(fileName, content);
-        System.out.println("java: start to wait for the future");
         Boolean result = future.join();
-        System.out.println("java: get the result: " + result);
+        assertTrue(result);
     }
 
     @Then("The async file {string} should exist")


### PR DESCRIPTION
link to #1572

This is a POC of bring async API for java binding, see https://github.com/apache/incubator-opendal/issues/1572#issuecomment-1519880511 for more details.

I add an `asyncWrite` function and related test for Java binding.

<img width="523" alt="image" src="https://user-images.githubusercontent.com/32436597/234193412-622f6c32-0794-4b4a-8417-68c2655abcbe.png">

As a result, `asyncWrite` will not block any Java thread and the user could collect results using `thenAccept` function of the `CompletableFuture`.

