### PR TITLE
refactor: Replace futures::ready with std::task::ready

### DIFF
--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -19,6 +19,7 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::io;
 use std::pin::Pin;
+use std::task::ready;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
@@ -30,7 +31,6 @@ use backon::ExponentialBackoff;
 use backon::ExponentialBuilder;
 use backon::Retryable;
 use bytes::Bytes;
-use futures::ready;
 use futures::FutureExt;
 use log::warn;
 

--- a/core/src/raw/http_util/body.rs
+++ b/core/src/raw/http_util/body.rs
@@ -18,13 +18,13 @@
 use std::cmp::min;
 use std::cmp::Ordering;
 use std::io;
+use std::task::ready;
 use std::task::Context;
 use std::task::Poll;
 
 use bytes::Buf;
 use bytes::BufMut;
 use bytes::Bytes;
-use futures::ready;
 use futures::Stream;
 use futures::StreamExt;
 

--- a/core/src/raw/oio/into_reader/by_range.rs
+++ b/core/src/raw/oio/into_reader/by_range.rs
@@ -20,11 +20,11 @@ use std::future::Future;
 use std::io::SeekFrom;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::ready;
 use std::task::Context;
 use std::task::Poll;
 
 use futures::future::BoxFuture;
-use futures::ready;
 use tokio::io::ReadBuf;
 
 use crate::ops::*;

--- a/core/src/raw/oio/into_reader/from_fd.rs
+++ b/core/src/raw/oio/into_reader/from_fd.rs
@@ -18,10 +18,10 @@
 use std::cmp;
 use std::io::SeekFrom;
 use std::pin::Pin;
+use std::task::ready;
 use std::task::Context;
 use std::task::Poll;
 
-use futures::ready;
 use futures::AsyncRead;
 use futures::AsyncSeek;
 

--- a/core/src/raw/oio/into_streamable.rs
+++ b/core/src/raw/oio/into_streamable.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::io::SeekFrom;
+use std::task::ready;
 use std::task::Context;
 use std::task::Poll;
 
 use bytes::Bytes;
-use futures::ready;
 use tokio::io::ReadBuf;
 
 use crate::raw::*;

--- a/core/src/services/ftp/util.rs
+++ b/core/src/services/ftp/util.rs
@@ -17,12 +17,12 @@
 
 use std::io;
 use std::pin::Pin;
+use std::task::ready;
 use std::task::Context;
 use std::task::Poll;
 
 use bb8::PooledConnection;
 use futures::future::BoxFuture;
-use futures::ready;
 use futures::AsyncRead;
 use futures::FutureExt;
 use suppaftp::Status;

--- a/core/src/types/list.rs
+++ b/core/src/types/list.rs
@@ -18,11 +18,11 @@
 use std::collections::VecDeque;
 use std::mem;
 use std::pin::Pin;
+use std::task::ready;
 use std::task::Context;
 use std::task::Poll;
 
 use futures::future::BoxFuture;
-use futures::ready;
 use futures::FutureExt;
 use futures::Stream;
 

--- a/core/src/types/reader.rs
+++ b/core/src/types/reader.rs
@@ -17,11 +17,11 @@
 
 use std::io;
 use std::pin::Pin;
+use std::task::ready;
 use std::task::Context;
 use std::task::Poll;
 
 use bytes::Bytes;
-use futures::ready;
 use futures::AsyncRead;
 use futures::AsyncSeek;
 use futures::Stream;

--- a/core/src/types/writer.rs
+++ b/core/src/types/writer.rs
@@ -18,12 +18,12 @@
 use std::fmt::Display;
 use std::io;
 use std::pin::Pin;
+use std::task::ready;
 use std::task::Context;
 use std::task::Poll;
 
 use bytes::Bytes;
 use futures::future::BoxFuture;
-use futures::ready;
 use futures::AsyncWrite;
 use futures::FutureExt;
 


### PR DESCRIPTION
We could use `std::task::ready` stabilized at 1.64 as `opendal`'s msrv is 1.64.