### PR TITLE
test: add job s3_with_iam with localstack support

### DIFF
--- a/.github/workflows/service_test_s3.yml
+++ b/.github/workflows/service_test_s3.yml
@@ -178,3 +178,37 @@ jobs:
           OPENDAL_S3_BUCKET: test
           OPENDAL_S3_ENDPOINT: "http://127.0.0.1:9000"
           OPENDAL_S3_ALLOW_ANONYMOUS: on
+
+  s3_with_iam:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup
+      - name: Start LocalStack
+        run: |
+          pip install localstack awscli-local[ver2]
+          docker pull localstack/localstack
+          localstack start -d
+          localstack wait -t 30
+          echo "Startup LocalStack complete"
+      - name: Create user, access key and S3 bucket
+        id: create-access-key
+        run: |
+          awslocal iam create-user --user-name test-user
+          awslocal iam create-access-key --user-name test-user > output.json
+          export ACCESS_KEY=$(cat output.json | jq -r '.AccessKey.AccessKeyId')
+          export SECRET_KEY=$(cat output.json | jq -r '.AccessKey.SecretAccessKey')
+          awslocal s3 mb s3://test
+      - name: Test
+        shell: bash
+        working-directory: core
+        run: cargo test s3 -- --show-output
+        env:
+          RUST_BACKTRACE: full
+          RUST_LOG: debug
+          OPENDAL_S3_TEST: on
+          OPENDAL_S3_BUCKET: test
+          OPENDAL_S3_ENDPOINT: "http://127.0.0.1:4566"
+          OPENDAL_S3_ACCESS_KEY_ID: $ACCESS_KEY
+          OPENDAL_S3_SECRET_ACCESS_KEY: $SECRET_KEY


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced by this PR. -->
- fixed: #1924 

## Encounter Problem:
### Failed on these behavior test:
   - services_s3::write_test_delete_with_special_chars
   - services_s3::write_test_read_with_special_chars
   - services_s3::write_test_stat_with_special_chars
   - services_s3::write_test_write_with_special_chars

All 4 Error Logs are the same:
```log
2023-05-21T23:03:10.5749643Z Context:
2023-05-21T23:03:10.5750818Z     response: Parts { status: 404, version: HTTP/1.1, headers: {"content-type": "application/xml", "content-length": "296", "x-amz-request-id": "1e65c26a-2833-4f3e-90c5-0718309a0758", "x-amz-id-2": "s9lzHYrFp76ZVxRcpX9+5cjAnEH2ROuNkd2BHfIa6UkFVdtjf5mKR3/eTPFvsiP/XV/VLi31234=", "connection": "close", "date": "Sun, 21 May 2023 23:02:59 GMT", "server": "hypercorn-h11"} }
2023-05-21T23:03:10.5750934Z     service: s3
2023-05-21T23:03:10.5751222Z     path: 65002cd5-bcc5-4127-94c5-3e81a53fddf7 !@#$%^&()_+-=;',.txt
2023-05-21T23:03:10.5751336Z 
2023-05-21T23:03:10.5751663Z    core/src/layers/logging.rs:1332
2023-05-21T23:03:10.5751671Z 
2023-05-21T23:03:10.5752260Z   2023-05-21T23:02:59.350155Z WARN;opendal::layers::complete: writer has not been closed or aborted, must be a bug
2023-05-21T23:03:10.5752602Z    core/src/layers/complete.rs:539
2023-05-21T23:03:10.5752615Z 
2023-05-21T23:03:10.5753319Z thread 'services_s3::write_test_read_with_special_chars' panicked at 'write must succeed: NotFound (permanent) at Writer::write => S3Error { code: "NoSuchKey", message: "The specified key does not exist.", resource: "", request_id: "1e65c26a-2833-4f3e-90c5-0718309a0758" }
```
(Note: There are some errors that appear in 6 other tests, but they are just warnings.)

Hi @Xuanwo, could you please confirm if this is the expected behavior? I'm afraid that this might be a problem with LocalStack. Thank you. (Also, regrading to the [original issue](https://github.com/apache/incubator-opendal/issues/1924).  I don't know what role `amazon-ec2-metadata-mock` and `minio` play in this test.)

## Proof Of Concept

### Remove `OPENDAL_S3_SECRET_ACCESS_KEY` and see if there is any difference.

Tests using ACCESS_KEY to create an s3 service will fail with the following error:
```log
2023-05-22T00:45:23.5647267Z Context:
2023-05-22T00:45:23.5647368Z     service: s3
2023-05-22T00:45:23.5647586Z     path: 916177b4-3166-42e6-97b6-762b5aaeeb0f
2023-05-22T00:45:23.5647696Z 
2023-05-22T00:45:23.5647911Z     at core/src/layers/logging.rs:1332
2023-05-22T00:45:23.5647920Z 
2023-05-22T00:45:23.5648795Z   2023-05-22T00:43:18.210932Z  WARN opendal::service: operation=Writer::write path=916177b4-3166-42e6-97b6-762b5aaeeb0f -> pager retry after 4s: error=PermissionDenied (temporary) at Writer::write => no valid credential found, please check configuration or try again
2023-05-22T00:45:23.5648807Z 
2023-05-22T00:45:23.5648897Z Context:
2023-05-22T00:45:23.5648996Z     service: s3
2023-05-22T00:45:23.5649210Z     path: 916177b4-3166-42e6-97b6-762b5aaeeb0f
2023-05-22T00:45:23.5649319Z 
2023-05-22T00:45:23.5649517Z     at core/src/layers/retry.rs:641
2023-05-22T00:45:23.5649541Z 
2023-05-22T00:45:23.5650010Z   2023-05-22T00:43:22.212386Z DEBUG opendalhyper::client::pool: reuse idle connection for ("http", 169.254.169.254)
2023-05-22T00:45:23.5650433Z     at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-0.14.25/src/client/pool.rs:250
2023-05-22T00:45:23.5650458Z 
2023-05-22T00:45:23.5650931Z   2023-05-22T00:43:22.215370Z DEBUG opendalhyper::client::pool: pooling idle connection for ("http", 169.254.169.254)
2023-05-22T00:45:23.5651350Z     at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-0.14.25/src/client/pool.rs:376
2023-05-22T00:45:23.5651374Z 
2023-05-22T00:45:23.5652013Z   2023-05-22T00:43:22.215530Z DEBUG opendalreqsign::aws::credential: load credential via imds_v2 failed: request to AWS EC2 Metadata Services failed: <?xml version="1.0" encoding="utf-8"?>
2023-05-22T00:45:23.5652527Z <Error xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
2023-05-22T00:45:23.5652658Z     <Code>InvalidHttpVerb</Code>
2023-05-22T00:45:23.5652869Z     <Message>The HTTP verb specified was not recognized by the server.</Message>
2023-05-22T00:45:23.5653106Z     <Details>'PUT' is not a supported verb.</Details>
2023-05-22T00:45:23.5653237Z </Error>
2023-05-22T00:45:23.5653659Z     at /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/reqsign-0.12.0/src/aws/credential.rs:166
2023-05-22T00:45:23.5653669Z 
2023-05-22T00:45:23.5654557Z   2023-05-22T00:43:22.215581Z ERROR opendal::services: service=s3 operation=Writer::write path=916177b4-3166-42e6-97b6-762b5aaeeb0f written=0 -> data write failed: PermissionDenied (temporary) at Writer::write => no valid credential found, please check configuration or try again
```