### PR TITLE
ci: use Temurin JDK 11 to build the bindings-java

### DIFF
--- a/.github/workflows/bindings_java.yml
+++ b/.github/workflows/bindings_java.yml
@@ -43,11 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
-          java-version: '8'
+          distribution: 'temurin'
+          java-version: '11'
           cache: 'maven'
       - name: Build with Maven
         run: mvn test --file ${{ github.workspace }}/bindings/java/pom.xml


### PR DESCRIPTION
### Motivation

I notice that we use Temurin JDK 11 in the `publish.yml` workflow, and use the Zulu JDK 8 in the `bindings_java.yml` workflow, I suggest that we unify the JDK version.

### Changes

- Switch the JDK distribution from Zulu to Temurin
- Use the different version of JDK to build the `bindings-java` module


