### PR TITLE
feat(bindings/python): Enable `abi3` to avoid building on different python version

### DIFF
--- a/.github/workflows/bindings_python.yml
+++ b/.github/workflows/bindings_python.yml
@@ -67,7 +67,7 @@ jobs:
           manylinux: auto
           working-directory: "bindings/python"
           command: build
-          args: --release --sdist -o dist --find-interpreter
+          args: --release --sdist -o dist
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
@@ -83,7 +83,7 @@ jobs:
         with:
           working-directory: "bindings/python"
           command: build
-          args: --release -o dist --find-interpreter
+          args: --release -o dist
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
@@ -99,7 +99,7 @@ jobs:
         with:
           working-directory: "bindings/python"
           command: build
-          args: --release -o dist --universal2 --find-interpreter
+          args: --release -o dist --universal2
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2711,7 +2711,6 @@ dependencies = [
 name = "opendal-python"
 version = "0.34.0"
 dependencies = [
- "chrono",
  "futures",
  "opendal",
  "pyo3",
@@ -3385,7 +3384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfb848f80438f926a9ebddf0a539ed6065434fd7aae03a89312a9821f81b8501"
 dependencies = [
  "cfg-if",
- "chrono",
  "indoc",
  "libc",
  "memoffset",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -32,9 +32,8 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
-chrono = { version = "0.4.24", default-features = false, features = ["std"] }
 futures = "0.3.28"
 opendal.workspace = true
-pyo3 = { version = "0.18", features = ["chrono"] }
+pyo3 = { version = "0.18", features = ["abi3-py37"] }
 pyo3-asyncio = { version = "0.18", features = ["tokio-runtime"] }
 tokio = "1"

--- a/bindings/python/python/opendal/layers.pyi
+++ b/bindings/python/python/opendal/layers.pyi
@@ -1,0 +1,15 @@
+class ConcurrentLimitLayer:
+    def __init__(self, permits: int) -> None: ...
+
+class ImmutableIndexLayer:
+    def insert(self, key: str) -> None: ...
+
+class RetryLayer:
+    def __init__(
+        self,
+        max_times: int | None = None,
+        factor: float | None = None,
+        jitter: bool = False,
+        max_delay: float | None = None,
+        min_delay: float | None = None,
+    ) -> None: ...


### PR DESCRIPTION
Fixes #2252

Signed-off-by: Frost Ming <me@frostming.com>

`chrono::Duration <-> pyo3::types::PyDelta` is [not availiable](https://docs.rs/pyo3/0.18.2/pyo3/types/struct.PyDelta.html) under `Py_Limited_API`, so I switch it to float(in seconds) instead.