### PR TITLE
test(core): test for `read_with_override_cache_control`

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -921,6 +921,7 @@ impl Accessor for S3Backend {
                 read_can_next: true,
                 read_with_if_match: true,
                 read_with_if_none_match: true,
+                read_with_override_cache_control: true,
                 read_with_override_content_disposition: true,
 
                 write: true,


### PR DESCRIPTION
Add test for `read_with_override_cache_control`

Capability-enabled services:
- s3