### PR TITLE
fix(services/gcs): Fix invalid url for gcs presign

### DIFF
--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -169,12 +169,7 @@ impl GcsCore {
     ) -> Result<Request<AsyncBody>> {
         let p = build_abs_path(&self.root, path);
 
-        let url = format!(
-            "{}/{}/{}",
-            self.endpoint,
-            self.bucket,
-            percent_encode_path(&p)
-        );
+        let url = format!("{}/{}/{}", self.endpoint, self.bucket, p);
 
         let mut req = Request::get(&url);
 
@@ -322,7 +317,12 @@ impl GcsCore {
     ) -> Result<Request<AsyncBody>> {
         let p = build_abs_path(&self.root, path);
 
-        let url = format!("{}/storage/v1/b/{}/o/{}", self.endpoint, self.bucket, p);
+        let url = format!(
+            "{}/storage/v1/b/{}/o/{}",
+            self.endpoint,
+            self.bucket,
+            percent_encode_path(&p)
+        );
 
         let mut req = Request::get(&url);
 

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -287,12 +287,7 @@ impl GcsCore {
     ) -> Result<Request<AsyncBody>> {
         let p = build_abs_path(&self.root, path);
 
-        let url = format!(
-            "{}/{}/{}",
-            self.endpoint,
-            self.bucket,
-            percent_encode_path(&p)
-        );
+        let url = format!("{}/{}/{}", self.endpoint, self.bucket, p);
 
         let mut req = Request::put(&url);
 
@@ -327,12 +322,7 @@ impl GcsCore {
     ) -> Result<Request<AsyncBody>> {
         let p = build_abs_path(&self.root, path);
 
-        let url = format!(
-            "{}/storage/v1/b/{}/o/{}",
-            self.endpoint,
-            self.bucket,
-            percent_encode_path(&p)
-        );
+        let url = format!("{}/storage/v1/b/{}/o/{}", self.endpoint, self.bucket, p);
 
         let mut req = Request::get(&url);
 
@@ -360,12 +350,7 @@ impl GcsCore {
     ) -> Result<Request<AsyncBody>> {
         let p = build_abs_path(&self.root, path);
 
-        let url = format!(
-            "{}/{}/{}",
-            self.endpoint,
-            self.bucket,
-            percent_encode_path(&p)
-        );
+        let url = format!("{}/{}/{}", self.endpoint, self.bucket, p);
 
         let mut req = Request::head(&url);
 


### PR DESCRIPTION
Close #2125

The url path in presign operation will be signed and put into body part. So it shouldn't do percent encoding.