### PR TITLE
feat(services/sftp): support copy and read_seek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2747,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "openssh-sftp-client"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7ee42fa3533261da10b179b27ce4fd7b6954b9919836d26d9a96f39c62d26"
+checksum = "866d0eab409a2fcb6b8c3838fdbf10d7399d486548c19179a80f1c1142e93348"
 dependencies = [
  "bytes",
  "derive_destructure2",
@@ -2768,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "openssh-sftp-client-lowlevel"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efd4c88a55c2baa1162e97f201a26a3d0b65773e6f942ada35ef455b1194ede"
+checksum = "f4975d0a824e82d4f61e3edf870254ce97bd7f8154751d2afdd97c7f43e57dff"
 dependencies = [
  "awaitable",
  "bytes",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -180,7 +180,7 @@ minitrace = { version = "0.4.0", optional = true }
 moka = { version = "0.10", optional = true, features = ["future"] }
 once_cell = "1"
 openssh = { version = "0.9.9", optional = true }
-openssh-sftp-client = { version = "0.13.4", optional = true, features = [
+openssh-sftp-client = { version = "0.13.5", optional = true, features = [
   "openssh",
   "tracing",
 ] }

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -69,7 +69,7 @@ use crate::*;
 /// - `user`: Set the login user
 /// - `key`: Set the public key for login
 /// - `known_hosts_strategy`: Set the strategy for known hosts, default to `Strict`
-/// - `copyable`: Set whether the remote server has copy-data extension
+/// - `copyable`: Set whether the remote server has copy-file extension
 ///
 /// It doesn't support password login, you can use public key instead.
 ///

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -69,6 +69,7 @@ use crate::*;
 /// - `user`: Set the login user
 /// - `key`: Set the public key for login
 /// - `known_hosts_strategy`: Set the strategy for known hosts, default to `Strict`
+/// - `copyable`: Set whether the remote server has copy-data extension
 ///
 /// It doesn't support password login, you can use public key instead.
 ///

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -69,7 +69,7 @@ use crate::*;
 /// - `user`: Set the login user
 /// - `key`: Set the public key for login
 /// - `known_hosts_strategy`: Set the strategy for known hosts, default to `Strict`
-/// - `copyable`: Set whether the remote server has copy-file extension
+/// - `enable_copy`: Set whether the remote server has copy-file extension
 ///
 /// It doesn't support password login, you can use public key instead.
 ///
@@ -105,7 +105,7 @@ pub struct SftpBuilder {
     user: Option<String>,
     key: Option<String>,
     known_hosts_strategy: Option<String>,
-    copyable: bool,
+    enable_copy: bool,
 }
 
 impl Debug for SftpBuilder {
@@ -177,10 +177,10 @@ impl SftpBuilder {
         self
     }
 
-    /// set copyable for sftp backend.
+    /// set enable_copy for sftp backend.
     /// It requires the server supports copy-file extension.
-    pub fn copyable(&mut self, copyable: bool) -> &mut Self {
-        self.copyable = copyable;
+    pub fn enable_copy(&mut self, enable_copy: bool) -> &mut Self {
+        self.enable_copy = enable_copy;
 
         self
     }
@@ -235,7 +235,7 @@ impl Builder for SftpBuilder {
             user,
             key: self.key.clone(),
             known_hosts_strategy,
-            copyable: self.copyable,
+            copyable: self.enable_copy,
             client: tokio::sync::OnceCell::new(),
         })
     }


### PR DESCRIPTION
Update:
  - add copyable setting in `SftpBuilder` to make user provide info about remote server extension
  - bump `openssh-sftp-client` version to 0.13.5 to fix the bug of `AsyncSeek`
  - add `read_can_seek` in `Capability`