### PR TITLE
fix(tests): Etag must be wrapped by `"`

### DIFF
--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -82,7 +82,7 @@ impl Operator {
             .info()
             .capability()
             .batch_max_operations
-            .unwrap_or(1000);
+            .unwrap_or(100);
         Self { accessor, limit }
     }
 

--- a/core/tests/behavior/write.rs
+++ b/core/tests/behavior/write.rs
@@ -344,7 +344,7 @@ pub async fn test_stat_with_if_match(op: Operator) -> Result<()> {
     assert_eq!(meta.content_length(), size as u64);
 
     let mut op_stat = OpStat::default();
-    op_stat = op_stat.with_if_match("invalid_etag");
+    op_stat = op_stat.with_if_match("\"invalid_etag\"");
 
     let res = op.stat_with(&path, op_stat).await;
     assert!(res.is_err());
@@ -386,7 +386,7 @@ pub async fn test_stat_with_if_none_match(op: Operator) -> Result<()> {
     assert_eq!(res.unwrap_err().kind(), ErrorKind::ConditionNotMatch);
 
     let mut op_stat = OpStat::default();
-    op_stat = op_stat.with_if_none_match("invalid_etag");
+    op_stat = op_stat.with_if_none_match("\"invalid_etag\"");
 
     let res = op.stat_with(&path, op_stat).await?;
     assert_eq!(res.mode(), meta.mode());
@@ -621,7 +621,7 @@ pub async fn test_read_with_if_match(op: Operator) -> Result<()> {
     let meta = op.stat(&path).await?;
 
     let mut op_read = OpRead::default();
-    op_read = op_read.with_if_match("invalid_etag");
+    op_read = op_read.with_if_match("\"invalid_etag\"");
 
     let res = op.read_with(&path, op_read).await;
     assert!(res.is_err());
@@ -664,7 +664,7 @@ pub async fn test_read_with_if_none_match(op: Operator) -> Result<()> {
     assert_eq!(res.unwrap_err().kind(), ErrorKind::ConditionNotMatch);
 
     let mut op_read = OpRead::default();
-    op_read = op_read.with_if_none_match("invalid_etag");
+    op_read = op_read.with_if_none_match("\"invalid_etag\"");
 
     let bs = op
         .read_with(&path, op_read)


### PR DESCRIPTION
R2 has strong requirement for Etag:

```shell
[2023-05-07T17:34:30Z ERROR opendal::services] service=s3 operation=read path=df189c54-4664-433d-9c85-ed8f830f55cf range=0- -> failed: Unexpected (permanent) at read => S3Error { code: "InvalidArgument", message: "Invalid Argument: If-Match each ETag must be surrounded by double quotes, got 'invalid_etag'.", resource: "", request_id: "" }
    
    Context:
        response: Parts { status: 400, version: HTTP/1.1, headers: {"date": "Sun, 07 May 2023 17:34:30 GMT", "content-type": "application/xml", "content-length": "203", "connection": "keep-alive", "server": "cloudflare", "cf-ray": "7c3b36ce3b1bc729-SEA"} }
        service: s3
        path: df189c54-4664-433d-9c85-ed8f830f55cf
        range: 0-
```