### PR TITLE
docs: Fixed links of languages to open in same tab

### DIFF
--- a/website/src/components/HomepageFeatures/_feature_languages.mdx
+++ b/website/src/components/HomepageFeatures/_feature_languages.mdx
@@ -1,4 +1,4 @@
-Apache OpenDAL provides [Rust Core](/docs/rust/opendal) and builds different language bindings like [Node.js Binding](/docs/nodejs) and [Python Binding](/docs/python).
+Apache OpenDAL provides [Rust Core](/docs/rust/opendal/) and builds different language bindings like [Node.js Binding](/docs/nodejs/) and [Python Binding](/docs/python/).
 
 > *More bindings like [C](https://github.com/apache/incubator-opendal/blob/main/bindings/c/README.md), [Java](https://github.com/apache/incubator-opendal/blob/main/bindings/java/README.md), [Ruby](https://github.com/apache/incubator-opendal/blob/main/bindings/ruby/README.md) are still working on.*
 


### PR DESCRIPTION
Fixes #2326 

Updates links of supported languages and bindings to open in the same/current tab. 