### PR TITLE
refactor(layers/logging): parsing level str

### DIFF
--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -109,7 +109,7 @@ impl LoggingLayer {
     /// Rollback to default value (`Level::Warn`) when parsing fails.
     pub fn with_error_level(mut self, level: Option<&str>) -> Self {
         if let Some(level) = level {
-            let level = Level::from_str(level).map_or(Some(Level::Warn), |l| Some(l));
+            let level = Level::from_str(level).map_or(Some(Level::Warn), Some);
             self.error_level = level;
         } else {
             self.error_level = None;
@@ -125,7 +125,7 @@ impl LoggingLayer {
     /// Rollback to default value (`Level::Error`) when parsing fails.
     pub fn with_failure_level(mut self, level: Option<&str>) -> Self {
         if let Some(level) = level {
-            let level = Level::from_str(level).map_or(Some(Level::Error), |l| Some(l));
+            let level = Level::from_str(level).map_or(Some(Level::Error), Some);
             self.failure_level = level;
         } else {
             self.failure_level = None;

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -106,14 +106,14 @@ impl LoggingLayer {
     /// For example: accessor returns NotFound.
     ///
     /// `None` means disable the log for error.
-    pub fn with_error_level(mut self, level: Option<&str>) -> Self {
+    pub fn with_error_level(mut self, level: Option<&str>) -> Result<Self> {
         if let Some(level) = level {
             let level = Level::from_str(level).expect("parse level must succeed");
             self.error_level = Some(level);
         } else {
             self.error_level = None;
         }
-        self
+        Ok(self)
     }
 
     /// Setting the log level while unexpected failure happened.
@@ -121,14 +121,14 @@ impl LoggingLayer {
     /// For example: accessor returns Unexpected network error.
     ///
     /// `None` means disable the log for failure.
-    pub fn with_failure_level(mut self, level: Option<&str>) -> Self {
+    pub fn with_failure_level(mut self, level: Option<&str>) -> Result<Self> {
         if let Some(level) = level {
             let level = Level::from_str(level).expect("parse level must succeed");
             self.failure_level = Some(level);
         } else {
             self.failure_level = None;
         }
-        self
+        Ok(self)
     }
 }
 

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -106,11 +106,10 @@ impl LoggingLayer {
     /// For example: accessor returns NotFound.
     ///
     /// `None` means disable the log for error.
-    /// Rollback to default value (`Level::Warn`) when parsing fails.
     pub fn with_error_level(mut self, level: Option<&str>) -> Self {
         if let Some(level) = level {
-            let level = Level::from_str(level).map_or(Some(Level::Warn), Some);
-            self.error_level = level;
+            let level = Level::from_str(level).expect("parse level must succeed");
+            self.error_level = Some(level);
         } else {
             self.error_level = None;
         }
@@ -122,11 +121,10 @@ impl LoggingLayer {
     /// For example: accessor returns Unexpected network error.
     ///
     /// `None` means disable the log for failure.
-    /// Rollback to default value (`Level::Error`) when parsing fails.
     pub fn with_failure_level(mut self, level: Option<&str>) -> Self {
         if let Some(level) = level {
-            let level = Level::from_str(level).map_or(Some(Level::Error), Some);
-            self.failure_level = level;
+            let level = Level::from_str(level).expect("parse level must succeed");
+            self.failure_level = Some(level);
         } else {
             self.failure_level = None;
         }

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -17,6 +17,7 @@
 
 use std::fmt::Debug;
 use std::io;
+use std::str::FromStr;
 use std::task::Context;
 use std::task::Poll;
 
@@ -105,8 +106,14 @@ impl LoggingLayer {
     /// For example: accessor returns NotFound.
     ///
     /// `None` means disable the log for error.
-    pub fn with_error_level(mut self, level: Option<Level>) -> Self {
-        self.error_level = level;
+    /// Rollback to default value (`Level::Warn`) when parsing fails.
+    pub fn with_error_level(mut self, level: Option<&str>) -> Self {
+        if let Some(level) = level {
+            let level = Level::from_str(level).map_or(Some(Level::Warn), |l| Some(l));
+            self.error_level = level;
+        } else {
+            self.error_level = None;
+        }
         self
     }
 
@@ -115,8 +122,14 @@ impl LoggingLayer {
     /// For example: accessor returns Unexpected network error.
     ///
     /// `None` means disable the log for failure.
-    pub fn with_failure_level(mut self, level: Option<Level>) -> Self {
-        self.failure_level = level;
+    /// Rollback to default value (`Level::Error`) when parsing fails.
+    pub fn with_failure_level(mut self, level: Option<&str>) -> Self {
+        if let Some(level) = level {
+            let level = Level::from_str(level).map_or(Some(Level::Error), |l| Some(l));
+            self.failure_level = level;
+        } else {
+            self.failure_level = None;
+        }
         self
     }
 }

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -17,7 +17,6 @@
 
 use std::fmt::Debug;
 use std::io;
-use std::str::FromStr;
 use std::task::Context;
 use std::task::Poll;
 
@@ -107,12 +106,12 @@ impl LoggingLayer {
     ///
     /// `None` means disable the log for error.
     pub fn with_error_level(mut self, level: Option<&str>) -> Result<Self> {
-        if let Some(level) = level {
-            if let Ok(level) = Level::from_str(level) {
-                self.error_level = Some(level);
-                return Ok(self);
-            }
-            return Err(Error::new(ErrorKind::ConfigInvalid, "invalid log level"));
+        if let Some(level_str) = level {
+            let level = level_str.parse().map_err(|_| {
+                Error::new(ErrorKind::ConfigInvalid, "invalid log level")
+                    .with_context("level", level_str)
+            })?;
+            self.error_level = Some(level);
         } else {
             self.error_level = None;
         }
@@ -125,12 +124,12 @@ impl LoggingLayer {
     ///
     /// `None` means disable the log for failure.
     pub fn with_failure_level(mut self, level: Option<&str>) -> Result<Self> {
-        if let Some(level) = level {
-            if let Ok(level) = Level::from_str(level) {
-                self.failure_level = Some(level);
-                return Ok(self);
-            }
-            return Err(Error::new(ErrorKind::ConfigInvalid, "invalid log level"));
+        if let Some(level_str) = level {
+            let level = level_str.parse().map_err(|_| {
+                Error::new(ErrorKind::ConfigInvalid, "invalid log level")
+                    .with_context("level", level_str)
+            })?;
+            self.failure_level = Some(level);
         } else {
             self.failure_level = None;
         }

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -108,8 +108,11 @@ impl LoggingLayer {
     /// `None` means disable the log for error.
     pub fn with_error_level(mut self, level: Option<&str>) -> Result<Self> {
         if let Some(level) = level {
-            let level = Level::from_str(level).expect("parse level must succeed");
-            self.error_level = Some(level);
+            if let Ok(level) = Level::from_str(level) {
+                self.error_level = Some(level);
+                return Ok(self);
+            }
+            return Err(Error::new(ErrorKind::ConfigInvalid, "invalid log level"));
         } else {
             self.error_level = None;
         }
@@ -123,8 +126,11 @@ impl LoggingLayer {
     /// `None` means disable the log for failure.
     pub fn with_failure_level(mut self, level: Option<&str>) -> Result<Self> {
         if let Some(level) = level {
-            let level = Level::from_str(level).expect("parse level must succeed");
-            self.failure_level = Some(level);
+            if let Ok(level) = Level::from_str(level) {
+                self.failure_level = Some(level);
+                return Ok(self);
+            }
+            return Err(Error::new(ErrorKind::ConfigInvalid, "invalid log level"));
         } else {
             self.failure_level = None;
         }


### PR DESCRIPTION
Attempt to parse `str` as level and parse level must succeed.

fixes: #2090 