### PR TITLE
refactor: Use list without delimiter to replace scan

### DIFF
--- a/core/src/layers/chaos.rs
+++ b/core/src/layers/chaos.rs
@@ -139,16 +139,8 @@ impl<A: Accessor> LayeredAccessor for ChaosAccessor<A> {
         self.inner.list(path, args).await
     }
 
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        self.inner.scan(path, args).await
-    }
-
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         self.inner.blocking_list(path, args)
-    }
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        self.inner.blocking_scan(path, args)
     }
 }
 

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -225,23 +225,48 @@ impl<A: Accessor> CompleteReaderAccessor<A> {
         path: &str,
         args: OpList,
     ) -> Result<(RpList, CompletePager<A, A::Pager>)> {
-        let capability = self.meta.capability();
-        let (can_list, can_scan) = (capability.list, capability.scan);
-
-        if can_list {
-            let (rp, p) = self.inner.list(path, args).await?;
-            Ok((rp, CompletePager::AlreadyComplete(p)))
-        } else if can_scan {
-            let (_, p) = self.inner.scan(path, OpScan::new()).await?;
-            let p = to_hierarchy_pager(p, path);
-            Ok((RpList::default(), CompletePager::NeedHierarchy(p)))
-        } else {
-            Err(
+        let cap = self.meta.capability();
+        if !cap.list {
+            return Err(
                 Error::new(ErrorKind::Unsupported, "operation is not supported")
                     .with_context("service", self.meta.scheme())
                     .with_operation("list"),
-            )
+            );
         }
+
+        let delimiter = args.delimiter();
+
+        if delimiter.is_empty() {
+            return if cap.list_without_delimiter {
+                let (rp, p) = self.inner.list(path, args).await?;
+                Ok((rp, CompletePager::AlreadyComplete(p)))
+            } else {
+                let p = to_flat_pager(
+                    self.inner.clone(),
+                    path,
+                    args.with_delimiter("/").limit().unwrap_or(1000),
+                );
+                Ok((RpList::default(), CompletePager::NeedFlat(p)))
+            };
+        }
+
+        if delimiter == "/" {
+            return if cap.list_with_delimiter_slash {
+                let (rp, p) = self.inner.list(path, args).await?;
+                Ok((rp, CompletePager::AlreadyComplete(p)))
+            } else {
+                let (_, p) = self.inner.list(path, args.with_delimiter("")).await?;
+                let p = to_hierarchy_pager(p, path);
+                Ok((RpList::default(), CompletePager::NeedHierarchy(p)))
+            };
+        }
+
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "list with other delimiter is not supported",
+        )
+        .with_context("service", self.meta.scheme())
+        .with_context("delimiter", delimiter))
     }
 
     fn complete_blocking_list(
@@ -249,69 +274,49 @@ impl<A: Accessor> CompleteReaderAccessor<A> {
         path: &str,
         args: OpList,
     ) -> Result<(RpList, CompletePager<A, A::BlockingPager>)> {
-        let capability = self.meta.capability();
-        let (can_list, can_scan) = (capability.list, capability.scan);
-
-        if can_list {
-            let (rp, p) = self.inner.blocking_list(path, args)?;
-            Ok((rp, CompletePager::AlreadyComplete(p)))
-        } else if can_scan {
-            let (_, p) = self.inner.blocking_scan(path, OpScan::new())?;
-            let p = to_hierarchy_pager(p, path);
-            Ok((RpList::default(), CompletePager::NeedHierarchy(p)))
-        } else {
-            Err(
+        let cap = self.meta.capability();
+        if !cap.list {
+            return Err(
                 Error::new(ErrorKind::Unsupported, "operation is not supported")
                     .with_context("service", self.meta.scheme())
                     .with_operation("list"),
-            )
+            );
         }
-    }
 
-    async fn complete_scan(
-        &self,
-        path: &str,
-        args: OpScan,
-    ) -> Result<(RpScan, CompletePager<A, A::Pager>)> {
-        let capability = self.meta.capability();
-        let (can_list, can_scan) = (capability.list, capability.scan);
+        let delimiter = args.delimiter();
 
-        if can_scan {
-            let (rp, p) = self.inner.scan(path, args).await?;
-            Ok((rp, CompletePager::AlreadyComplete(p)))
-        } else if can_list {
-            let p = to_flat_pager(self.inner.clone(), path, args.limit().unwrap_or(1000));
-            Ok((RpScan::default(), CompletePager::NeedFlat(p)))
-        } else {
-            Err(
-                Error::new(ErrorKind::Unsupported, "operation is not supported")
-                    .with_context("service", self.meta.scheme())
-                    .with_operation("scan"),
-            )
+        if delimiter.is_empty() {
+            return if cap.list_without_delimiter {
+                let (rp, p) = self.inner.blocking_list(path, args)?;
+                Ok((rp, CompletePager::AlreadyComplete(p)))
+            } else {
+                let p = to_flat_pager(
+                    self.inner.clone(),
+                    path,
+                    args.with_delimiter("/").limit().unwrap_or(1000),
+                );
+                Ok((RpList::default(), CompletePager::NeedFlat(p)))
+            };
         }
-    }
 
-    fn complete_blocking_scan(
-        &self,
-        path: &str,
-        args: OpScan,
-    ) -> Result<(RpScan, CompletePager<A, A::BlockingPager>)> {
-        let capability = self.meta.capability();
-        let (can_list, can_scan) = (capability.list, capability.scan);
-
-        if can_scan {
-            let (rp, p) = self.inner.blocking_scan(path, args)?;
-            Ok((rp, CompletePager::AlreadyComplete(p)))
-        } else if can_list {
-            let p = to_flat_pager(self.inner.clone(), path, args.limit().unwrap_or(1000));
-            Ok((RpScan::default(), CompletePager::NeedFlat(p)))
-        } else {
-            Err(
-                Error::new(ErrorKind::Unsupported, "operation is not supported")
-                    .with_context("service", self.meta.scheme())
-                    .with_operation("scan"),
-            )
+        if delimiter == "/" {
+            return if cap.list_with_delimiter_slash {
+                let (rp, p) = self.inner.blocking_list(path, args)?;
+                Ok((rp, CompletePager::AlreadyComplete(p)))
+            } else {
+                let (_, p) = self.inner.blocking_list(path, args.with_delimiter(""))?;
+                let p: ToHierarchyPager<<A as Accessor>::BlockingPager> =
+                    to_hierarchy_pager(p, path);
+                Ok((RpList::default(), CompletePager::NeedHierarchy(p)))
+            };
         }
+
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "list with other delimiter is not supported",
+        )
+        .with_context("service", self.meta.scheme())
+        .with_context("delimiter", delimiter))
     }
 }
 
@@ -376,14 +381,6 @@ impl<A: Accessor> LayeredAccessor for CompleteReaderAccessor<A> {
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         self.complete_blocking_list(path, args)
-    }
-
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        self.complete_scan(path, args).await
-    }
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        self.complete_blocking_scan(path, args)
     }
 }
 

--- a/core/src/layers/concurrent_limit.rs
+++ b/core/src/layers/concurrent_limit.rs
@@ -166,20 +166,6 @@ impl<A: Accessor> LayeredAccessor for ConcurrentLimitAccessor<A> {
             .map(|(rp, s)| (rp, ConcurrentLimitWrapper::new(s, permit)))
     }
 
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        let permit = self
-            .semaphore
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("semaphore must be valid");
-
-        self.inner
-            .scan(path, args)
-            .await
-            .map(|(rp, s)| (rp, ConcurrentLimitWrapper::new(s, permit)))
-    }
-
     async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
         let _permit = self
             .semaphore
@@ -250,18 +236,6 @@ impl<A: Accessor> LayeredAccessor for ConcurrentLimitAccessor<A> {
 
         self.inner
             .blocking_list(path, args)
-            .map(|(rp, it)| (rp, ConcurrentLimitWrapper::new(it, permit)))
-    }
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        let permit = self
-            .semaphore
-            .clone()
-            .try_acquire_owned()
-            .expect("semaphore must be valid");
-
-        self.inner
-            .blocking_scan(path, args)
             .map(|(rp, it)| (rp, ConcurrentLimitWrapper::new(it, permit)))
     }
 }

--- a/core/src/layers/concurrent_limit.rs
+++ b/core/src/layers/concurrent_limit.rs
@@ -94,7 +94,7 @@ impl<A: Accessor> LayeredAccessor for ConcurrentLimitAccessor<A> {
         &self.inner
     }
 
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         let _permit = self
             .semaphore
             .acquire()
@@ -190,7 +190,7 @@ impl<A: Accessor> LayeredAccessor for ConcurrentLimitAccessor<A> {
         self.inner.batch(args).await
     }
 
-    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         let _permit = self
             .semaphore
             .try_acquire()

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -82,7 +82,7 @@ impl<A: Accessor> LayeredAccessor for ErrorContextAccessor<A> {
         self.meta.clone()
     }
 
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.inner
             .create_dir(path, args)
             .map_err(|err| {
@@ -260,7 +260,7 @@ impl<A: Accessor> LayeredAccessor for ErrorContextAccessor<A> {
             .await
     }
 
-    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.inner.blocking_create_dir(path, args).map_err(|err| {
             err.with_operation(Operation::BlockingCreateDir)
                 .with_context("service", self.meta.scheme())

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -205,27 +205,6 @@ impl<A: Accessor> LayeredAccessor for ErrorContextAccessor<A> {
             .await
     }
 
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        self.inner
-            .scan(path, args)
-            .map_ok(|(rp, os)| {
-                (
-                    rp,
-                    ErrorContextWrapper {
-                        scheme: self.meta.scheme(),
-                        path: path.to_string(),
-                        inner: os,
-                    },
-                )
-            })
-            .map_err(|err| {
-                err.with_operation(Operation::Scan)
-                    .with_context("service", self.meta.scheme())
-                    .with_context("path", path)
-            })
-            .await
-    }
-
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
         self.inner.presign(path, args).await.map_err(|err| {
             err.with_operation(Operation::Presign)
@@ -357,26 +336,6 @@ impl<A: Accessor> LayeredAccessor for ErrorContextAccessor<A> {
             })
             .map_err(|err| {
                 err.with_operation(Operation::BlockingList)
-                    .with_context("service", self.meta.scheme())
-                    .with_context("path", path)
-            })
-    }
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        self.inner
-            .blocking_scan(path, args)
-            .map(|(rp, os)| {
-                (
-                    rp,
-                    ErrorContextWrapper {
-                        scheme: self.meta.scheme(),
-                        path: path.to_string(),
-                        inner: os,
-                    },
-                )
-            })
-            .map_err(|err| {
-                err.with_operation(Operation::BlockingScan)
                     .with_context("service", self.meta.scheme())
                     .with_context("path", path)
             })

--- a/core/src/layers/immutable_index.rs
+++ b/core/src/layers/immutable_index.rs
@@ -152,7 +152,8 @@ impl<A: Accessor> LayeredAccessor for ImmutableIndexAccessor<A> {
 
         let cap = meta.capability_mut();
         cap.list = true;
-        cap.scan = true;
+        cap.list_with_delimiter_slash = true;
+        cap.list_without_delimiter = true;
 
         meta
     }
@@ -161,28 +162,24 @@ impl<A: Accessor> LayeredAccessor for ImmutableIndexAccessor<A> {
         self.inner.read(path, args).await
     }
 
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Pager)> {
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
         let mut path = path;
         if path == "/" {
             path = ""
         }
 
-        Ok((
-            RpList::default(),
-            ImmutableDir::new(self.children_hierarchy(path)),
-        ))
-    }
+        let idx = if args.delimiter() == "/" {
+            self.children_hierarchy(path)
+        } else if args.delimiter().is_empty() {
+            self.children_flat(path)
+        } else {
+            return Err(Error::new(
+                ErrorKind::Unsupported,
+                &format!("delimiter {} is not supported", args.delimiter()),
+            ));
+        };
 
-    async fn scan(&self, path: &str, _: OpScan) -> Result<(RpScan, Self::Pager)> {
-        let mut path = path;
-        if path == "/" {
-            path = ""
-        }
-
-        Ok((
-            RpScan::default(),
-            ImmutableDir::new(self.children_flat(path)),
-        ))
+        Ok((RpList::default(), ImmutableDir::new(idx)))
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
@@ -197,28 +194,24 @@ impl<A: Accessor> LayeredAccessor for ImmutableIndexAccessor<A> {
         self.inner.blocking_write(path, args)
     }
 
-    fn blocking_list(&self, path: &str, _: OpList) -> Result<(RpList, Self::BlockingPager)> {
+    fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         let mut path = path;
         if path == "/" {
             path = ""
         }
 
-        Ok((
-            RpList::default(),
-            ImmutableDir::new(self.children_hierarchy(path)),
-        ))
-    }
+        let idx = if args.delimiter() == "/" {
+            self.children_hierarchy(path)
+        } else if args.delimiter().is_empty() {
+            self.children_flat(path)
+        } else {
+            return Err(Error::new(
+                ErrorKind::Unsupported,
+                &format!("delimiter {} is not supported", args.delimiter()),
+            ));
+        };
 
-    fn blocking_scan(&self, path: &str, _: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        let mut path = path;
-        if path == "/" {
-            path = ""
-        }
-
-        Ok((
-            RpScan::default(),
-            ImmutableDir::new(self.children_flat(path)),
-        ))
+        Ok((RpList::default(), ImmutableDir::new(idx)))
     }
 }
 

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -216,7 +216,7 @@ impl<A: Accessor> LayeredAccessor for LoggingAccessor<A> {
         result
     }
 
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         debug!(
             target: LOGGING_TARGET,
             "service={} operation={} path={} -> started",
@@ -672,7 +672,7 @@ impl<A: Accessor> LayeredAccessor for LoggingAccessor<A> {
             .await
     }
 
-    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         debug!(
             target: LOGGING_TARGET,
             "service={} operation={} path={} -> started",

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -546,54 +546,6 @@ impl<A: Accessor> LayeredAccessor for LoggingAccessor<A> {
             .await
     }
 
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        debug!(
-            target: LOGGING_TARGET,
-            "service={} operation={} path={} -> started",
-            self.scheme,
-            Operation::Scan,
-            path
-        );
-
-        self.inner
-            .scan(path, args)
-            .map(|v| match v {
-                Ok((rp, v)) => {
-                    debug!(
-                        target: LOGGING_TARGET,
-                        "service={} operation={} path={} -> start scanning",
-                        self.scheme,
-                        Operation::Scan,
-                        path
-                    );
-                    let streamer = LoggingPager::new(
-                        self.scheme,
-                        path,
-                        Operation::Scan,
-                        v,
-                        self.error_level,
-                        self.failure_level,
-                    );
-                    Ok((rp, streamer))
-                }
-                Err(err) => {
-                    if let Some(lvl) = self.err_level(&err) {
-                        log!(
-                            target: LOGGING_TARGET,
-                            lvl,
-                            "service={} operation={} path={} -> {}: {err:?}",
-                            self.scheme,
-                            Operation::Scan,
-                            path,
-                            self.err_status(&err)
-                        );
-                    }
-                    Err(err)
-                }
-            })
-            .await
-    }
-
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
         debug!(
             target: LOGGING_TARGET,
@@ -991,51 +943,6 @@ impl<A: Accessor> LayeredAccessor for LoggingAccessor<A> {
                         "service={} operation={} path={} -> {}: {err:?}",
                         self.scheme,
                         Operation::BlockingList,
-                        path,
-                        self.err_status(&err)
-                    );
-                }
-                err
-            })
-    }
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        debug!(
-            target: LOGGING_TARGET,
-            "service={} operation={} path={} -> started",
-            self.scheme,
-            Operation::BlockingScan,
-            path
-        );
-
-        self.inner
-            .blocking_scan(path, args)
-            .map(|(rp, v)| {
-                debug!(
-                    target: LOGGING_TARGET,
-                    "service={} operation={} path={} -> start scanning",
-                    self.scheme,
-                    Operation::BlockingScan,
-                    path
-                );
-                let li = LoggingPager::new(
-                    self.scheme,
-                    path,
-                    Operation::BlockingScan,
-                    v,
-                    self.error_level,
-                    self.failure_level,
-                );
-                (rp, li)
-            })
-            .map_err(|err| {
-                if let Some(lvl) = self.err_level(&err) {
-                    log!(
-                        target: LOGGING_TARGET,
-                        lvl,
-                        "service={} operation={} path={} -> {}: {err:?}",
-                        self.scheme,
-                        Operation::BlockingScan,
                         path,
                         self.err_status(&err)
                     );

--- a/core/src/layers/madsim.rs
+++ b/core/src/layers/madsim.rs
@@ -228,13 +228,6 @@ impl LayeredAccessor for MadsimAccessor {
         ))
     }
 
-    async fn scan(&self, path: &str, args: OpScan) -> crate::Result<(RpScan, Self::Pager)> {
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "will be supported in the future",
-        ))
-    }
-
     fn blocking_read(
         &self,
         path: &str,
@@ -262,17 +255,6 @@ impl LayeredAccessor for MadsimAccessor {
         path: &str,
         args: OpList,
     ) -> crate::Result<(RpList, Self::BlockingPager)> {
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "will not be supported in MadsimLayer",
-        ))
-    }
-
-    fn blocking_scan(
-        &self,
-        path: &str,
-        args: OpScan,
-    ) -> crate::Result<(RpScan, Self::BlockingPager)> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "will not be supported in MadsimLayer",

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -460,7 +460,7 @@ impl<A: Accessor> LayeredAccessor for MetricsAccessor<A> {
         result
     }
 
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.handle.requests_total_create.increment(1);
 
         let start = Instant::now();
@@ -646,7 +646,7 @@ impl<A: Accessor> LayeredAccessor for MetricsAccessor<A> {
         })
     }
 
-    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.handle.requests_total_blocking_create.increment(1);
 
         let start = Instant::now();

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -160,9 +160,6 @@ struct MetricsHandler {
     requests_total_list: Counter,
     requests_duration_seconds_list: Histogram,
 
-    requests_total_scan: Counter,
-    requests_duration_seconds_scan: Histogram,
-
     requests_total_presign: Counter,
     requests_duration_seconds_presign: Histogram,
 
@@ -189,9 +186,6 @@ struct MetricsHandler {
 
     requests_total_blocking_list: Counter,
     requests_duration_seconds_blocking_list: Histogram,
-
-    requests_total_blocking_scan: Counter,
-    requests_duration_seconds_blocking_scan: Histogram,
 }
 
 impl MetricsHandler {
@@ -284,17 +278,6 @@ impl MetricsHandler {
                 METRIC_REQUESTS_DURATION_SECONDS,
                 LABEL_SERVICE => service,
                 LABEL_OPERATION => Operation::List.into_static(),
-            ),
-
-            requests_total_scan: register_counter!(
-                METRIC_REQUESTS_TOTAL,
-                LABEL_SERVICE => service,
-                LABEL_OPERATION => Operation::Scan.into_static(),
-            ),
-            requests_duration_seconds_scan: register_histogram!(
-                METRIC_REQUESTS_DURATION_SECONDS,
-                LABEL_SERVICE => service,
-                LABEL_OPERATION => Operation::Scan.into_static(),
             ),
 
             requests_total_presign: register_counter!(
@@ -393,17 +376,6 @@ impl MetricsHandler {
                 METRIC_REQUESTS_DURATION_SECONDS,
                 LABEL_SERVICE => service,
                 LABEL_OPERATION => Operation::BlockingList.into_static(),
-            ),
-
-            requests_total_blocking_scan: register_counter!(
-                METRIC_REQUESTS_TOTAL,
-                LABEL_SERVICE => service,
-                LABEL_OPERATION => Operation::BlockingScan.into_static(),
-            ),
-            requests_duration_seconds_blocking_scan: register_histogram!(
-                METRIC_REQUESTS_DURATION_SECONDS,
-                LABEL_SERVICE => service,
-                LABEL_OPERATION => Operation::BlockingScan.into_static(),
             ),
         }
     }
@@ -595,25 +567,6 @@ impl<A: Accessor> LayeredAccessor for MetricsAccessor<A> {
             .await
     }
 
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        self.handle.requests_total_scan.increment(1);
-
-        let start = Instant::now();
-
-        self.inner
-            .scan(path, args)
-            .inspect_ok(|_| {
-                let dur = start.elapsed().as_secs_f64();
-
-                self.handle.requests_duration_seconds_scan.record(dur);
-            })
-            .inspect_err(|e| {
-                self.handle
-                    .increment_errors_total(Operation::Scan, e.kind());
-            })
-            .await
-    }
-
     async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
         self.handle.requests_total_batch.increment(1);
 
@@ -771,24 +724,6 @@ impl<A: Accessor> LayeredAccessor for MetricsAccessor<A> {
         result.map_err(|e| {
             self.handle
                 .increment_errors_total(Operation::BlockingList, e.kind());
-            e
-        })
-    }
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        self.handle.requests_total_blocking_scan.increment(1);
-
-        let start = Instant::now();
-        let result = self.inner.blocking_scan(path, args);
-        let dur = start.elapsed().as_secs_f64();
-
-        self.handle
-            .requests_duration_seconds_blocking_scan
-            .record(dur);
-
-        result.map_err(|e| {
-            self.handle
-                .increment_errors_total(Operation::BlockingScan, e.kind());
             e
         })
     }

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -196,14 +196,6 @@ impl<A: Accessor> LayeredAccessor for MinitraceAccessor<A> {
             .await
     }
 
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        let span = Span::enter_with_local_parent("scan");
-        self.inner
-            .scan(path, args)
-            .map(|v| v.map(|(rp, s)| (rp, MinitraceWrapper::new(span, s))))
-            .await
-    }
-
     #[trace("presign", enter_on_poll = true)]
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
         self.inner.presign(path, args).await
@@ -262,16 +254,6 @@ impl<A: Accessor> LayeredAccessor for MinitraceAccessor<A> {
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         let span = Span::enter_with_local_parent("blocking_list");
         self.inner.blocking_list(path, args).map(|(rp, it)| {
-            (
-                rp,
-                MinitraceWrapper::new(Span::enter_with_parent("PageOperation", &span), it),
-            )
-        })
-    }
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        let span = Span::enter_with_local_parent("blocking_scan");
-        self.inner.blocking_scan(path, args).map(|(rp, it)| {
             (
                 rp,
                 MinitraceWrapper::new(Span::enter_with_parent("PageOperation", &span), it),

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -148,7 +148,7 @@ impl<A: Accessor> LayeredAccessor for MinitraceAccessor<A> {
     }
 
     #[trace("create", enter_on_poll = true)]
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.inner.create_dir(path, args).await
     }
 
@@ -215,7 +215,7 @@ impl<A: Accessor> LayeredAccessor for MinitraceAccessor<A> {
     }
 
     #[trace("blocking_create")]
-    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.inner.blocking_create_dir(path, args)
     }
 

--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -165,17 +165,6 @@ impl<A: Accessor> LayeredAccessor for OtelTraceAccessor<A> {
             .await
     }
 
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        let tracer = global::tracer("opendal");
-        let mut span = tracer.start("scan");
-        span.set_attribute(KeyValue::new("path", path.to_string()));
-        span.set_attribute(KeyValue::new("args", format!("{:?}", args)));
-        self.inner
-            .scan(path, args)
-            .map(|v| v.map(|(rp, s)| (rp, OtelTraceWrapper::new(span, s))))
-            .await
-    }
-
     async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
         let tracer = global::tracer("opendal");
         let mut span = tracer.start("batch");
@@ -272,16 +261,6 @@ impl<A: Accessor> LayeredAccessor for OtelTraceAccessor<A> {
         span.set_attribute(KeyValue::new("args", format!("{:?}", args)));
         self.inner
             .blocking_list(path, args)
-            .map(|(rp, it)| (rp, OtelTraceWrapper::new(span, it)))
-    }
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        let tracer = global::tracer("opendal");
-        let mut span = tracer.start("blocking_scan");
-        span.set_attribute(KeyValue::new("path", path.to_string()));
-        span.set_attribute(KeyValue::new("args", format!("{:?}", args)));
-        self.inner
-            .blocking_scan(path, args)
             .map(|(rp, it)| (rp, OtelTraceWrapper::new(span, it)))
     }
 }

--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -85,7 +85,7 @@ impl<A: Accessor> LayeredAccessor for OtelTraceAccessor<A> {
         tracer.in_span("metadata", |_cx| self.inner.info())
     }
 
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         let tracer = global::tracer("opendal");
         let mut span = tracer.start("create");
         span.set_attribute(KeyValue::new("path", path.to_string()));
@@ -193,7 +193,7 @@ impl<A: Accessor> LayeredAccessor for OtelTraceAccessor<A> {
         self.inner().presign(path, args).with_context(cx).await
     }
 
-    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         let tracer = global::tracer("opendal");
         tracer.in_span("blocking_create_dir", |cx| {
             let span = cx.span(); // let mut span = cx.();

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -200,7 +200,7 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
         &self.inner
     }
 
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.stats
             .requests_total
             .with_label_values(&[&self.scheme])
@@ -427,7 +427,7 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
         })
     }
 
-    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.stats
             .requests_total
             .with_label_values(&[&self.scheme, Operation::BlockingCreateDir.into_static()])

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -365,26 +365,6 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
         })
     }
 
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::Scan.into_static()])
-            .inc();
-
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Scan.into_static()])
-            .start_timer();
-
-        let scan_res = self.inner.scan(path, args).await;
-        timer.observe_duration();
-        scan_res.map_err(|e| {
-            self.stats.increment_errors_total(Operation::Scan, e.kind());
-            e
-        })
-    }
-
     async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
         self.stats
             .requests_total
@@ -571,26 +551,6 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
         result.map_err(|e| {
             self.stats
                 .increment_errors_total(Operation::BlockingList, e.kind());
-            e
-        })
-    }
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingScan.into_static()])
-            .inc();
-
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::BlockingScan.into_static()])
-            .start_timer();
-        let result = self.inner.blocking_scan(path, args);
-        timer.observe_duration();
-        result.map_err(|e| {
-            self.stats
-                .increment_errors_total(Operation::BlockingScan, e.kind());
             e
         })
     }

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -797,6 +797,8 @@ mod tests {
             let mut am = AccessorInfo::default();
             am.set_capability(Capability {
                 list: true,
+                list_with_delimiter_slash: true,
+                list_without_delimiter: true,
                 batch: true,
                 ..Default::default()
             });

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -168,7 +168,7 @@ impl<A: Accessor> LayeredAccessor for RetryAccessor<A> {
         &self.inner
     }
 
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         { || self.inner.create_dir(path, args.clone()) }
             .retry(&self.builder)
             .when(|e| e.is_temporary())
@@ -339,7 +339,7 @@ impl<A: Accessor> LayeredAccessor for RetryAccessor<A> {
         .map_err(|e| e.set_persistent())
     }
 
-    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         { || self.inner.blocking_create_dir(path, args.clone()) }
             .retry(&self.builder)
             .when(|e| e.is_temporary())

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -151,7 +151,7 @@ impl<A: Accessor> LayeredAccessor for TracingAccessor<A> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.inner.create_dir(path, args).await
     }
 
@@ -218,7 +218,7 @@ impl<A: Accessor> LayeredAccessor for TracingAccessor<A> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.inner.blocking_create_dir(path, args)
     }
 

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -200,14 +200,6 @@ impl<A: Accessor> LayeredAccessor for TracingAccessor<A> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        self.inner
-            .scan(path, args)
-            .map(|v| v.map(|(rp, s)| (rp, TracingWrapper::new(Span::current(), s))))
-            .await
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
         self.inner.presign(path, args).await
     }
@@ -260,13 +252,6 @@ impl<A: Accessor> LayeredAccessor for TracingAccessor<A> {
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         self.inner
             .blocking_list(path, args)
-            .map(|(rp, it)| (rp, TracingWrapper::new(Span::current(), it)))
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        self.inner
-            .blocking_scan(path, args)
             .map(|(rp, it)| (rp, TracingWrapper::new(Span::current(), it)))
     }
 }

--- a/core/src/layers/type_eraser.rs
+++ b/core/src/layers/type_eraser.rs
@@ -103,17 +103,4 @@ impl<A: Accessor> LayeredAccessor for TypeEraseAccessor<A> {
             .blocking_list(path, args)
             .map(|(rp, p)| (rp, Box::new(p) as oio::BlockingPager))
     }
-
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        self.inner
-            .scan(path, args)
-            .await
-            .map(|(rp, p)| (rp, Box::new(p) as oio::Pager))
-    }
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        self.inner
-            .blocking_scan(path, args)
-            .map(|(rp, p)| (rp, Box::new(p) as oio::BlockingPager))
-    }
 }

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -93,7 +93,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     ///
     /// - Input path MUST match with EntryMode, DON'T NEED to check mode.
     /// - Create on existing dir SHOULD succeed.
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         let (_, _) = (path, args);
 
         Err(Error::new(
@@ -268,7 +268,7 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     /// This operation is the blocking version of [`Accessor::create_dir`]
     ///
     /// Require [`Capability::create_dir`] and [`Capability::blocking`]
-    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         let (_, _) = (path, args);
 
         Err(Error::new(
@@ -427,7 +427,7 @@ impl<T: Accessor + ?Sized> Accessor for Arc<T> {
         self.as_ref().info()
     }
 
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.as_ref().create_dir(path, args).await
     }
 
@@ -467,7 +467,7 @@ impl<T: Accessor + ?Sized> Accessor for Arc<T> {
         self.as_ref().presign(path, args).await
     }
 
-    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.as_ref().blocking_create_dir(path, args)
     }
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -86,17 +86,17 @@ impl<S: Adapter> Accessor for Backend<S> {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let p = build_abs_path(&self.root, path);
         self.kv.set(&p, &[]).await?;
-        Ok(RpCreate::default())
+        Ok(RpCreateDir::default())
     }
 
-    fn blocking_create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let p = build_abs_path(&self.root, path);
         self.kv.blocking_set(&p, &[])?;
 
-        Ok(RpCreate::default())
+        Ok(RpCreateDir::default())
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {

--- a/core/src/raw/adapters/typed_kv/backend.rs
+++ b/core/src/raw/adapters/typed_kv/backend.rs
@@ -94,17 +94,17 @@ impl<S: Adapter> Accessor for Backend<S> {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let p = build_abs_path(&self.root, path);
         self.kv.set(&p, Value::new_dir()).await?;
-        Ok(RpCreate::default())
+        Ok(RpCreateDir::default())
     }
 
-    fn blocking_create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let p = build_abs_path(&self.root, path);
         self.kv.blocking_set(&p, Value::new_dir())?;
 
-        Ok(RpCreate::default())
+        Ok(RpCreateDir::default())
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {

--- a/core/src/raw/layer.rs
+++ b/core/src/raw/layer.rs
@@ -101,14 +101,6 @@ use crate::*;
 ///     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
 ///         self.inner.blocking_list(path, args)
 ///     }
-///
-///     async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-///         self.inner.scan(path, args).await
-///     }
-///
-///     fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-///         self.inner.blocking_scan(path, args)
-///     }
 /// }
 ///
 /// /// The public struct that exposed to users.
@@ -177,8 +169,6 @@ pub trait LayeredAccessor: Send + Sync + Debug + Unpin + 'static {
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)>;
 
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)>;
-
     async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
         self.inner().batch(args).await
     }
@@ -212,8 +202,6 @@ pub trait LayeredAccessor: Send + Sync + Debug + Unpin + 'static {
     }
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)>;
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)>;
 }
 
 #[async_trait]
@@ -261,10 +249,6 @@ impl<L: LayeredAccessor> Accessor for L {
         (self as &L).list(path, args).await
     }
 
-    async fn scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::Pager)> {
-        (self as &L).scan(path, args).await
-    }
-
     async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
         (self as &L).batch(args).await
     }
@@ -303,10 +287,6 @@ impl<L: LayeredAccessor> Accessor for L {
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         (self as &L).blocking_list(path, args)
-    }
-
-    fn blocking_scan(&self, path: &str, args: OpScan) -> Result<(RpScan, Self::BlockingPager)> {
-        (self as &L).blocking_scan(path, args)
     }
 }
 

--- a/core/src/raw/layer.rs
+++ b/core/src/raw/layer.rs
@@ -151,7 +151,7 @@ pub trait LayeredAccessor: Send + Sync + Debug + Unpin + 'static {
         self.inner().info()
     }
 
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.inner().create_dir(path, args).await
     }
 
@@ -187,7 +187,7 @@ pub trait LayeredAccessor: Send + Sync + Debug + Unpin + 'static {
         self.inner().presign(path, args).await
     }
 
-    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.inner().blocking_create_dir(path, args)
     }
 
@@ -229,7 +229,7 @@ impl<L: LayeredAccessor> Accessor for L {
         (self as &L).metadata()
     }
 
-    async fn create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         (self as &L).create_dir(path, args).await
     }
 
@@ -273,7 +273,7 @@ impl<L: LayeredAccessor> Accessor for L {
         (self as &L).presign(path, args).await
     }
 
-    fn blocking_create_dir(&self, path: &str, args: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         (self as &L).blocking_create_dir(path, args)
     }
 

--- a/core/src/raw/oio/to_flat_pager.rs
+++ b/core/src/raw/oio/to_flat_pager.rs
@@ -30,11 +30,7 @@ pub fn to_flat_pager<A: Accessor, P>(acc: A, path: &str, size: usize) -> ToFlatP
     {
         let meta = acc.info();
         debug_assert!(
-            !meta.capability().scan,
-            "service already supports scan, call to_flat_pager must be a mistake"
-        );
-        debug_assert!(
-            meta.capability().list,
+            meta.capability().list_with_delimiter_slash,
             "service doesn't support list hierarchy, it must be a bug"
         );
     }

--- a/core/src/raw/oio/to_flat_pager.rs
+++ b/core/src/raw/oio/to_flat_pager.rs
@@ -255,6 +255,7 @@ mod tests {
         fn info(&self) -> AccessorInfo {
             let mut am = AccessorInfo::default();
             am.capability_mut().list = true;
+            am.capability_mut().list_with_delimiter_slash = true;
 
             am
         }

--- a/core/src/raw/rps.rs
+++ b/core/src/raw/rps.rs
@@ -31,10 +31,6 @@ pub struct RpDelete {}
 #[derive(Debug, Clone, Default)]
 pub struct RpList {}
 
-/// Reply for `scan` operation.
-#[derive(Debug, Clone, Default)]
-pub struct RpScan {}
-
 /// Reply for `presign` operation.
 #[derive(Debug, Clone)]
 pub struct RpPresign {

--- a/core/src/raw/rps.rs
+++ b/core/src/raw/rps.rs
@@ -19,9 +19,9 @@ use http::Request;
 
 use crate::*;
 
-/// Reply for `create` operation
+/// Reply for `create_dir` operation
 #[derive(Debug, Clone, Default)]
-pub struct RpCreate {}
+pub struct RpCreateDir {}
 
 /// Reply for `delete` operation
 #[derive(Debug, Clone, Default)]

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -477,7 +477,6 @@ impl Accessor for AzblobBackend {
                 create_dir: true,
                 copy: true,
 
-                scan: true,
                 list: true,
                 list_with_delimiter_slash: true,
                 list_without_delimiter: true,

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -496,7 +496,7 @@ impl Accessor for AzblobBackend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let mut req =
             self.core
                 .azblob_put_blob_request(path, Some(0), None, None, AsyncBody::Empty)?;
@@ -510,7 +510,7 @@ impl Accessor for AzblobBackend {
         match status {
             StatusCode::CREATED | StatusCode::OK => {
                 resp.into_body().consume().await?;
-                Ok(RpCreate::default())
+                Ok(RpCreateDir::default())
             }
             _ => Err(parse_error(resp).await?),
         }

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -480,6 +480,7 @@ impl Accessor for AzblobBackend {
                 scan: true,
                 list: true,
                 list_with_delimiter_slash: true,
+                list_without_delimiter: true,
 
                 presign: self.has_sas_token,
                 presign_stat: self.has_sas_token,

--- a/core/src/services/azdfs/backend.rs
+++ b/core/src/services/azdfs/backend.rs
@@ -333,7 +333,7 @@ impl Accessor for AzdfsBackend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let mut req =
             self.core
                 .azdfs_create_request(path, "directory", None, None, AsyncBody::Empty)?;
@@ -347,7 +347,7 @@ impl Accessor for AzdfsBackend {
         match status {
             StatusCode::CREATED | StatusCode::OK => {
                 resp.into_body().consume().await?;
-                Ok(RpCreate::default())
+                Ok(RpCreateDir::default())
             }
             _ => Err(parse_error(resp).await?),
         }

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -328,12 +328,12 @@ impl Accessor for FsBackend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let p = self.root.join(path.trim_end_matches('/'));
 
         fs::create_dir_all(&p).await.map_err(parse_io_error)?;
 
-        Ok(RpCreate::default())
+        Ok(RpCreateDir::default())
     }
 
     /// # Notes
@@ -526,12 +526,12 @@ impl Accessor for FsBackend {
         Ok((RpList::default(), Some(rd)))
     }
 
-    fn blocking_create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let p = self.root.join(path.trim_end_matches('/'));
 
         std::fs::create_dir_all(p).map_err(parse_io_error)?;
 
-        Ok(RpCreate::default())
+        Ok(RpCreateDir::default())
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -340,7 +340,7 @@ impl Accessor for FtpBackend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let mut ftp_stream = self.ftp_connect(Operation::CreateDir).await?;
 
         let paths: Vec<&str> = path.split_inclusive('/').collect();
@@ -362,7 +362,7 @@ impl Accessor for FtpBackend {
             }
         }
 
-        return Ok(RpCreate::default());
+        return Ok(RpCreateDir::default());
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -438,7 +438,7 @@ impl Accessor for GcsBackend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let mut req = self
             .core
             .gcs_insert_object_request(path, Some(0), None, AsyncBody::Empty)?;
@@ -449,7 +449,7 @@ impl Accessor for GcsBackend {
 
         if resp.status().is_success() {
             resp.into_body().consume().await?;
-            Ok(RpCreate::default())
+            Ok(RpCreateDir::default())
         } else {
             Err(parse_error(resp).await?)
         }

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -421,7 +421,6 @@ impl Accessor for GcsBackend {
                 delete: true,
                 copy: true,
 
-                scan: true,
                 list: true,
                 list_with_limit: true,
                 list_with_start_after: true,

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -320,10 +320,10 @@ impl Accessor for GhacBackend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         // ignore creation of dir.
         if path.ends_with('/') {
-            return Ok(RpCreate::default());
+            return Ok(RpCreateDir::default());
         }
         if !self.enable_create_simulation {
             return Err(Error::new(
@@ -343,7 +343,7 @@ impl Accessor for GhacBackend {
             reserve_resp.cache_id
         } else if resp.status().as_u16() == StatusCode::CONFLICT {
             // If the file is already exist, just return Ok.
-            return Ok(RpCreate::default());
+            return Ok(RpCreateDir::default());
         } else {
             return Err(parse_error(resp)
                 .await
@@ -370,7 +370,7 @@ impl Accessor for GhacBackend {
 
         if resp.status().is_success() {
             resp.into_body().consume().await?;
-            Ok(RpCreate::default())
+            Ok(RpCreateDir::default())
         } else {
             Err(parse_error(resp)
                 .await

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -263,12 +263,12 @@ impl Accessor for HdfsBackend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let p = build_rooted_abs_path(&self.root, path);
 
         self.client.create_dir(&p).map_err(parse_io_error)?;
 
-        Ok(RpCreate::default())
+        Ok(RpCreateDir::default())
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
@@ -401,12 +401,12 @@ impl Accessor for HdfsBackend {
         Ok((RpList::default(), Some(rd)))
     }
 
-    fn blocking_create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    fn blocking_create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let p = build_rooted_abs_path(&self.root, path);
 
         self.client.create_dir(&p).map_err(parse_io_error)?;
 
-        Ok(RpCreate::default())
+        Ok(RpCreateDir::default())
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -110,7 +110,7 @@ impl Accessor for IpmfsBackend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let resp = self.ipmfs_mkdir(path).await?;
 
         let status = resp.status();
@@ -118,7 +118,7 @@ impl Accessor for IpmfsBackend {
         match status {
             StatusCode::CREATED | StatusCode::OK => {
                 resp.into_body().consume().await?;
-                Ok(RpCreate::default())
+                Ok(RpCreateDir::default())
             }
             _ => Err(parse_error(resp).await?),
         }

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -328,7 +328,6 @@ impl Accessor for ObsBackend {
                 create_dir: true,
                 copy: true,
 
-                scan: true,
                 list: true,
                 list_with_delimiter_slash: true,
                 list_without_delimiter: true,

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -339,7 +339,7 @@ impl Accessor for ObsBackend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let mut req =
             self.core
                 .obs_put_object_request(path, Some(0), None, None, AsyncBody::Empty)?;
@@ -353,7 +353,7 @@ impl Accessor for ObsBackend {
         match status {
             StatusCode::CREATED | StatusCode::OK => {
                 resp.into_body().consume().await?;
-                Ok(RpCreate::default())
+                Ok(RpCreateDir::default())
             }
             _ => Err(parse_error(resp).await?),
         }

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -487,7 +487,7 @@ impl Accessor for OssBackend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let resp = self
             .core
             .oss_put_object(path, None, None, None, None, AsyncBody::Empty)
@@ -497,7 +497,7 @@ impl Accessor for OssBackend {
         match status {
             StatusCode::CREATED | StatusCode::OK => {
                 resp.into_body().consume().await?;
-                Ok(RpCreate::default())
+                Ok(RpCreateDir::default())
             }
             _ => Err(parse_error(resp).await?),
         }

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -468,7 +468,6 @@ impl Accessor for OssBackend {
                 create_dir: true,
                 copy: true,
 
-                scan: true,
                 list: true,
                 list_with_delimiter_slash: true,
                 list_without_delimiter: true,

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -1001,7 +1001,7 @@ impl Accessor for S3Backend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let mut req =
             self.core
                 .s3_put_object_request(path, Some(0), None, None, None, AsyncBody::Empty)?;
@@ -1015,7 +1015,7 @@ impl Accessor for S3Backend {
         match status {
             StatusCode::CREATED | StatusCode::OK => {
                 resp.into_body().consume().await?;
-                Ok(RpCreate::default())
+                Ok(RpCreateDir::default())
             }
             _ => Err(parse_error(resp).await?),
         }

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -980,7 +980,6 @@ impl Accessor for S3Backend {
                 delete: true,
                 copy: true,
 
-                scan: true,
                 list: true,
                 list_with_limit: true,
                 list_with_start_after: true,

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -324,7 +324,7 @@ impl Accessor for SftpBackend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let client = self.sftp_connect().await?;
         let mut fs = client.sftp.fs();
         fs.set_cwd(self.root.clone());
@@ -348,7 +348,7 @@ impl Accessor for SftpBackend {
             fs.set_cwd(current.clone());
         }
 
-        return Ok(RpCreate::default());
+        return Ok(RpCreateDir::default());
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
@@ -398,7 +398,7 @@ impl Accessor for SftpBackend {
         }
 
         if let Some((dir, _)) = path.rsplit_once('/') {
-            self.create_dir(dir, OpCreate::default()).await?;
+            self.create_dir(dir, OpCreateDir::default()).await?;
         }
 
         let path = format!("{}{}", self.root, path);

--- a/core/src/services/sled/backend.rs
+++ b/core/src/services/sled/backend.rs
@@ -158,7 +158,7 @@ impl kv::Adapter for Adapter {
             Capability {
                 read: true,
                 write: true,
-                scan: true,
+                list: true,
                 blocking: true,
                 ..Default::default()
             },

--- a/core/src/services/supabase/backend.rs
+++ b/core/src/services/supabase/backend.rs
@@ -233,7 +233,7 @@ impl Accessor for SupabaseBackend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let mut req =
             self.core
                 .supabase_upload_object_request(path, Some(0), None, AsyncBody::Empty)?;
@@ -246,12 +246,12 @@ impl Accessor for SupabaseBackend {
 
         if status.is_success() {
             resp.into_body().consume().await?;
-            Ok(RpCreate::default())
+            Ok(RpCreateDir::default())
         } else {
             // create duplicate dir is ok
             let e = parse_error(resp).await?;
             if e.kind() == ErrorKind::AlreadyExists {
-                Ok(RpCreate::default())
+                Ok(RpCreateDir::default())
             } else {
                 Err(e)
             }

--- a/core/src/services/wasabi/backend.rs
+++ b/core/src/services/wasabi/backend.rs
@@ -919,7 +919,6 @@ impl Accessor for WasabiBackend {
                 copy: true,
                 rename: true,
 
-                scan: true,
                 list: true,
                 list_without_delimiter: true,
                 list_with_delimiter_slash: true,

--- a/core/src/services/wasabi/backend.rs
+++ b/core/src/services/wasabi/backend.rs
@@ -937,7 +937,7 @@ impl Accessor for WasabiBackend {
         am
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let mut req =
             self.core
                 .put_object_request(path, Some(0), None, None, None, AsyncBody::Empty)?;
@@ -951,7 +951,7 @@ impl Accessor for WasabiBackend {
         match status {
             StatusCode::CREATED | StatusCode::OK => {
                 resp.into_body().consume().await?;
-                Ok(RpCreate::default())
+                Ok(RpCreateDir::default())
             }
             _ => Err(parse_error(resp).await?),
         }

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -292,7 +292,7 @@ impl Accessor for WebdavBackend {
         ma
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         self.ensure_parent_path(path).await?;
 
         let abs_path = build_abs_path(&self.root, path);
@@ -633,7 +633,7 @@ impl WebdavBackend {
         self.client.send(req).await
     }
 
-    async fn create_internal(&self, abs_path: &str) -> Result<RpCreate> {
+    async fn create_internal(&self, abs_path: &str) -> Result<RpCreateDir> {
         let resp = if abs_path.ends_with('/') {
             self.webdav_mkcol(abs_path, None, None, AsyncBody::Empty)
                 .await?
@@ -654,7 +654,7 @@ impl WebdavBackend {
             // create existing file will return no_content
             | StatusCode::NO_CONTENT => {
                 resp.into_body().consume().await?;
-                Ok(RpCreate::default())
+                Ok(RpCreateDir::default())
             }
             _ => Err(parse_error(resp).await?),
         }

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -283,7 +283,6 @@ impl Accessor for WebdavBackend {
                 rename: true,
 
                 list: true,
-                list_without_delimiter: true,
                 list_with_delimiter_slash: true,
 
                 ..Default::default()
@@ -405,7 +404,14 @@ impl Accessor for WebdavBackend {
         }
     }
 
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Pager)> {
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
+        if args.delimiter() != "/" {
+            return Err(Error::new(
+                ErrorKind::Unsupported,
+                "webdav only support delimiter `/`",
+            ));
+        }
+
         let mut header_map = HeaderMap::new();
         header_map.insert("Depth", "1".parse().unwrap());
         header_map.insert(header::CONTENT_TYPE, "application/xml".parse().unwrap());

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -449,7 +449,7 @@ impl WebhdfsBackend {
                 }
             }
             StatusCode::NOT_FOUND => {
-                self.create_dir("/", OpCreate::new()).await?;
+                self.create_dir("/", OpCreateDir::new()).await?;
             }
             _ => return Err(parse_error(resp).await?),
         }
@@ -491,7 +491,7 @@ impl Accessor for WebhdfsBackend {
     }
 
     /// Create a file or directory
-    async fn create_dir(&self, path: &str, _: OpCreate) -> Result<RpCreate> {
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let req = self
             .webhdfs_create_object_request(path, Some(0), None, AsyncBody::Empty)
             .await?;
@@ -512,7 +512,7 @@ impl Accessor for WebhdfsBackend {
                     .map_err(new_json_deserialize_error)?;
 
                 if resp.boolean {
-                    Ok(RpCreate::default())
+                    Ok(RpCreateDir::default())
                 } else {
                     Err(Error::new(
                         ErrorKind::Unexpected,

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -482,7 +482,6 @@ impl Accessor for WebhdfsBackend {
                 delete: true,
 
                 list: true,
-                list_without_delimiter: true,
                 list_with_delimiter_slash: true,
 
                 ..Default::default()
@@ -594,7 +593,14 @@ impl Accessor for WebhdfsBackend {
         }
     }
 
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Pager)> {
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
+        if args.delimiter() != "/" {
+            return Err(Error::new(
+                ErrorKind::Unsupported,
+                "webhdfs only support delimiter `/`",
+            ));
+        }
+
         let path = path.trim_end_matches('/');
         let req = self.webhdfs_list_status_request(path)?;
 

--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -108,10 +108,6 @@ pub struct Capability {
     pub list_with_delimiter_slash: bool,
     /// If backend supports list without delimiter.
     pub list_without_delimiter: bool,
-    /// If operator supports scan natively, it will be true.
-    pub scan: bool,
-    /// If backend supports scan with limit, it will be true.
-    pub scan_with_limit: bool,
 
     /// If operator supports presign natively, it will be true.
     pub presign: bool,
@@ -160,9 +156,6 @@ impl Debug for Capability {
         }
         if self.list {
             s.push("List");
-        }
-        if self.scan {
-            s.push("Scan");
         }
         if self.presign {
             s.push("Presign");

--- a/core/src/types/operator/blocking_operator.rs
+++ b/core/src/types/operator/blocking_operator.rs
@@ -737,6 +737,7 @@ impl BlockingOperator {
     /// # Notes
     ///
     /// - `scan` will not return the prefix itself.
+    /// - `scan` is an alias of `list_with(OpList::new().with_delimiter(""))`
     ///
     /// # Examples
     ///

--- a/core/src/types/operator/blocking_operator.rs
+++ b/core/src/types/operator/blocking_operator.rs
@@ -773,12 +773,14 @@ impl BlockingOperator {
                 ErrorKind::NotADirectory,
                 "the path trying to scan should end with `/`",
             )
-            .with_operation("BlockingOperator::scan")
+            .with_operation("BlockingOperator::list")
             .with_context("service", self.info().scheme().into_static())
             .with_context("path", path));
         }
 
-        let (_, pager) = self.inner().blocking_scan(&path, OpScan::new())?;
+        let (_, pager) = self
+            .inner()
+            .blocking_list(&path, OpList::new().with_delimiter(""))?;
         Ok(BlockingLister::new(pager))
     }
 }

--- a/core/src/types/operator/blocking_operator.rs
+++ b/core/src/types/operator/blocking_operator.rs
@@ -307,7 +307,8 @@ impl BlockingOperator {
             .with_context("path", &path));
         }
 
-        self.inner().blocking_create_dir(&path, OpCreate::new())?;
+        self.inner()
+            .blocking_create_dir(&path, OpCreateDir::new())?;
 
         Ok(())
     }

--- a/core/src/types/operator/metadata.rs
+++ b/core/src/types/operator/metadata.rs
@@ -77,11 +77,6 @@ impl OperatorInfo {
         self.0.capability().list
     }
 
-    /// Check if current backend supports [`Accessor::scan`] or not.
-    pub fn can_scan(&self) -> bool {
-        self.0.capability().scan
-    }
-
     /// Check if current backend supports [`Accessor::presign`] or not.
     pub fn can_presign(&self) -> bool {
         self.0.capability().presign

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -1190,12 +1190,15 @@ impl Operator {
                 ErrorKind::NotADirectory,
                 "the path trying to scan should end with `/`",
             )
-            .with_operation("scan")
+            .with_operation("list")
             .with_context("service", self.info().scheme().into_static())
             .with_context("path", &path));
         }
 
-        let (_, pager) = self.inner().scan(&path, OpScan::new()).await?;
+        let (_, pager) = self
+            .inner()
+            .list(&path, OpList::new().with_delimiter(""))
+            .await?;
 
         Ok(Lister::new(pager))
     }

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -1099,6 +1099,8 @@ impl Operator {
     ///
     /// # Examples
     ///
+    /// ## List current dir
+    ///
     /// ```no_run
     /// # use anyhow::Result;
     /// # use futures::io;
@@ -1110,6 +1112,38 @@ impl Operator {
     /// # #[tokio::main]
     /// # async fn test(op: Operator) -> Result<()> {
     /// let option = OpList::new().with_limit(10).with_start_after("start");
+    /// let mut ds = op.list_with("path/to/dir/", option).await?;
+    /// while let Some(mut de) = ds.try_next().await? {
+    ///     let meta = op.metadata(&de, Metakey::Mode).await?;
+    ///     match meta.mode() {
+    ///         EntryMode::FILE => {
+    ///             println!("Handling file")
+    ///         }
+    ///         EntryMode::DIR => {
+    ///             println!("Handling dir like start a new list via meta.path()")
+    ///         }
+    ///         EntryMode::Unknown => continue,
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ## List all files recursively
+    ///
+    /// We can use `op.scan()` as a shorter alias.
+    ///
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// # use futures::io;
+    /// use futures::TryStreamExt;
+    /// use opendal::ops::OpList;
+    /// use opendal::EntryMode;
+    /// use opendal::Metakey;
+    /// use opendal::Operator;
+    /// # #[tokio::main]
+    /// # async fn test(op: Operator) -> Result<()> {
+    /// let option = OpList::new().with_delimiter("");
     /// let mut ds = op.list_with("path/to/dir/", option).await?;
     /// while let Some(mut de) = ds.try_next().await? {
     ///     let meta = op.metadata(&de, Metakey::Mode).await?;
@@ -1153,6 +1187,7 @@ impl Operator {
     /// # Notes
     ///
     /// - `scan` will not return the prefix itself.
+    /// - `scan` is an alias of `list_with(OpList::new().with_delimiter(""))`
     ///
     /// # Examples
     ///

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -400,7 +400,7 @@ impl Operator {
             .with_context("path", &path));
         }
 
-        self.inner().create_dir(&path, OpCreate::new()).await?;
+        self.inner().create_dir(&path, OpCreateDir::new()).await?;
 
         Ok(())
     }

--- a/core/src/types/ops.rs
+++ b/core/src/types/ops.rs
@@ -27,10 +27,10 @@ use crate::raw::*;
 ///
 /// The path must be normalized.
 #[derive(Debug, Clone, Default)]
-pub struct OpCreate {}
+pub struct OpCreateDir {}
 
-impl OpCreate {
-    /// Create a new `OpCreate`.
+impl OpCreateDir {
+    /// Create a new `OpCreateDir`.
     pub fn new() -> Self {
         Self::default()
     }

--- a/core/src/types/ops.rs
+++ b/core/src/types/ops.rs
@@ -114,32 +114,6 @@ impl OpList {
     }
 }
 
-/// Args for `scan` operation.
-#[derive(Debug, Default, Clone)]
-pub struct OpScan {
-    /// The limit passed to underlying service to specify the max results
-    /// that could return.
-    limit: Option<usize>,
-}
-
-impl OpScan {
-    /// Create a new `OpList`.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Change the limit of this list operation.
-    pub fn with_limit(mut self, limit: usize) -> Self {
-        self.limit = Some(limit);
-        self
-    }
-
-    /// Get the limit of list operation.
-    pub fn limit(&self) -> Option<usize> {
-        self.limit
-    }
-}
-
 /// Args for `presign` operation.
 ///
 /// The path must be normalized.

--- a/core/tests/behavior/blocking_list.rs
+++ b/core/tests/behavior/blocking_list.rs
@@ -43,7 +43,7 @@ macro_rules! behavior_blocking_list_test {
                     match OPERATOR.as_ref() {
                         Some(op) if op.info().can_read()
                             && op.info().can_write()
-                            && op.info().can_blocking() && (op.info().can_list()||op.info().can_scan()) => $crate::blocking_list::$test(op.blocking()),
+                            && op.info().can_blocking() && op.info().can_list() => $crate::blocking_list::$test(op.blocking()),
                         Some(_) => {
                             log::warn!("service {} doesn't support blocking_list, ignored", opendal::Scheme::$service);
                             Ok(())

--- a/core/tests/behavior/list.rs
+++ b/core/tests/behavior/list.rs
@@ -47,8 +47,8 @@ macro_rules! behavior_list_test {
                     match OPERATOR.as_ref() {
                         Some(op) if op.info().can_read()
                             && op.info().can_write()
-                            && (op.info().can_list()
-                                || op.info().can_scan()) => RUNTIME.block_on($crate::list::$test(op.clone())),
+                            && op.info().can_list()
+                                 => RUNTIME.block_on($crate::list::$test(op.clone())),
                         Some(_) => {
                             log::warn!("service {} doesn't support list, ignored", opendal::Scheme::$service);
                             Ok(())


### PR DESCRIPTION
This PR will remove all not used scan related code.

Fix https://github.com/apache/incubator-opendal/issues/2072