### PR TITLE
feat(bindings/C): opendal_operator_ptr construction using kvs

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -208,7 +208,7 @@ extern "C" {
  opendal_operator_options options = opendal_operator_options_new();
  opendal_operator_options_set(&options, "root", "/myroot");
 
- opendal_operator_ptr ptr = opendal_operator_from_kvs("memory", options);
+ opendal_operator_ptr ptr = opendal_operator_new("memory", options);
 
  opendal_operator_options_free(&options);
 

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn opendal_operator_new(
     scheme: *const c_char,
     options: opendal_operator_options,
 ) -> opendal_operator_ptr {
-    if scheme.is_null() || options.inner.is_null() {
+    if scheme.is_null() || options.is_null() {
         return opendal_operator_ptr::null();
     }
 
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn opendal_operator_new(
     };
 
     let mut map = HashMap::default();
-    for (k, v) in &*options.inner {
+    for (k, v) in options.as_ref() {
         map.insert(k.to_string(), v.to_string());
     }
 

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -31,22 +31,47 @@ use error::opendal_code;
 use result::opendal_result_is_exist;
 use result::opendal_result_read;
 use result::opendal_result_stat;
+use types::opendal_kv;
 use types::opendal_metadata;
 
 use crate::types::opendal_bytes;
 use crate::types::opendal_operator_ptr;
 
-/// Returns a result type [`opendal_result_op`], with operator_ptr. If the construction succeeds
-/// the error is nullptr, otherwise it contains the error information.
+/// Uses an array of key-value pairs to initialize the operator based on provided scheme.
+///
+/// # Example
+///
+/// Following is a C example.
+/// ```no_run
+/// // It is okay to use temporary stack memory for kvs since the only functionality of
+/// // kvs here is to pass it into opendal_operator_from_kvs
+/// opendal_kvs kvs[1];
+/// kvs[0] = opendal_kv { .key = "root", .value = "/myroot"};
+///
+/// opendal_operator_ptr ptr = opendal_operator_from_kvs("memory", kvs, 1);
+///
+/// // ... your operations
+/// ```
 ///
 /// # Safety
 ///
+/// This function is unsafe because it deferences and casts the raw pointers.
 /// It is [safe] under two cases below
 /// * The memory pointed to by `scheme` must contain a valid nul terminator at the end of
 ///   the string.
 /// * The `scheme` points to NULL, this function simply returns you a null opendal_operator_ptr
+/// * The `nr_kvs` provided is correct. If not, this will incur segfault.
+///
+/// # Returns
+///
+/// Returns a result type [`opendal_result_op`], with operator_ptr. If the construction succeeds
+/// the error is nullptr, otherwise it contains the error information.
 #[no_mangle]
-pub unsafe extern "C" fn opendal_operator_new(scheme: *const c_char) -> opendal_operator_ptr {
+pub unsafe extern "C" fn opendal_operator_from_kvs(
+    scheme: *const c_char,
+    kvs: *const opendal_kv,
+    nr_kvs: usize,
+) -> opendal_operator_ptr {
     if scheme.is_null() {
         return opendal_operator_ptr::null();
     }
@@ -59,8 +84,19 @@ pub unsafe extern "C" fn opendal_operator_new(scheme: *const c_char) -> opendal_
         }
     };
 
-    // todo: api for map construction
-    let map = HashMap::default();
+    let mut map = HashMap::default();
+    for i in 0..nr_kvs {
+        let kv = kvs.add(i).as_ref().unwrap();
+        let key = std::ffi::CStr::from_ptr(kv.key)
+            .to_str()
+            .unwrap()
+            .to_string();
+        let value = std::ffi::CStr::from_ptr(kv.value)
+            .to_str()
+            .unwrap()
+            .to_string();
+        map.insert(key, value);
+    }
 
     let op = match scheme {
         od::Scheme::Memory => generate_operator!(od::services::Memory, map),

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -46,7 +46,7 @@ use crate::types::opendal_operator_ptr;
 /// opendal_operator_options options = opendal_operator_options_new();
 /// opendal_operator_options_set(&options, "root", "/myroot");
 ///
-/// opendal_operator_ptr ptr = opendal_operator_from_kvs("memory", options);
+/// opendal_operator_ptr ptr = opendal_operator_new("memory", options);
 ///
 // free the options right away since the options is not used later on
 /// opendal_operator_options_free(&options);

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -184,7 +184,7 @@ impl opendal_metadata {
 /// [`opendal_operator_options`] represents a series of string type key-value pairs, it may be used for initialization
 #[repr(transparent)]
 pub struct opendal_operator_options {
-    pub(crate) inner: *mut HashMap<String, String>,
+    inner: *mut HashMap<String, String>,
 }
 
 impl opendal_operator_options {
@@ -229,6 +229,16 @@ impl opendal_operator_options {
             .unwrap()
             .to_string();
         (*self.inner).insert(k, v);
+    }
+
+    /// Returns a reference to the underlying [`HashMap<String, String>`]
+    pub(crate) fn as_ref(&self) -> &HashMap<String, String> {
+        unsafe { &*(self.inner) }
+    }
+
+    /// Returns whether the underlying HashMap points to NULL
+    pub(crate) fn is_null(&self) -> bool {
+        self.inner.is_null()
     }
 
     /// Free the allocated memory used by [`opendal_operator_options`]

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -17,6 +17,8 @@
 
 use ::opendal as od;
 
+use std::os::raw::c_char;
+
 /// The [`opendal_operator_ptr`] owns a pointer to a [`od::BlockingOperator`].
 /// It is also the key struct that OpenDAL's APIs access the real
 /// operator's memory. The use of OperatorPtr is zero cost, it
@@ -177,4 +179,11 @@ impl opendal_metadata {
             inner: Box::leak(Box::new(m)),
         }
     }
+}
+
+/// [`opendal_kv`] represents a string type key-value pair, it may be used for initialization
+#[repr(C)]
+pub struct opendal_kv {
+    pub key: *const c_char,
+    pub value: *const c_char,
 }

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -184,7 +184,7 @@ impl opendal_metadata {
 /// [`opendal_operator_options`] represents a series of string type key-value pairs, it may be used for initialization
 #[repr(transparent)]
 pub struct opendal_operator_options {
-    pub inner: *mut HashMap<String, String>,
+    pub(crate) inner: *mut HashMap<String, String>,
 }
 
 impl opendal_operator_options {

--- a/bindings/c/tests/bdd.cpp
+++ b/bindings/c/tests/bdd.cpp
@@ -39,10 +39,14 @@ protected:
     this->path = std::string("test");
     this->content = std::string("Hello, World!");
 
-    // set a root
-    opendal_kv kv = opendal_kv{.key = "root", .value = "/root"};
+    // set options
+    opendal_operator_options options = opendal_operator_options_new();
+    opendal_operator_options_set(&options, "root", "/myroot");
 
-    this->p = opendal_operator_from_kvs(scheme.c_str(), &kv, 1);
+    this->p = opendal_operator_new(scheme.c_str(), options);
+
+    // free the options right away since the options is not used later on
+    opendal_operator_options_free(&options);
 
     EXPECT_TRUE(this->p);
 

--- a/bindings/c/tests/bdd.cpp
+++ b/bindings/c/tests/bdd.cpp
@@ -25,98 +25,93 @@ extern "C" {
 
 class OpendalBddTest : public ::testing::Test {
 protected:
-    // Setup code for the fixture
-    opendal_operator_ptr p;
-    std::string scheme;
-    std::string path;
-    std::string content;
+  // Setup code for the fixture
+  opendal_operator_ptr p;
+  std::string scheme;
+  std::string path;
+  std::string content;
 
-    // the fixture setup is an operator write, which will be
-    // run at the beginning of every tests
-    void SetUp() override
-    {
-        // construct the memory operator
-        this->scheme = std::string("memory");
-        this->path = std::string("test");
-        this->content = std::string("Hello, World!");
+  // the fixture setup is an operator write, which will be
+  // run at the beginning of every tests
+  void SetUp() override {
+    // construct the memory operator
+    this->scheme = std::string("memory");
+    this->path = std::string("test");
+    this->content = std::string("Hello, World!");
 
-        this->p = opendal_operator_new(scheme.c_str());
+    // set a root
+    opendal_kv kv = opendal_kv{.key = "root", .value = "/root"};
 
-        EXPECT_TRUE(this->p);
+    this->p = opendal_operator_from_kvs(scheme.c_str(), &kv, 1);
 
-        const opendal_bytes data = {
-            .data = (uint8_t*)this->content.c_str(),
-            .len = this->content.length(),
-        };
+    EXPECT_TRUE(this->p);
 
-        opendal_code code = opendal_operator_blocking_write(this->p, this->path.c_str(), data);
+    const opendal_bytes data = {
+        .data = (uint8_t *)this->content.c_str(),
+        .len = this->content.length(),
+    };
 
-        EXPECT_EQ(code, OPENDAL_OK);
-    }
+    opendal_code code =
+        opendal_operator_blocking_write(this->p, this->path.c_str(), data);
 
-    // Teardown code for the fixture, free the operator
-    void TearDown() override
-    {
-        opendal_operator_free(&this->p);
-    }
+    EXPECT_EQ(code, OPENDAL_OK);
+  }
+
+  // Teardown code for the fixture, free the operator
+  void TearDown() override { opendal_operator_free(&this->p); }
 };
 
 // do nothing, the fixture does the Write Test
-TEST_F(OpendalBddTest, Write)
-{
-}
+TEST_F(OpendalBddTest, Write) {}
 
 // The path must exist
-TEST_F(OpendalBddTest, Exist)
-{
-    opendal_result_is_exist r = opendal_operator_is_exist(this->p, this->path.c_str());
+TEST_F(OpendalBddTest, Exist) {
+  opendal_result_is_exist r =
+      opendal_operator_is_exist(this->p, this->path.c_str());
 
-    EXPECT_EQ(r.code, OPENDAL_OK);
-    EXPECT_TRUE(r.is_exist);
+  EXPECT_EQ(r.code, OPENDAL_OK);
+  EXPECT_TRUE(r.is_exist);
 }
 
 // The entry mode must be file
-TEST_F(OpendalBddTest, EntryMode)
-{
-    opendal_result_stat r = opendal_operator_stat(this->p, this->path.c_str());
-    EXPECT_EQ(r.code, OPENDAL_OK);
+TEST_F(OpendalBddTest, EntryMode) {
+  opendal_result_stat r = opendal_operator_stat(this->p, this->path.c_str());
+  EXPECT_EQ(r.code, OPENDAL_OK);
 
-    opendal_metadata meta = r.meta;
-    EXPECT_TRUE(opendal_metadata_is_file(&meta));
+  opendal_metadata meta = r.meta;
+  EXPECT_TRUE(opendal_metadata_is_file(&meta));
 
-    opendal_metadata_free(&meta);
+  opendal_metadata_free(&meta);
 }
 
 // The content length must be consistent
-TEST_F(OpendalBddTest, ContentLength)
-{
-    opendal_result_stat r = opendal_operator_stat(this->p, this->path.c_str());
-    EXPECT_EQ(r.code, OPENDAL_OK);
+TEST_F(OpendalBddTest, ContentLength) {
+  opendal_result_stat r = opendal_operator_stat(this->p, this->path.c_str());
+  EXPECT_EQ(r.code, OPENDAL_OK);
 
-    opendal_metadata meta = r.meta;
-    EXPECT_EQ(opendal_metadata_content_length(&meta), 13);
+  opendal_metadata meta = r.meta;
+  EXPECT_EQ(opendal_metadata_content_length(&meta), 13);
 
-    opendal_metadata_free(&meta);
+  opendal_metadata_free(&meta);
 }
 
 // We must read the correct content
-TEST_F(OpendalBddTest, Read)
-{
-    struct opendal_result_read r = opendal_operator_blocking_read(this->p, this->path.c_str());
+TEST_F(OpendalBddTest, Read) {
+  struct opendal_result_read r =
+      opendal_operator_blocking_read(this->p, this->path.c_str());
 
-    EXPECT_EQ(r.code, OPENDAL_OK);
-    EXPECT_EQ(r.data->len, this->content.length());
+  EXPECT_EQ(r.code, OPENDAL_OK);
+  EXPECT_EQ(r.data->len, this->content.length());
 
-    for (int i = 0; i < r.data->len; i++) {
-        EXPECT_EQ(this->content[i], (char)(r.data->data[i]));
-    }
+  for (int i = 0; i < r.data->len; i++) {
+    EXPECT_EQ(this->content[i], (char)(r.data->data[i]));
+  }
 
-    // free the bytes's heap memory
-    opendal_bytes_free(r.data);
+  // free the bytes's heap memory
+  opendal_bytes_free(r.data);
 }
 
-int main(int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Introduce initializing opendal_operator by key-value pairs. With this PR, we can build operator on any scheme theoretically 😆 .

# Some explainations

For map construction, I came up with essentially three ideas.

1. Use a `opendal_map` struct, which is essentially a pointer to Rust Hashmap. I did **not** use this because this introduce complexity just like we construct a `opendal_operator_ptr`, users have to pay their extra attention on freeing the heap memory that is even used only once.
```Rust
opendal_map m = opendal_map_new(kvs: opendal_kvs);
opendal_operator_ptr ptr = opendal_operator_from_map(scheme, m);

/* I don't want this since this is not necessary, we are not using this anymore */
opendal_map_free(m);

opendal_operator_ptr_free(ptr);
```

---

2. Use a series of keys and values in the `opendal_operator_ptr_from_kvs()`,  this api would be like
```Rust
fn opendal_operator_ptr_from_kvs(scheme: *const c_char, keys: *const c_char, values: *const c_char) -> ....
```

The pro of this is that we do not need to introduce any new foreign, hard to manage data structures into Rust (like we actually do in this PR for `opendal_kv`).
The con of this is that users have we make sure that **the ordering and the number** of the provided keys and values are correct, making this API really bad.

---

3. The approach used in this PR. We introduce a new data structure called `opendal_kv`, which is essentially a simple key-value pair. This helps us to easier **align the keys and values** provided by user, and provide **a more friendly interface**.
```Rust
opendal_kv kvs[3];
kvs[0] = opendal_kv {.key = "k1", .value = "v1"};
kvs[1] = opendal_kv {.key = "k2", .value = "v2"};
kvs[2] = opendal_kv {.key = "k3", .value = "v3"};

opendal_operator_ptr ptr = opendal_operator_ptr_from_kvs("memory", kvs, 3);
...
```
We do **not** need to explicitly manage heap allocation of hashmap, manage the correctness of the ordering of key-values, and we can make use of this kv data structure in the future.