### PR TITLE
feat: Add typed kv adapter and migrate moka to it

### DIFF
--- a/core/benches/ops/utils.rs
+++ b/core/benches/ops/utils.rs
@@ -45,6 +45,8 @@ pub fn services() -> Vec<(&'static str, Option<Operator>)> {
         ("fs", service::<services::Fs>()),
         ("s3", service::<services::S3>()),
         ("memory", service::<services::Memory>()),
+        #[cfg(feature = "services-moka")]
+        ("moka", service::<services::Moka>()),
     ]
 }
 

--- a/core/src/raw/adapters/kv/mod.rs
+++ b/core/src/raw/adapters/kv/mod.rs
@@ -18,12 +18,6 @@
 //! Providing Key Value Adapter for OpenDAL.
 //!
 //! Any services that implement `Adapter` can be used an OpenDAL Service.
-//!
-//! # Notes
-//!
-//! This adapter creates a new storage format which is not stable.
-//!
-//! Any service that built upon this adapter should not be persisted.
 
 mod api;
 pub use api::Adapter;

--- a/core/src/raw/adapters/typed_kv/api.rs
+++ b/core/src/raw/adapters/typed_kv/api.rs
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::{fmt::Debug, mem::size_of};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use chrono::Utc;
+
+use crate::*;
+
+/// Adapter is the typed adapter to underlying kv services.
+///
+/// By implement this trait, any kv service can work as an OpenDAL Service.
+///
+/// # Notes
+///
+/// `typed_kv::Adapter` is the typed version of `kv::Adapter`. It's more
+/// efficient if the uderlying kv service can store data with its type. For
+/// example, we can store `Bytes` along with it's metadata so that we don't
+/// need to serialize/deserialize it when we get it from the service.
+///
+/// Ideally, we should use `typed_kv::Adapter` instead of `kv::Adapter` for
+/// in-memory rust libs like moka and dashmap.
+#[async_trait]
+pub trait Adapter: Send + Sync + Debug + Unpin + 'static {
+    /// Get the scheme and name of current adapter.
+    fn metadata(&self) -> (Scheme, String);
+
+    /// Get a value from adapter.
+    async fn get(&self, path: &str) -> Result<Option<Value>>;
+
+    /// Get a value from adapter.
+    fn blocking_get(&self, path: &str) -> Result<Option<Value>>;
+
+    /// Set a value into adapter.
+    async fn set(&self, path: &str, value: Value) -> Result<()>;
+
+    /// Set a value into adapter.
+    fn blocking_set(&self, path: &str, value: Value) -> Result<()>;
+
+    /// Delete a value from adapter.
+    async fn delete(&self, path: &str) -> Result<()>;
+
+    /// Delete a value from adapter.
+    fn blocking_delete(&self, path: &str) -> Result<()>;
+}
+
+/// Value is the typed value stored in adapter.
+///
+/// It's cheap to clone so that users can read data without extra copy.
+#[derive(Debug, Clone)]
+pub struct Value {
+    /// Metadata of this value.
+    pub metadata: Metadata,
+    /// The correbonding content of this value.
+    pub value: Bytes,
+}
+
+impl Value {
+    /// Create a new dir of value.
+    pub fn new_dir() -> Self {
+        Self {
+            metadata: Metadata::new(EntryMode::DIR)
+                .with_content_length(0)
+                .with_last_modified(Utc::now()),
+            value: Bytes::new(),
+        }
+    }
+
+    /// Size returns the in-memory size of Value.
+    pub fn size(&self) -> usize {
+        size_of::<Metadata>() + self.value.len()
+    }
+}

--- a/core/src/raw/adapters/typed_kv/backend.rs
+++ b/core/src/raw/adapters/typed_kv/backend.rs
@@ -1,0 +1,282 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use super::Adapter;
+use super::Value;
+use crate::ops::*;
+use crate::raw::oio::VectorCursor;
+use crate::raw::*;
+use crate::*;
+
+/// The typed kv backend which implmenets Accessor for for typed kv adapter.
+#[derive(Debug, Clone)]
+pub struct Backend<S: Adapter> {
+    kv: Arc<S>,
+    root: String,
+}
+
+impl<S> Backend<S>
+where
+    S: Adapter,
+{
+    /// Create a new kv backend.
+    pub fn new(kv: S) -> Self {
+        Self {
+            kv: Arc::new(kv),
+            root: "/".to_string(),
+        }
+    }
+
+    /// Configure root within this backend.
+    pub fn with_root(mut self, root: &str) -> Self {
+        self.root = normalize_root(root);
+        self
+    }
+}
+
+#[async_trait]
+impl<S: Adapter> Accessor for Backend<S> {
+    type Reader = oio::Cursor;
+    type BlockingReader = oio::Cursor;
+    type Writer = KvWriter<S>;
+    type BlockingWriter = KvWriter<S>;
+    type Pager = ();
+    type BlockingPager = ();
+
+    fn info(&self) -> AccessorInfo {
+        let (scheme, name) = self.kv.metadata();
+
+        let mut am = AccessorInfo::default();
+        am.set_scheme(scheme);
+        am.set_name(&name);
+        am.set_root(&self.root);
+
+        let cap = am.capability_mut();
+        cap.read = true;
+        cap.read_can_seek = true;
+        cap.read_can_next = true;
+        cap.read_with_range = true;
+        cap.stat = true;
+
+        cap.write = true;
+        cap.write_with_cache_control = true;
+        cap.write_with_content_disposition = true;
+        cap.write_with_content_type = true;
+        cap.write_without_content_length = true;
+        cap.create_dir = true;
+        cap.delete = true;
+
+        am
+    }
+
+    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+        let p = build_abs_path(&self.root, path);
+        self.kv.set(&p, Value::new_dir()).await?;
+        Ok(RpCreate::default())
+    }
+
+    fn blocking_create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+        let p = build_abs_path(&self.root, path);
+        self.kv.blocking_set(&p, Value::new_dir())?;
+
+        Ok(RpCreate::default())
+    }
+
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        let p = build_abs_path(&self.root, path);
+
+        let bs = match self.kv.get(&p).await? {
+            // TODO: we can reuse the metadata in value to build content range.
+            Some(bs) => bs.value,
+            None => return Err(Error::new(ErrorKind::NotFound, "kv doesn't have this path")),
+        };
+
+        let bs = self.apply_range(bs, args.range());
+
+        let length = bs.len();
+        Ok((RpRead::new(length as u64), oio::Cursor::from(bs)))
+    }
+
+    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
+        let p = build_abs_path(&self.root, path);
+
+        let bs = match self.kv.blocking_get(&p)? {
+            // TODO: we can reuse the metadata in value to build content range.
+            Some(bs) => bs.value,
+            None => return Err(Error::new(ErrorKind::NotFound, "kv doesn't have this path")),
+        };
+
+        let bs = self.apply_range(bs, args.range());
+        Ok((RpRead::new(bs.len() as u64), oio::Cursor::from(bs)))
+    }
+
+    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
+        let p = build_abs_path(&self.root, path);
+
+        Ok((RpWrite::new(), KvWriter::new(self.kv.clone(), p, args)))
+    }
+
+    fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
+        let p = build_abs_path(&self.root, path);
+
+        Ok((RpWrite::new(), KvWriter::new(self.kv.clone(), p, args)))
+    }
+
+    async fn stat(&self, path: &str, _: OpStat) -> Result<RpStat> {
+        let p = build_abs_path(&self.root, path);
+
+        if p.is_empty() || p.ends_with('/') {
+            Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
+        } else {
+            let bs = self.kv.get(&p).await?;
+            match bs {
+                Some(bs) => Ok(RpStat::new(bs.metadata)),
+                None => Err(Error::new(ErrorKind::NotFound, "kv doesn't have this path")),
+            }
+        }
+    }
+
+    fn blocking_stat(&self, path: &str, _: OpStat) -> Result<RpStat> {
+        let p = build_abs_path(&self.root, path);
+
+        if p.is_empty() || p.ends_with('/') {
+            Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
+        } else {
+            let bs = self.kv.blocking_get(&p)?;
+            match bs {
+                Some(bs) => Ok(RpStat::new(bs.metadata)),
+                None => Err(Error::new(ErrorKind::NotFound, "kv doesn't have this path")),
+            }
+        }
+    }
+
+    async fn delete(&self, path: &str, _: OpDelete) -> Result<RpDelete> {
+        let p = build_abs_path(&self.root, path);
+
+        self.kv.delete(&p).await?;
+        Ok(RpDelete::default())
+    }
+
+    fn blocking_delete(&self, path: &str, _: OpDelete) -> Result<RpDelete> {
+        let p = build_abs_path(&self.root, path);
+
+        self.kv.blocking_delete(&p)?;
+        Ok(RpDelete::default())
+    }
+}
+
+impl<S> Backend<S>
+where
+    S: Adapter,
+{
+    fn apply_range(&self, mut bs: Bytes, br: BytesRange) -> Bytes {
+        match (br.offset(), br.size()) {
+            (Some(offset), Some(size)) => {
+                let mut bs = bs.split_off(offset as usize);
+                if (size as usize) < bs.len() {
+                    let _ = bs.split_off(size as usize);
+                }
+                bs
+            }
+            (Some(offset), None) => bs.split_off(offset as usize),
+            (None, Some(size)) => bs.split_off(bs.len() - size as usize),
+            (None, None) => bs,
+        }
+    }
+}
+
+pub struct KvWriter<S> {
+    kv: Arc<S>,
+    path: String,
+
+    op: OpWrite,
+    buf: VectorCursor,
+}
+
+impl<S> KvWriter<S> {
+    fn new(kv: Arc<S>, path: String, op: OpWrite) -> Self {
+        KvWriter {
+            kv,
+            path,
+            op,
+            buf: VectorCursor::new(),
+        }
+    }
+
+    fn build(&self) -> Value {
+        let mut metadata = Metadata::new(EntryMode::FILE);
+        if let Some(v) = self.op.cache_control() {
+            metadata.set_cache_control(v);
+        }
+        if let Some(v) = self.op.content_disposition() {
+            metadata.set_content_disposition(v);
+        }
+        if let Some(v) = self.op.content_type() {
+            metadata.set_content_type(v);
+        }
+        if let Some(v) = self.op.content_length() {
+            metadata.set_content_length(v);
+        } else {
+            metadata.set_content_length(self.buf.len() as u64);
+        }
+
+        Value {
+            metadata,
+            value: self.buf.peak_all(),
+        }
+    }
+}
+
+#[async_trait]
+impl<S: Adapter> oio::Write for KvWriter<S> {
+    // TODO: we need to support append in the future.
+    async fn write(&mut self, bs: Bytes) -> Result<()> {
+        self.buf.push(bs);
+
+        Ok(())
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        self.buf.clear();
+
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.kv.set(&self.path, self.build()).await?;
+        Ok(())
+    }
+}
+
+impl<S: Adapter> oio::BlockingWrite for KvWriter<S> {
+    fn write(&mut self, bs: Bytes) -> Result<()> {
+        self.buf.push(bs);
+
+        Ok(())
+    }
+
+    fn close(&mut self) -> Result<()> {
+        self.kv.blocking_set(&self.path, self.build())?;
+
+        Ok(())
+    }
+}

--- a/core/src/raw/adapters/typed_kv/backend.rs
+++ b/core/src/raw/adapters/typed_kv/backend.rs
@@ -27,7 +27,7 @@ use crate::raw::oio::VectorCursor;
 use crate::raw::*;
 use crate::*;
 
-/// The typed kv backend which implmenets Accessor for for typed kv adapter.
+/// The typed kv backend which implements Accessor for for typed kv adapter.
 #[derive(Debug, Clone)]
 pub struct Backend<S: Adapter> {
     kv: Arc<S>,

--- a/core/src/raw/adapters/typed_kv/mod.rs
+++ b/core/src/raw/adapters/typed_kv/mod.rs
@@ -15,35 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Providing adapters and its implementations.
+//! Providing Typed Key Value Adapter for OpenDAL.
 //!
-//! Adapters in OpenDAL means services that shares similar behaviors. We use
-//! adapter to make those services been implemented more easily. For example,
-//! with [`kv::Adapter`], users only need to implement `get`, `set` for a service.
-//!
-//! # Notes
-//!
-//! Please import the module instead of its type.
-//!
-//! For example, use the following:
-//!
-//! ```ignore
-//! use opendal::adapters::kv;
-//!
-//! impl kv::Adapter for MyType {}
-//! ```
-//!
-//! Instead of:
-//!
-//! ```ignore
-//! use opendal::adapters::kv::Adapter;
-//!
-//! impl Adapter for MyType {}
-//! ```
-//!
-//! # Available Adapters
-//!
-//! - [`kv::Adapter`]: Adapter for Key Value Services like in-memory map, `redis`.
+//! Any services that implement `Adapter` can be used an OpenDAL Service.
 
-pub mod kv;
-pub mod typed_kv;
+mod api;
+pub use api::Adapter;
+pub use api::Value;
+
+mod backend;
+pub use backend::Backend;

--- a/core/src/raw/oio/cursor.rs
+++ b/core/src/raw/oio/cursor.rs
@@ -47,6 +47,12 @@ impl Cursor {
     }
 }
 
+impl From<Bytes> for Cursor {
+    fn from(v: Bytes) -> Self {
+        Cursor { inner: v, pos: 0 }
+    }
+}
+
 impl From<Vec<u8>> for Cursor {
     fn from(v: Vec<u8>) -> Self {
         Cursor {
@@ -255,6 +261,21 @@ impl VectorCursor {
             let len = b.len().min(n);
             bs.extend_from_slice(&b[..len]);
             n -= len;
+        }
+        bs.freeze()
+    }
+
+    /// peak all will read and copy all bytes from current cursor
+    /// without change it's content.
+    pub fn peak_all(&self) -> Bytes {
+        // Avoid data copy if we only have one bytes.
+        if self.inner.len() == 1 {
+            return self.inner[0].clone();
+        }
+
+        let mut bs = BytesMut::with_capacity(self.len());
+        for b in &self.inner {
+            bs.extend_from_slice(b);
         }
         bs.freeze()
     }


### PR DESCRIPTION
This PR will close https://github.com/apache/incubator-opendal/issues/1392.

By adding a new typed kv adapter, we can store metadata and bytes in rust containers like moka, dashmap, and avoid the extra cost of ser/de the bytes.

This PR will improve the read perf of `moka` at 1500%, and write perf at 160000% (the best case).

Read Before:

```rust
service_moka_read_full/4.00 KiB
                        time:   [3.1231 µs 3.1270 µs 3.1312 µs]
                        thrpt:  [1.2183 GiB/s 1.2199 GiB/s 1.2214 GiB/s]
service_moka_read_full/256 KiB
                        time:   [67.995 µs 68.043 µs 68.094 µs]
                        thrpt:  [3.5853 GiB/s 3.5881 GiB/s 3.5906 GiB/s]
service_moka_read_full/4.00 MiB
                        time:   [127.98 µs 128.19 µs 128.43 µs]
                        thrpt:  [30.415 GiB/s 30.473 GiB/s 30.522 GiB/s]
service_moka_read_full/16.0 MiB
                        time:   [731.54 µs 736.31 µs 741.73 µs]
                        thrpt:  [21.066 GiB/s 21.221 GiB/s 21.359 GiB/s]

service_moka_read_part/4.00 KiB
                        time:   [1.8117 µs 1.8238 µs 1.8349 µs]
                        thrpt:  [2.0790 GiB/s 2.0916 GiB/s 2.1056 GiB/s]
service_moka_read_part/256 KiB
                        time:   [24.402 µs 24.425 µs 24.449 µs]
                        thrpt:  [9.9856 GiB/s 9.9953 GiB/s 10.005 GiB/s]
service_moka_read_part/4.00 MiB
                        time:   [342.33 µs 342.99 µs 343.77 µs]
                        thrpt:  [11.363 GiB/s 11.389 GiB/s 11.411 GiB/s]
service_moka_read_part/16.0 MiB
                        time:   [6.1593 ms 6.1756 ms 6.1953 ms]
                        thrpt:  [2.5221 GiB/s 2.5301 GiB/s 2.5368 GiB/s]
```

Read After

```rust
service_moka_read_full/4.00 KiB
                        time:   [1.2101 µs 1.2125 µs 1.2151 µs]
                        thrpt:  [3.1394 GiB/s 3.1460 GiB/s 3.1525 GiB/s]
                 change:
                        time:   [-61.435% -61.358% -61.273%] (p = 0.00 < 0.05)
                        thrpt:  [+158.22% +158.79% +159.30%]
                        Performance has improved.
service_moka_read_full/256 KiB
                        time:   [5.4017 µs 5.4343 µs 5.4911 µs]
                        thrpt:  [44.462 GiB/s 44.926 GiB/s 45.197 GiB/s]
                 change:
                        time:   [-92.017% -91.914% -91.805%] (p = 0.00 < 0.05)
                        thrpt:  [+1120.2% +1136.7% +1152.6%]
                        Performance has improved.
service_moka_read_full/4.00 MiB
                        time:   [69.694 µs 71.709 µs 73.882 µs]
                        thrpt:  [52.872 GiB/s 54.474 GiB/s 56.049 GiB/s]
                 change:
                        time:   [-46.655% -45.354% -44.136%] (p = 0.00 < 0.05)
                        thrpt:  [+79.005% +82.995% +87.460%]
                        Performance has improved.
service_moka_read_full/16.0 MiB
                        time:   [225.82 µs 226.70 µs 227.88 µs]
                        thrpt:  [68.568 GiB/s 68.923 GiB/s 69.191 GiB/s]
                 change:
                        time:   [-69.957% -69.431% -68.914%] (p = 0.00 < 0.05)
                        thrpt:  [+221.69% +227.13% +232.86%]
                        Performance has improved.

service_moka_read_part/4.00 KiB
                        time:   [1.6380 µs 1.6405 µs 1.6434 µs]
                        thrpt:  [2.3212 GiB/s 2.3254 GiB/s 2.3289 GiB/s]
                 change:
                        time:   [-9.5756% -9.2733% -8.9819%] (p = 0.00 < 0.05)
                        thrpt:  [+9.8682% +10.221% +10.590%]
                        Performance has improved.
service_moka_read_part/256 KiB
                        time:   [6.0927 µs 6.1006 µs 6.1091 µs]
                        thrpt:  [39.964 GiB/s 40.019 GiB/s 40.071 GiB/s]
                 change:
                        time:   [-75.077% -75.015% -74.957%] (p = 0.00 < 0.05)
                        thrpt:  [+299.31% +300.24% +301.23%]
                        Performance has improved.
service_moka_read_part/4.00 MiB
                        time:   [95.818 µs 95.949 µs 96.095 µs]
                        thrpt:  [40.650 GiB/s 40.712 GiB/s 40.767 GiB/s]
                 change:
                        time:   [-72.177% -71.859% -71.610%] (p = 0.00 < 0.05)
                        thrpt:  [+252.23% +255.35% +259.41%]
                        Performance has improved.
service_moka_read_part/16.0 MiB
                        time:   [375.72 µs 378.70 µs 381.96 µs]
                        thrpt:  [40.908 GiB/s 41.260 GiB/s 41.586 GiB/s]
                 change:
                        time:   [-93.900% -93.826% -93.745%] (p = 0.00 < 0.05)
                        thrpt:  [+1498.6% +1519.8% +1539.4%]
                        Performance has improved.
```

Write before:

```rust
service_moka_write_once/4.00 KiB
                        time:   [2.4354 µs 2.4410 µs 2.4477 µs]
                        thrpt:  [1.5585 GiB/s 1.5628 GiB/s 1.5664 GiB/s]
service_moka_write_once/256 KiB
                        time:   [117.32 µs 117.43 µs 117.54 µs]
                        thrpt:  [2.0770 GiB/s 2.0791 GiB/s 2.0811 GiB/s]
service_moka_write_once/4.00 MiB
                        time:   [223.68 µs 225.31 µs 227.32 µs]
                        thrpt:  [17.184 GiB/s 17.337 GiB/s 17.464 GiB/s]
service_moka_write_once/16.0 MiB
                        time:   [3.1602 ms 3.2230 ms 3.2908 ms]
                        thrpt:  [4.7481 GiB/s 4.8480 GiB/s 4.9443 GiB/s]
```

Write after:

```rust
service_moka_write_once/4.00 KiB
                        time:   [1.4844 µs 1.4906 µs 1.4977 µs]
                        thrpt:  [2.5470 GiB/s 2.5592 GiB/s 2.5699 GiB/s]
                 change:
                        time:   [-38.877% -38.651% -38.452%] (p = 0.00 < 0.05)
                        thrpt:  [+62.474% +63.001% +63.605%]
                        Performance has improved.
service_moka_write_once/256 KiB
                        time:   [1.9958 µs 2.0072 µs 2.0204 µs]
                        thrpt:  [120.84 GiB/s 121.63 GiB/s 122.33 GiB/s]
                 change:
                        time:   [-98.297% -98.288% -98.280%] (p = 0.00 < 0.05)
                        thrpt:  [+5714.8% +5742.7% +5772.0%]
                        Performance has improved.
service_moka_write_once/4.00 MiB
                        time:   [1.9519 µs 1.9536 µs 1.9560 µs]
                        thrpt:  [1997.1 GiB/s 1999.5 GiB/s 2001.3 GiB/s]
                 change:
                        time:   [-99.128% -99.122% -99.117%] (p = 0.00 < 0.05)
                        thrpt:  [+11227% +11292% +11362%]
                        Performance has improved.
service_moka_write_once/16.0 MiB
                        time:   [1.9317 µs 1.9340 µs 1.9373 µs]
                        thrpt:  [8065.2 GiB/s 8079.1 GiB/s 8088.7 GiB/s]
                 change:
                        time:   [-99.941% -99.940% -99.939%] (p = 0.00 < 0.05)
                        thrpt:  [+163072% +166323% +169800%]
                        Performance has improved.
```