### PR TITLE
ci(binding/nodejs): Use docker to build nodejs binding

### DIFF
--- a/.github/workflows/bindings_nodejs.yml
+++ b/.github/workflows/bindings_nodejs.yml
@@ -74,7 +74,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
+#    if: "startsWith(github.ref, 'refs/tags/')"
 
     # Notes: this defaults only apply on run tasks.
     defaults:

--- a/.github/workflows/bindings_nodejs.yml
+++ b/.github/workflows/bindings_nodejs.yml
@@ -37,11 +37,6 @@ on:
 
 jobs:
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        node:
-          - '18'
     runs-on: ubuntu-latest
 
     # Notes: this defaults only apply on run tasks.
@@ -56,7 +51,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '18'
           cache: yarn
           cache-dependency-path: "bindings/nodejs/yarn.lock"
 
@@ -78,11 +73,6 @@ jobs:
         run: yarn test
 
   linux:
-    strategy:
-      fail-fast: false
-      matrix:
-        node:
-          - '18'
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
 
@@ -96,7 +86,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 18
           cache: yarn
           cache-dependency-path: "bindings/nodejs/yarn.lock"
       - name: Corepack
@@ -104,7 +94,15 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Build
-        run: yarn build
+        run: |
+          docker run \
+            -v ${{ github.workspace }}:/build \
+            -e NAPI_TARGET=x86_64-unknown-linux-gnu \
+            -w /build/bindings/nodejs \
+            ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian \
+            bash -c "yarn build"
+          # change owner to current user
+          chown -R 1001:121 *.node
       - uses: actions/upload-artifact@v3
         with:
           name: bindings-linux
@@ -113,11 +111,6 @@ jobs:
         run: yarn test
 
   windows:
-    strategy:
-      fail-fast: false
-      matrix:
-        node:
-          - '18'
     runs-on: windows-latest
     if: "startsWith(github.ref, 'refs/tags/')"
 
@@ -131,7 +124,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '18'
           cache: yarn
           cache-dependency-path: "bindings/nodejs/yarn.lock"
       - name: Corepack
@@ -148,11 +141,10 @@ jobs:
         run: yarn test
 
   macos:
+    runs-on: macos-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
     strategy:
-      fail-fast: false
       matrix:
-        node:
-          - '18'
         settings:
           - target: x86_64-apple-darwin
             test: yarn test
@@ -171,8 +163,6 @@ jobs:
               export NAPI_TARGET=aarch64-apple-darwin;
               yarn build
               strip -x *.node
-    runs-on: macos-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
 
     # Notes: this defaults only apply on run tasks.
     defaults:
@@ -186,7 +176,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '18'
           cache: yarn
           cache-dependency-path: "bindings/nodejs/yarn.lock"
       - name: Corepack

--- a/.github/workflows/bindings_nodejs.yml
+++ b/.github/workflows/bindings_nodejs.yml
@@ -74,7 +74,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-#    if: "startsWith(github.ref, 'refs/tags/')"
+    if: "startsWith(github.ref, 'refs/tags/')"
 
     # Notes: this defaults only apply on run tasks.
     defaults:

--- a/.github/workflows/bindings_nodejs.yml
+++ b/.github/workflows/bindings_nodejs.yml
@@ -102,7 +102,7 @@ jobs:
             ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian \
             bash -c "yarn build"
           # change owner to current user
-          chown -R 1001:121 *.node
+          sudo chown -R 1001:121 *.node
       - uses: actions/upload-artifact@v3
         with:
           name: bindings-linux


### PR DESCRIPTION
This PR will use `ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian` to build nodejs binding.