### PR TITLE
refactor: Add Operator::via_map to support init without generic type parameters

### DIFF
--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -25,63 +25,6 @@ use std::time::Duration;
 use futures::TryStreamExt;
 use napi::bindgen_prelude::*;
 
-fn build_operator(
-    scheme: opendal::Scheme,
-    map: HashMap<String, String>,
-) -> Result<opendal::Operator> {
-    use opendal::services::*;
-
-    let op = match scheme {
-        opendal::Scheme::Azblob => opendal::Operator::from_map::<Azblob>(map)
-            .map_err(format_napi_error)?
-            .finish(),
-        opendal::Scheme::Azdfs => opendal::Operator::from_map::<Azdfs>(map)
-            .map_err(format_napi_error)?
-            .finish(),
-        opendal::Scheme::Fs => opendal::Operator::from_map::<Fs>(map)
-            .map_err(format_napi_error)?
-            .finish(),
-        opendal::Scheme::Gcs => opendal::Operator::from_map::<Gcs>(map)
-            .map_err(format_napi_error)?
-            .finish(),
-        opendal::Scheme::Ghac => opendal::Operator::from_map::<Ghac>(map)
-            .map_err(format_napi_error)?
-            .finish(),
-        opendal::Scheme::Http => opendal::Operator::from_map::<Http>(map)
-            .map_err(format_napi_error)?
-            .finish(),
-        opendal::Scheme::Ipmfs => opendal::Operator::from_map::<Ipmfs>(map)
-            .map_err(format_napi_error)?
-            .finish(),
-        opendal::Scheme::Memory => opendal::Operator::from_map::<Memory>(map)
-            .map_err(format_napi_error)?
-            .finish(),
-        opendal::Scheme::Obs => opendal::Operator::from_map::<Obs>(map)
-            .map_err(format_napi_error)?
-            .finish(),
-        opendal::Scheme::Oss => opendal::Operator::from_map::<Oss>(map)
-            .map_err(format_napi_error)?
-            .finish(),
-        opendal::Scheme::S3 => opendal::Operator::from_map::<S3>(map)
-            .map_err(format_napi_error)?
-            .finish(),
-        opendal::Scheme::Webdav => opendal::Operator::from_map::<Webdav>(map)
-            .map_err(format_napi_error)?
-            .finish(),
-        opendal::Scheme::Webhdfs => opendal::Operator::from_map::<Webhdfs>(map)
-            .map_err(format_napi_error)?
-            .finish(),
-        _ => {
-            return Err(format_napi_error(opendal::Error::new(
-                opendal::ErrorKind::Unexpected,
-                "not supported scheme",
-            )))
-        }
-    };
-
-    Ok(op)
-}
-
 #[napi]
 pub struct Operator(opendal::Operator);
 
@@ -97,7 +40,9 @@ impl Operator {
             .map_err(format_napi_error)?;
         let options = options.unwrap_or_default();
 
-        build_operator(scheme, options).map(Operator)
+        opendal::Operator::via_map(scheme, options)
+            .map_err(format_napi_error)
+            .map(Operator)
     }
 
     /// Get current path's metadata **without cache** directly.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -62,52 +62,7 @@ fn build_operator(
     map: HashMap<String, String>,
     layers: Vec<layers::Layer>,
 ) -> PyResult<od::Operator> {
-    use od::services::*;
-
-    let op = match scheme {
-        od::Scheme::Azblob => od::Operator::from_map::<Azblob>(map)
-            .map_err(format_pyerr)?
-            .finish(),
-        od::Scheme::Azdfs => od::Operator::from_map::<Azdfs>(map)
-            .map_err(format_pyerr)?
-            .finish(),
-        od::Scheme::Fs => od::Operator::from_map::<Fs>(map)
-            .map_err(format_pyerr)?
-            .finish(),
-        od::Scheme::Gcs => od::Operator::from_map::<Gcs>(map)
-            .map_err(format_pyerr)?
-            .finish(),
-        od::Scheme::Ghac => od::Operator::from_map::<Ghac>(map)
-            .map_err(format_pyerr)?
-            .finish(),
-        od::Scheme::Http => od::Operator::from_map::<Http>(map)
-            .map_err(format_pyerr)?
-            .finish(),
-        od::Scheme::Ipmfs => od::Operator::from_map::<Ipmfs>(map)
-            .map_err(format_pyerr)?
-            .finish(),
-        od::Scheme::Memory => od::Operator::from_map::<Memory>(map)
-            .map_err(format_pyerr)?
-            .finish(),
-        od::Scheme::Obs => od::Operator::from_map::<Obs>(map)
-            .map_err(format_pyerr)?
-            .finish(),
-        od::Scheme::Oss => od::Operator::from_map::<Oss>(map)
-            .map_err(format_pyerr)?
-            .finish(),
-        od::Scheme::S3 => od::Operator::from_map::<S3>(map)
-            .map_err(format_pyerr)?
-            .finish(),
-        od::Scheme::Webdav => od::Operator::from_map::<Webdav>(map)
-            .map_err(format_pyerr)?
-            .finish(),
-        od::Scheme::Webhdfs => od::Operator::from_map::<Webhdfs>(map)
-            .map_err(format_pyerr)?
-            .finish(),
-        _ => Err(PyNotImplementedError::new_err(format!(
-            "unsupported scheme `{scheme}`"
-        )))?,
-    };
+    let op = od::Operator::via_map(scheme, map).map_err(format_pyerr)?;
 
     add_layers(op, layers)
 }

--- a/core/benches/ops/utils.rs
+++ b/core/benches/ops/utils.rs
@@ -31,8 +31,17 @@ fn service<AB: Builder>() -> Option<Operator> {
         return None;
     }
 
+    let prefix = format!("opendal_{}_", AB::SCHEME);
+    let envs = env::vars()
+        .filter_map(move |(k, v)| {
+            k.to_lowercase()
+                .strip_prefix(&prefix)
+                .map(|k| (k.to_string(), v))
+        })
+        .collect();
+
     Some(
-        Operator::from_env::<AB>()
+        Operator::from_map::<AB>(envs)
             .unwrap_or_else(|_| panic!("init {} must succeed", AB::SCHEME))
             .finish(),
     )

--- a/core/src/layers/immutable_index.rs
+++ b/core/src/layers/immutable_index.rs
@@ -289,9 +289,12 @@ mod tests {
             iil.insert(i.to_string())
         }
 
-        let op = Operator::new(Http::from_iter(
-            vec![("endpoint".to_string(), "https://xuanwo.io".to_string())].into_iter(),
-        ))?
+        let op = Operator::new(Http::from_map({
+            let mut map = HashMap::new();
+            map.insert("endpoint".to_string(), "https://xuanwo.io".to_string());
+
+            map
+        }))?
         .layer(LoggingLayer::default())
         .layer(iil)
         .finish();
@@ -327,9 +330,12 @@ mod tests {
             iil.insert(i.to_string())
         }
 
-        let op = Operator::new(Http::from_iter(
-            vec![("endpoint".to_string(), "https://xuanwo.io".to_string())].into_iter(),
-        ))?
+        let op = Operator::new(Http::from_map({
+            let mut map = HashMap::new();
+            map.insert("endpoint".to_string(), "https://xuanwo.io".to_string());
+
+            map
+        }))?
         .layer(LoggingLayer::default())
         .layer(iil)
         .finish();
@@ -371,9 +377,12 @@ mod tests {
             iil.insert(i.to_string())
         }
 
-        let op = Operator::new(Http::from_iter(
-            vec![("endpoint".to_string(), "https://xuanwo.io".to_string())].into_iter(),
-        ))?
+        let op = Operator::new(Http::from_map({
+            let mut map = HashMap::new();
+            map.insert("endpoint".to_string(), "https://xuanwo.io".to_string());
+
+            map
+        }))?
         .layer(LoggingLayer::default())
         .layer(iil)
         .finish();
@@ -432,9 +441,12 @@ mod tests {
             iil.insert(i.to_string())
         }
 
-        let op = Operator::new(Http::from_iter(
-            vec![("endpoint".to_string(), "https://xuanwo.io".to_string())].into_iter(),
-        ))?
+        let op = Operator::new(Http::from_map({
+            let mut map = HashMap::new();
+            map.insert("endpoint".to_string(), "https://xuanwo.io".to_string());
+
+            map
+        }))?
         .layer(LoggingLayer::default())
         .layer(iil)
         .finish();

--- a/core/src/types/builder.rs
+++ b/core/src/types/builder.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::collections::HashMap;
-use std::env;
 
 use crate::raw::*;
 use crate::*;
@@ -44,31 +43,6 @@ pub trait Builder: Default {
 
     /// Construct a builder from given map which contains several parameters needed by underlying service.
     fn from_map(map: HashMap<String, String>) -> Self;
-
-    /// Construct a builder from given iterator.
-    fn from_iter(iter: impl Iterator<Item = (String, String)>) -> Self
-    where
-        Self: Sized,
-    {
-        Self::from_map(iter.collect())
-    }
-
-    /// Construct a builder from envs. Please note that the env should begin with `opendal_{schema_name}_`.
-    fn from_env() -> Self
-    where
-        Self: Sized,
-    {
-        let prefix = format!("opendal_{}_", Self::SCHEME);
-        let envs = env::vars()
-            .filter_map(move |(k, v)| {
-                k.to_lowercase()
-                    .strip_prefix(&prefix)
-                    .map(|k| (k.to_string(), v))
-            })
-            .collect();
-
-        Self::from_map(envs)
-    }
 
     /// Consume the accessor builder to build a service.
     fn build(&mut self) -> Result<Self::Accessor>;

--- a/core/src/types/operator/builder.rs
+++ b/core/src/types/operator/builder.rs
@@ -82,6 +82,15 @@ impl Operator {
 
     /// Create a new operator from given map.
     ///
+    /// # Notes
+    ///
+    /// from_map is using static dispatch layers which is zero cost. via_map is
+    /// using dynamic dispatch layers which has a bit runtime overhead with an
+    /// extra vtable lookup and unable to inline. But from_map requires generic
+    /// type parameter which is not always easy to be used.
+    ///
+    /// # Examples
+    ///
     /// ```
     /// # use anyhow::Result;
     /// use std::collections::HashMap;
@@ -108,6 +117,110 @@ impl Operator {
     ) -> Result<OperatorBuilder<impl Accessor>> {
         let acc = B::from_map(map).build()?;
         Ok(OperatorBuilder::new(acc))
+    }
+
+    /// Create a new operator from given shceme and map.
+    ///
+    /// # Notes
+    ///
+    /// from_map is using static dispatch layers which is zero cost. via_map is
+    /// using dynamic dispatch layers which has a bit runtime overhead with an
+    /// extra vtable lookup and unable to inline. But from_map requires generic
+    /// type parameter which is not always easy to be used.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use anyhow::Result;
+    /// use std::collections::HashMap;
+    ///
+    /// use opendal::Scheme;
+    /// use opendal::Operator;
+    /// #[tokio::main]
+    /// async fn main() -> Result<()> {
+    ///     let map = HashMap::from([
+    ///         // Set the root for fs, all operations will happen under this root.
+    ///         //
+    ///         // NOTE: the root must be absolute path.
+    ///         ("root".to_string(), "/tmp".to_string()),
+    ///     ]);
+    ///
+    ///     // Build an `Operator` to start operating the storage.
+    ///     let op: Operator = Operator::via_map(Scheme::Fs, map)?.finish();
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn via_map(scheme: Scheme, map: HashMap<String, String>) -> Result<Operator> {
+        let op = match scheme {
+            #[cfg(feature = "services-azblob")]
+            Scheme::Azblob => Self::from_map::<services::Azblob>(map)?.finish(),
+            #[cfg(feature = "services-azdfs")]
+            Scheme::Azdfs => Self::from_map::<services::Azdfs>(map)?.finish(),
+            #[cfg(feature = "services-cos")]
+            Scheme::Cos => Self::from_map::<services::Cos>(map)?.finish(),
+            #[cfg(feature = "services-dashmap")]
+            Scheme::Dashmap => Self::from_map::<services::Dashmap>(map)?.finish(),
+            #[cfg(feature = "services-fs")]
+            Scheme::Fs => Self::from_map::<services::Fs>(map)?.finish(),
+            #[cfg(feature = "services-ftp")]
+            Scheme::Ftp => Self::from_map::<services::Ftp>(map)?.finish(),
+            #[cfg(feature = "services-gcs")]
+            Scheme::Gcs => Self::from_map::<services::Gcs>(map)?.finish(),
+            #[cfg(feature = "services-ghac")]
+            Scheme::Ghac => Self::from_map::<services::Ghac>(map)?.finish(),
+            #[cfg(feature = "services-hdfs")]
+            Scheme::Hdfs => Self::from_map::<services::Hdfs>(map)?.finish(),
+            #[cfg(feature = "services-http")]
+            Scheme::Http => Self::from_map::<services::Http>(map)?.finish(),
+            #[cfg(feature = "services-ipfs")]
+            Scheme::Ipfs => Self::from_map::<services::Ipfs>(map)?.finish(),
+            #[cfg(feature = "services-ipmfs")]
+            Scheme::Ipmfs => Self::from_map::<services::Ipmfs>(map)?.finish(),
+            #[cfg(feature = "services-memcached")]
+            Scheme::Memcached => Self::from_map::<services::Memcached>(map)?.finish(),
+            #[cfg(feature = "services-memory")]
+            Scheme::Memory => Self::from_map::<services::Memory>(map)?.finish(),
+            #[cfg(feature = "services-moka")]
+            Scheme::Moka => Self::from_map::<services::Moka>(map)?.finish(),
+            #[cfg(feature = "services-obs")]
+            Scheme::Obs => Self::from_map::<services::Obs>(map)?.finish(),
+            #[cfg(feature = "services-onedrive")]
+            Scheme::Onedrive => Self::from_map::<services::Onedrive>(map)?.finish(),
+            #[cfg(feature = "services-gdrive")]
+            Scheme::Gdrive => Self::from_map::<services::Gdrive>(map)?.finish(),
+            #[cfg(feature = "services-oss")]
+            Scheme::Oss => Self::from_map::<services::Oss>(map)?.finish(),
+            #[cfg(feature = "services-redis")]
+            Scheme::Redis => Self::from_map::<services::Redis>(map)?.finish(),
+            #[cfg(feature = "services-rocksdb")]
+            Scheme::Rocksdb => Self::from_map::<services::Rocksdb>(map)?.finish(),
+            #[cfg(feature = "services-s3")]
+            Scheme::S3 => Self::from_map::<services::S3>(map)?.finish(),
+            #[cfg(feature = "services-sftp")]
+            Scheme::Sftp => Self::from_map::<services::Sftp>(map)?.finish(),
+            #[cfg(feature = "services-sled")]
+            Scheme::Sled => Self::from_map::<services::Sled>(map)?.finish(),
+            #[cfg(feature = "services-supabase")]
+            Scheme::Supabase => Self::from_map::<services::Supabase>(map)?.finish(),
+            #[cfg(feature = "services-vercel-artifacts")]
+            Scheme::VercelArtifacts => Self::from_map::<services::VercelArtifacts>(map)?.finish(),
+            #[cfg(feature = "services-wasabi")]
+            Scheme::Wasabi => Self::from_map::<services::Wasabi>(map)?.finish(),
+            #[cfg(feature = "services-webdav")]
+            Scheme::Webdav => Self::from_map::<services::Webdav>(map)?.finish(),
+            #[cfg(feature = "services-webhdfs")]
+            Scheme::Webhdfs => Self::from_map::<services::Webhdfs>(map)?.finish(),
+            v => {
+                return Err(Error::new(
+                    ErrorKind::Unsupported,
+                    "scheme is not enabled or supported",
+                )
+                .with_context("scheme", v))
+            }
+        };
+
+        Ok(op)
     }
 
     /// Create a new layer with dynamic dispatch.

--- a/core/src/types/operator/builder.rs
+++ b/core/src/types/operator/builder.rs
@@ -110,31 +110,6 @@ impl Operator {
         Ok(OperatorBuilder::new(acc))
     }
 
-    /// Create a new operator from iter.
-    ///
-    /// # WARNING
-    ///
-    /// It's better to use `from_map`. We may remove this API in the
-    /// future.
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_iter<B: Builder>(
-        iter: impl Iterator<Item = (String, String)>,
-    ) -> Result<OperatorBuilder<impl Accessor>> {
-        let acc = B::from_iter(iter).build()?;
-        Ok(OperatorBuilder::new(acc))
-    }
-
-    /// Create a new operator from env.
-    ///
-    /// # WARNING
-    ///
-    /// It's better to use `from_map`. We may remove this API in the
-    /// future.
-    pub fn from_env<B: Builder>() -> Result<OperatorBuilder<impl Accessor>> {
-        let acc = B::from_env().build()?;
-        Ok(OperatorBuilder::new(acc))
-    }
-
     /// Create a new layer with dynamic dispatch.
     ///
     /// # Notes

--- a/core/src/types/scheme.rs
+++ b/core/src/types/scheme.rs
@@ -41,6 +41,8 @@ pub enum Scheme {
     Dashmap,
     /// [fs][crate::services::Fs]: POSIX alike file system.
     Fs,
+    /// [ftp][crate::services::Ftp]: FTP backend.
+    Ftp,
     /// [gcs][crate::services::Gcs]: Google Cloud Storage backend.
     Gcs,
     /// [ghac][crate::services::Ghac]: GitHub Action Cache services.
@@ -49,8 +51,7 @@ pub enum Scheme {
     Hdfs,
     /// [http][crate::services::Http]: HTTP backend.
     Http,
-    /// [ftp][crate::services::Ftp]: FTP backend.
-    Ftp,
+
     /// [ipmfs][crate::services::Ipfs]: IPFS HTTP Gateway
     Ipfs,
     /// [ipmfs][crate::services::Ipmfs]: IPFS mutable file system


### PR DESCRIPTION
This PR also removes not used `from_iter` and `from_env`.