### PR TITLE
docs: fix some grammar errors in the doc of Operator

### DIFF
--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -37,7 +37,7 @@ use crate::*;
 ///
 /// We will usually do some general checks and data transformations in this layer,
 /// like normalizing path from input, checking whether the path refers to one file or one directory, and so on.
-/// Read [`concepts`][docs::concepts] for know more about [`Operator`].
+/// Read [`concepts`][docs::concepts] for more about [`Operator`].
 ///
 /// # Examples
 ///
@@ -164,7 +164,7 @@ impl Operator {
     ///
     /// Use `stat` if you:
     ///
-    /// - Want detect the outside changes of path.
+    /// - Want to detect the outside changes of path.
     /// - Don't want to read from cached metadata.
     ///
     /// You may want to use `metadata` if you are working with entries
@@ -199,7 +199,7 @@ impl Operator {
     ///
     /// Use `stat` if you:
     ///
-    /// - Want detect the outside changes of path.
+    /// - Want to detect the outside changes of path.
     /// - Don't want to read from cached metadata.
     ///
     /// You may want to use `metadata` if you are working with entries
@@ -247,7 +247,7 @@ impl Operator {
     ///
     /// You may want to use `stat`, if you:
     ///
-    /// - Want detect the outside changes of path.
+    /// - Want to detect the outside changes of path.
     /// - Don't want to read from cached metadata.
     ///
     /// # Behavior
@@ -259,8 +259,8 @@ impl Operator {
     ///
     /// ## Query already cached metadata
     ///
-    /// By query metadata with `None`, we can only query in-memory metadata
-    /// cache. In this way, we can make sure that no API call will send.
+    /// By querying metadata with `None`, we can only query in-memory metadata
+    /// cache. In this way, we can make sure that no API call will be sent.
     ///
     /// ```
     /// # use anyhow::Result;
@@ -300,7 +300,7 @@ impl Operator {
     ///
     /// ## Query all metadata
     ///
-    /// By query metadata with `Complete`, we can make sure that we have fetched all metadata of this entry.
+    /// By querying metadata with `Complete`, we can make sure that we have fetched all metadata of this entry.
     ///
     /// ```
     /// # use anyhow::Result;
@@ -656,7 +656,7 @@ impl Operator {
     ///
     /// - `from` and `to` must be a file.
     /// - `to` will be overwritten if it exists.
-    /// - If `from` and `to` are the same,  a `IsSameFile` error will occur.
+    /// - If `from` and `to` are the same,  an `IsSameFile` error will occur.
     /// - `copy` is idempotent. For same `from` and `to` input, the result will be the same.
     ///
     /// # Examples
@@ -715,7 +715,7 @@ impl Operator {
     ///
     /// - `from` and `to` must be a file.
     /// - `to` will be overwritten if it exists.
-    /// - If `from` and `to` are the same, a `IsSameFile` error will occur.
+    /// - If `from` and `to` are the same, an `IsSameFile` error will occur.
     ///
     /// # Examples
     ///
@@ -881,7 +881,7 @@ impl Operator {
     ///
     /// # Notes
     ///
-    /// - Delete not existing error won't return errors.
+    /// - Deleting a file that does not exist won't return errors.
     ///
     /// # Examples
     ///
@@ -927,9 +927,9 @@ impl Operator {
         self.remove_via(stream::iter(paths)).await
     }
 
-    /// remove will given paths.
-
-    /// remove_via will remove files via given stream.
+    /// remove will remove files via the given paths.
+    ///
+    /// remove_via will remove files via the given stream.
     ///
     /// We will delete by chunks with given batch limit on the stream.
     ///


### PR DESCRIPTION
## What does this PR do
* Fix some grammar errors in the documentation of `Operator`.

-----
Playing with the `Operator` type and I found some documents were a little bit confusing, so here comes the patch