### PR TITLE
chore(test): Avoid test names becoming prefixes of other tests

### DIFF
--- a/core/tests/behavior/append.rs
+++ b/core/tests/behavior/append.rs
@@ -64,7 +64,7 @@ macro_rules! behavior_append_tests {
             behavior_append_test!(
                 $service,
 
-                test_append,
+                test_append_create_append,
                 test_append_with_dir_path,
                 test_append_with_cache_control,
                 test_append_with_content_type,
@@ -78,7 +78,7 @@ macro_rules! behavior_append_tests {
 }
 
 /// Test append to a file must success.
-pub async fn test_append(op: Operator) -> Result<()> {
+pub async fn test_append_create_append(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
     let (content_one, size_one) = gen_bytes();
     let (content_two, size_two) = gen_bytes();

--- a/core/tests/behavior/blocking_copy.rs
+++ b/core/tests/behavior/blocking_copy.rs
@@ -62,7 +62,7 @@ macro_rules! behavior_blocking_copy_tests {
             behavior_blocking_copy_test!(
                 $service,
 
-                test_copy,
+                test_copy_file,
                 test_copy_non_existing_source,
                 test_copy_source_dir,
                 test_copy_target_dir,
@@ -75,7 +75,7 @@ macro_rules! behavior_blocking_copy_tests {
 }
 
 /// Copy a file and test with stat.
-pub fn test_copy(op: BlockingOperator) -> Result<()> {
+pub fn test_copy_file(op: BlockingOperator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
     let (source_content, _) = gen_bytes();
 

--- a/core/tests/behavior/blocking_read.rs
+++ b/core/tests/behavior/blocking_read.rs
@@ -61,7 +61,7 @@ macro_rules! behavior_blocking_read_tests {
             behavior_blocking_read_test!(
                 $service,
 
-                test_stat,
+                test_stat_file_and_dir,
                 test_stat_special_chars,
                 test_stat_not_exist,
                 test_read_full,
@@ -73,7 +73,7 @@ macro_rules! behavior_blocking_read_tests {
 }
 
 /// Stat normal file and dir should return metadata
-pub fn test_stat(op: BlockingOperator) -> Result<()> {
+pub fn test_stat_file_and_dir(op: BlockingOperator) -> Result<()> {
     let meta = op.stat("normal_file")?;
     assert_eq!(meta.mode(), EntryMode::FILE);
     assert_eq!(meta.content_length(), 262144);

--- a/core/tests/behavior/blocking_rename.rs
+++ b/core/tests/behavior/blocking_rename.rs
@@ -62,7 +62,7 @@ macro_rules! behavior_blocking_rename_tests {
             behavior_blocking_rename_test!(
                 $service,
 
-                test_rename,
+                test_rename_file,
                 test_rename_non_existing_source,
                 test_rename_source_dir,
                 test_rename_target_dir,
@@ -75,7 +75,7 @@ macro_rules! behavior_blocking_rename_tests {
 }
 
 /// Rename a file and test with stat.
-pub fn test_rename(op: BlockingOperator) -> Result<()> {
+pub fn test_rename_file(op: BlockingOperator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
     let (source_content, _) = gen_bytes();
 

--- a/core/tests/behavior/blocking_write.rs
+++ b/core/tests/behavior/blocking_write.rs
@@ -69,10 +69,10 @@ macro_rules! behavior_blocking_write_tests {
 
                 test_create_dir,
                 test_create_dir_existing,
-                test_write,
+                test_write_file,
                 test_write_with_dir_path,
                 test_write_with_special_chars,
-                test_stat,
+                test_stat_file,
                 test_stat_dir,
                 test_stat_with_special_chars,
                 test_stat_not_exist,
@@ -83,7 +83,7 @@ macro_rules! behavior_blocking_write_tests {
                 test_fuzz_range_reader,
                 test_fuzz_offset_reader,
                 test_fuzz_part_reader,
-                test_delete,
+                test_delete_file,
             );
         )*
     };
@@ -118,7 +118,7 @@ pub fn test_create_dir_existing(op: BlockingOperator) -> Result<()> {
 }
 
 /// Write a single file and test with stat.
-pub fn test_write(op: BlockingOperator) -> Result<()> {
+pub fn test_write_file(op: BlockingOperator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
     debug!("Generate a random file: {}", &path);
     let (content, size) = gen_bytes();
@@ -160,7 +160,7 @@ pub fn test_write_with_special_chars(op: BlockingOperator) -> Result<()> {
 }
 
 /// Stat existing file should return metadata
-pub fn test_stat(op: BlockingOperator) -> Result<()> {
+pub fn test_stat_file(op: BlockingOperator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
     debug!("Generate a random file: {}", &path);
     let (content, size) = gen_bytes();
@@ -399,7 +399,7 @@ pub fn test_fuzz_part_reader(op: BlockingOperator) -> Result<()> {
 }
 
 // Delete existing file should succeed.
-pub fn test_delete(op: BlockingOperator) -> Result<()> {
+pub fn test_delete_file(op: BlockingOperator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
     debug!("Generate a random file: {}", &path);
     let (content, _) = gen_bytes();

--- a/core/tests/behavior/copy.rs
+++ b/core/tests/behavior/copy.rs
@@ -60,7 +60,7 @@ macro_rules! behavior_copy_tests {
             behavior_copy_test!(
                 $service,
 
-                test_copy,
+                test_copy_file,
                 test_copy_non_existing_source,
                 test_copy_source_dir,
                 test_copy_target_dir,
@@ -74,7 +74,7 @@ macro_rules! behavior_copy_tests {
 }
 
 /// Copy a file and test with stat.
-pub async fn test_copy(op: Operator) -> Result<()> {
+pub async fn test_copy_file(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
     let (source_content, _) = gen_bytes();
 

--- a/core/tests/behavior/read_only.rs
+++ b/core/tests/behavior/read_only.rs
@@ -59,7 +59,7 @@ macro_rules! behavior_read_tests {
             behavior_read_test!(
                 $service,
 
-                test_stat,
+                test_stat_file_and_dir,
                 test_stat_special_chars,
                 test_stat_not_cleaned_path,
                 test_stat_not_exist,
@@ -82,7 +82,7 @@ macro_rules! behavior_read_tests {
 }
 
 /// Stat normal file and dir should return metadata
-pub async fn test_stat(op: Operator) -> Result<()> {
+pub async fn test_stat_file_and_dir(op: Operator) -> Result<()> {
     let meta = op.stat("normal_file").await?;
     assert_eq!(meta.mode(), EntryMode::FILE);
     assert_eq!(meta.content_length(), 262144);

--- a/core/tests/behavior/rename.rs
+++ b/core/tests/behavior/rename.rs
@@ -60,7 +60,7 @@ macro_rules! behavior_rename_tests {
             behavior_rename_test!(
                 $service,
 
-                test_rename,
+                test_rename_file,
                 test_rename_non_existing_source,
                 test_rename_source_dir,
                 test_rename_target_dir,
@@ -74,7 +74,7 @@ macro_rules! behavior_rename_tests {
 }
 
 /// Rename a file and test with stat.
-pub async fn test_rename(op: Operator) -> Result<()> {
+pub async fn test_rename_file(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
     let (source_content, _) = gen_bytes();
 

--- a/core/tests/behavior/write.rs
+++ b/core/tests/behavior/write.rs
@@ -72,13 +72,13 @@ macro_rules! behavior_write_tests {
 
                 test_create_dir,
                 test_create_dir_existing,
-                test_write,
+                test_write_only,
                 test_write_with_dir_path,
                 test_write_with_special_chars,
                 test_write_with_cache_control,
                 test_write_with_content_type,
                 test_write_with_content_disposition,
-                test_stat,
+                test_stat_file,
                 test_stat_dir,
                 test_stat_with_special_chars,
                 test_stat_not_cleaned_path,
@@ -102,7 +102,7 @@ macro_rules! behavior_write_tests {
                 test_read_with_special_chars,
                 test_read_with_override_cache_control,
                 test_read_with_override_content_disposition,
-                test_delete,
+                test_delete_file,
                 test_delete_empty_dir,
                 test_delete_with_special_chars,
                 test_delete_not_existing,
@@ -145,7 +145,7 @@ pub async fn test_create_dir_existing(op: Operator) -> Result<()> {
 }
 
 /// Write a single file and test with stat.
-pub async fn test_write(op: Operator) -> Result<()> {
+pub async fn test_write_only(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
     let (content, size) = gen_bytes();
 
@@ -271,7 +271,7 @@ pub async fn test_write_with_content_disposition(op: Operator) -> Result<()> {
 }
 
 /// Stat existing file should return metadata
-pub async fn test_stat(op: Operator) -> Result<()> {
+pub async fn test_stat_file(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
     let (content, size) = gen_bytes();
 
@@ -981,7 +981,7 @@ pub async fn test_writer_abort(op: Operator) -> Result<()> {
 }
 
 /// Delete existing file should succeed.
-pub async fn test_delete(op: Operator) -> Result<()> {
+pub async fn test_delete_file(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
     let (content, _) = gen_bytes();
 


### PR DESCRIPTION
This can help to run an individual test more effectively.