### PR TITLE
Bump to version 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v0.34.0] - 2023-05-09
+
+### Added
+
+- feat(writer): configurable buffer size of unsized write (#2143)
+- feat(oay): Add basic s3 list_objects_v2 with start_after support (#2219)
+- feat: Add typed kv adapter and migrate moka to it (#2222)
+- feat: migrate service dashmap (#2225)
+- feat(services/memory): migrate service memory  (#2229)
+- feat: Add assert for public types to ensure Send + Sync (#2237)
+- feat(services/gcs): Add abort support for writer (#2242)
+
+### Changed
+
+- refactor: Replace futures::ready with std::task::ready (#2221)
+- refactor: Use list without delimiter to replace scan (#2243)
+
+### Fixed
+
+- fix(services/gcs): checked_rem_euclid could return Some(0) (#2220)
+- fix(tests): Etag must be wrapped by `"` (#2226)
+- fix(services/s3): Return error if credential load fail instead skip (#2233)
+- fix(services/s3): Return error if region not set for AWS S3 (#2234)
+- fix(services/gcs): rsa 0.9 breaks gcs presign (#2236)
+
+### Chore
+
+- chore: change log subscriber from env_logger to tracing-subscriber (#2238)
+- chore: Fix build of wasabi (#2241)
+
 ## [v0.33.3] - 2023-05-06
 
 ### Added
@@ -2067,6 +2097,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 Hello, OpenDAL!
 
+[v0.34.0]: https://github.com/apache/incubator-opendal/compare/v0.33.3...v0.34.0
 [v0.33.3]: https://github.com/apache/incubator-opendal/compare/v0.33.2...v0.33.3
 [v0.33.2]: https://github.com/apache/incubator-opendal/compare/v0.33.1...v0.33.2
 [v0.33.1]: https://github.com/apache/incubator-opendal/compare/v0.33.0...v0.33.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "oay"
-version = "0.33.3"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2574,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_opendal"
-version = "0.33.3"
+version = "0.34.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "oli"
-version = "0.33.3"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2617,7 +2617,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.33.3"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-nodejs"
-version = "0.33.3"
+version = "0.34.0"
 dependencies = [
  "futures",
  "napi",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-python"
-version = "0.33.3"
+version = "0.34.0"
 dependencies = [
  "chrono",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-opendal"
 rust-version = "1.65"
-version = "0.33.3"
+version = "0.34.0"
 
 [workspace.dependencies]
-opendal = { version = "0.33", path = "core" }
+opendal = { version = "0.34", path = "core" }

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-arm64",
   "repository": "git@github.com/apache/incubator-opendal.git",
-  "version": "0.33.3",
+  "version": "0.34.0",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-x64",
   "repository": "git@github.com/apache/incubator-opendal.git",
-  "version": "0.33.3",
+  "version": "0.34.0",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.33.3",
+  "version": "0.34.0",
   "repository": "git@github.com/apache/incubator-opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.33.3",
+  "version": "0.34.0",
   "repository": "git@github.com/apache/incubator-opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "OpenDAL Contributors <dev@opendal.apache.org>",
-  "version": "0.33.3",
+  "version": "0.34.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",

--- a/core/src/docs/upgrade.md
+++ b/core/src/docs/upgrade.md
@@ -1,3 +1,22 @@
+# Upgrade to v0.34
+
+## Public API
+
+- OpenDAL raises it's MSRV to 1.65 for dependences changes
+- `OperatorInfo::can_scan` has been removed, to check if underlying services support scan a dir natively, please use `Capability::list_without_delimiter` instead.
+
+## Raw API
+
+### Merged `scan` into `list`
+
+After `Capability` introduced, we have added `delimiter` in `OpList`. Users can specify the delimiter to `""` or `"/"` to control the list behavior.
+
+Along with this change, `Operator::scan()` becomes a short alias of `Operator::list_with(OpList::new().with_delimiter(""))`.
+
+### Typed Kv Adapter
+
+In v0.34, OpenDAL adds a typed kv adapter for zero-copy read and write. If you are implemented kv adapter for a rust in-memory data struct, please consider migrate.
+
 # Upgrade to v0.33
 
 ## Public API


### PR DESCRIPTION
### Added

- feat(writer): configurable buffer size of unsized write (#2143)
- feat(oay): Add basic s3 list_objects_v2 with start_after support (#2219)
- feat: Add typed kv adapter and migrate moka to it (#2222)
- feat: migrate service dashmap (#2225)
- feat(services/memory): migrate service memory  (#2229)
- feat: Add assert for public types to ensure Send + Sync (#2237)
- feat(services/gcs): Add abort support for writer (#2242)

### Changed

- refactor: Replace futures::ready with std::task::ready (#2221)
- refactor: Use list without delimiter to replace scan (#2243)

### Fixed

- fix(services/gcs): checked_rem_euclid could return Some(0) (#2220)
- fix(tests): Etag must be wrapped by `"` (#2226)
- fix(services/s3): Return error if credential load fail instead skip (#2233)
- fix(services/s3): Return error if region not set for AWS S3 (#2234)
- fix(services/gcs): rsa 0.9 breaks gcs presign (#2236)

### Chore

- chore: change log subscriber from env_logger to tracing-subscriber (#2238)
- chore: Fix build of wasabi (#2241)
