### PR TITLE
Bump to version 0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v0.35.0] - 2023-05-23
+
+### Added
+
+- feat(services/onedrive): Implement `list`, `create_dir`, `stat` and upload
+ing large files (#2231)
+- feat(bindings/C): Initially support stat in C binding (#2249)
+- feat(bindings/python): Enable `abi3` to avoid building on different python
+ version (#2255)
+- feat(bindings/C): support BDD tests using GTest (#2254)
+- feat(services/sftp): setup integration tests (#2192)
+- feat(core): Add trait and public API for `append` (#2260)
+- feat(services/sftp): support copy and rename for sftp (#2263)
+- feat(services/sftp): support copy and read_seek (#2267)
+- feat: Add COS service support (#2269)
+- feat(services/cos): Add support for loading from env (#2271)
+- feat(core): add presign support for obs (#2253)
+- feat(services/sftp): setup integration tests (#2192)
+- feat(core): add presign support for obs (#2253)
+- feat(core): public API of append (#2284)
+- test(core): test for append (#2286)
+- feat(services/oss): add append support (#2279)
+- feat(bindings/java): implement async ops to pass AsyncStepsTest (#2291)
+
+### Changed
+
+- services/gdrive: port code to GdriveCore & add path_2_id cache (#2203)
+- refactor: Minimize futures dependencies (#2248)
+- refactor: Add Operator::via_map to support init without generic type parameters (#2280)
+- refactor(binding/java): build, async and docs (#2276)
+
+### Fixed
+
+- fix: Fix bugs that failed wasabi's integration tests (#2273)
+
+### Removed
+
+- feat(core): remove `scan` from raw API (#2262)
+
+### Docs
+
+- chore(s3): update builder region doc (#2247)
+- docs: Add services in readme (#2251)
+- docs: Unify capabilities list for kv services (#2257)
+- docs(nodejs): fix some example code errors (#2277)
+- docs(bindings/C): C binding contributing documentation (#2266)
+- docs: Add new docs that available for all languages (#2285)
+- docs: Remove unlicensed svg (#2289)
+- fix(website): double active route (#2290)
+
+### CI
+
+- ci: Enable test for cos (#2270)
+- ci: Add integration tests for supabase (#2272)
+- ci: replace set-output for docs (#2275)
+- ci: Fix unit tests (#2282)
+- ci: Cleanup NOTICE file (#2281)
+- ci: Fix release not contains incubating (#2292)
+
+### Chore
+
+- chore(core): remove unnecessary path prefix (#2265)
+
 ## [v0.34.0] - 2023-05-09
 
 ### Added
@@ -2097,6 +2160,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 Hello, OpenDAL!
 
+[v0.35.0]: https://github.com/apache/incubator-opendal/compare/v0.34.0...v0.35.0
 [v0.34.0]: https://github.com/apache/incubator-opendal/compare/v0.33.3...v0.34.0
 [v0.33.3]: https://github.com/apache/incubator-opendal/compare/v0.33.2...v0.33.3
 [v0.33.2]: https://github.com/apache/incubator-opendal/compare/v0.33.1...v0.33.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "oay"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_opendal"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "oli"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2618,7 +2618,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-nodejs"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "futures",
  "napi",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-python"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "futures",
  "opendal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-opendal"
 rust-version = "1.65"
-version = "0.34.0"
+version = "0.35.0"
 
 [workspace.dependencies]
-opendal = { version = "0.34", path = "core" }
+opendal = { version = "0.35", path = "core" }

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-arm64",
   "repository": "git@github.com/apache/incubator-opendal.git",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-x64",
   "repository": "git@github.com/apache/incubator-opendal.git",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "repository": "git@github.com/apache/incubator-opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "repository": "git@github.com/apache/incubator-opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "OpenDAL Contributors <dev@opendal.apache.org>",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",

--- a/core/src/docs/upgrade.md
+++ b/core/src/docs/upgrade.md
@@ -1,3 +1,15 @@
+# Upgrade to v0.35
+
+## Public API
+
+- OpenDAL removes rarely used `Operator::from_env` and `Operator::from_iter` APIs
+  - Users can use `Operator::via_map` instead.
+
+## Raw API
+
+- OpenDAL adds `append` support with could break existing layers. Please make sure `append` requests have been forward correctly.
+- After the merging of `scan` and `list`, OpenDAL removes the `scan` from raw API. Please use `list_without_delimiter` instead.
+
 # Upgrade to v0.34
 
 ## Public API


### PR DESCRIPTION
### Added

- feat(services/onedrive): Implement `list`, `create_dir`, `stat` and upload
ing large files (#2231)
- feat(bindings/C): Initially support stat in C binding (#2249)
- feat(bindings/python): Enable `abi3` to avoid building on different python
 version (#2255)
- feat(bindings/C): support BDD tests using GTest (#2254)
- feat(services/sftp): setup integration tests (#2192)
- feat(core): Add trait and public API for `append` (#2260)
- feat(services/sftp): support copy and rename for sftp (#2263)
- feat(services/sftp): support copy and read_seek (#2267)
- feat: Add COS service support (#2269)
- feat(services/cos): Add support for loading from env (#2271)
- feat(core): add presign support for obs (#2253)
- feat(services/sftp): setup integration tests (#2192)
- feat(core): add presign support for obs (#2253)
- feat(core): public API of append (#2284)
- test(core): test for append (#2286)
- feat(services/oss): add append support (#2279)
- feat(bindings/java): implement async ops to pass AsyncStepsTest (#2291)

### Changed

- services/gdrive: port code to GdriveCore & add path_2_id cache (#2203)
- refactor: Minimize futures dependencies (#2248)
- refactor: Add Operator::via_map to support init without generic type parameters (#2280)
- refactor(binding/java): build, async and docs (#2276)

### Fixed

- fix: Fix bugs that failed wasabi's integration tests (#2273)

### Removed

- feat(core): remove `scan` from raw API (#2262)

### Docs

- chore(s3): update builder region doc (#2247)
- docs: Add services in readme (#2251)
- docs: Unify capabilities list for kv services (#2257)
- docs(nodejs): fix some example code errors (#2277)
- docs(bindings/C): C binding contributing documentation (#2266)
- docs: Add new docs that available for all languages (#2285)
- docs: Remove unlicensed svg (#2289)
- fix(website): double active route (#2290)

### CI

- ci: Enable test for cos (#2270)
- ci: Add integration tests for supabase (#2272)
- ci: replace set-output for docs (#2275)
- ci: Fix unit tests (#2282)
- ci: Cleanup NOTICE file (#2281)
- ci: Fix release not contains incubating (#2292)

### Chore

- chore(core): remove unnecessary path prefix (#2265)