### PR TITLE
feat: server side encryption support for azblob

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -209,6 +209,7 @@ reqwest = { version = "0.11.13", features = [
 rocksdb = { version = "0.20.1", default-features = false, optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 sled = { version = "0.34.7", optional = true }
 suppaftp = { version = "4.5", default-features = false, features = [
   "async-secure",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -92,6 +92,7 @@ layers-tracing = ["dep:tracing"]
 layers-otel-trace = ["dep:opentelemetry"]
 
 services-azblob = [
+  "dep:sha2",
   "dep:reqsign",
   "reqsign?/services-azblob",
   "reqsign?/reqwest_request",
@@ -209,7 +210,7 @@ reqwest = { version = "0.11.13", features = [
 rocksdb = { version = "0.20.1", default-features = false, optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = { version = "0.10", optional = true }
 sled = { version = "0.34.7", optional = true }
 suppaftp = { version = "4.5", default-features = false, features = [
   "async-secure",

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -150,28 +150,61 @@ impl AzblobBuilder {
         self
     }
 
-    /// Set server_side_encryption_customer_key of this backend.
-    pub fn encryption_key(&mut self, encryption_key: &str) -> &mut Self {
-        if !encryption_key.is_empty() {
-            self.encryption_key = Some(encryption_key.to_string());
+    /// Set encryption_key of this backend.
+    ///
+    /// # Args
+    ///
+    /// `v`: Base64-encoded key that matches algorithm specified in `encryption_algorithm`.
+    ///
+    /// # Note
+    ///
+    /// This function is the low-level setting for SSE related features.
+    ///
+    /// SSE related options should be set carefully to make them works.
+    /// Please use `server_side_encryption_with_*` helpers if even possible.
+    pub fn encryption_key(&mut self, v: &str) -> &mut Self {
+        if !v.is_empty() {
+            self.encryption_key = Some(v.to_string());
         }
 
         self
     }
 
-    /// Set server_side_encryption_customer_key_sha256 of this backend.
-    pub fn encryption_key_sha256(&mut self, encryption_key_sha256: &str) -> &mut Self {
-        if !encryption_key_sha256.is_empty() {
-            self.encryption_key_sha256 = Some(encryption_key_sha256.to_string());
+    /// Set encryption_key_sha256 of this backend.
+    ///
+    /// # Args
+    ///
+    /// `v`: Base64-encoded SHA256 digest of the key specified in encryption_key.
+    ///
+    /// # Note
+    ///
+    /// This function is the low-level setting for SSE related features.
+    ///
+    /// SSE related options should be set carefully to make them works.
+    /// Please use `server_side_encryption_with_*` helpers if even possible.
+    pub fn encryption_key_sha256(&mut self, v: &str) -> &mut Self {
+        if !v.is_empty() {
+            self.encryption_key_sha256 = Some(v.to_string());
         }
 
         self
     }
 
-    /// Set server_side_encryption_customer_algorithm of this backend.
-    pub fn encryption_algorithm(&mut self, encryption_algorithm: &str) -> &mut Self {
-        if !encryption_algorithm.is_empty() {
-            self.encryption_algorithm = Some(encryption_algorithm.to_string());
+    /// Set encryption_algorithm of this backend.
+    ///
+    /// # Args
+    ///
+    /// `v`: server-side encryption algorithm. (Available values: `AES256`)
+    ///
+    /// # Note
+    ///
+    /// This function is the low-level setting for SSE related features.
+    ///
+    /// SSE related options should be set carefully to make them works.
+    /// Please use `server_side_encryption_with_*` helpers if even possible.
+    pub fn encryption_algorithm(&mut self, v: &str) -> &mut Self {
+        if !v.is_empty() {
+            self.encryption_algorithm = Some(v.to_string());
         }
 
         self
@@ -181,6 +214,15 @@ impl AzblobBuilder {
     ///
     /// As known as: CPK
     ///
+    /// # Args
+    ///
+    /// `key`: Base64-encoded SHA256 digest of the key specified in encryption_key.
+    ///
+    /// # Note
+    ///
+    /// Function that helps the user to set the server-side customer-provided encryption key, the key's SHA256, and the algorithm.
+    /// See [Server-side encryption with customer-provided keys (CPK)](https://learn.microsoft.com/en-us/azure/storage/blobs/encryption-customer-provided-keys)
+    /// for more info.
     pub fn server_side_encryption_with_customer_key(&mut self, key: &[u8]) -> &mut Self {
         // Only AES256 is supported for now
         self.encryption_algorithm = Some("AES256".to_string());

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -147,30 +147,42 @@ impl AzblobBuilder {
     }
 
     /// Set server_side_encryption_customer_key of this backend.
-    pub fn server_side_encryption_customer_key(&mut self, server_side_encryption_customer_key: &str) -> &mut Self {
+    pub fn server_side_encryption_customer_key(
+        &mut self,
+        server_side_encryption_customer_key: &str,
+    ) -> &mut Self {
         if !server_side_encryption_customer_key.is_empty() {
-            self.server_side_encryption_customer_key = Some(server_side_encryption_customer_key.to_string());
+            self.server_side_encryption_customer_key =
+                Some(server_side_encryption_customer_key.to_string());
         }
 
         self
     }
 
     /// Set server_side_encryption_customer_key_sha256 of this backend.
-    pub fn server_side_encryption_customer_key_sha256(&mut self, server_side_encryption_customer_key_sha256: &str) -> &mut Self {
+    pub fn server_side_encryption_customer_key_sha256(
+        &mut self,
+        server_side_encryption_customer_key_sha256: &str,
+    ) -> &mut Self {
         if !server_side_encryption_customer_key_sha256.is_empty() {
-            self.server_side_encryption_customer_key_sha256 = Some(server_side_encryption_customer_key_sha256.to_string());
+            self.server_side_encryption_customer_key_sha256 =
+                Some(server_side_encryption_customer_key_sha256.to_string());
         }
 
         self
     }
 
     /// Set server_side_encryption_customer_algorithm of this backend.
-    pub fn server_side_encryption_customer_algorithm(&mut self, server_side_encryption_customer_algorithm: &str) -> &mut Self {
+    pub fn server_side_encryption_customer_algorithm(
+        &mut self,
+        server_side_encryption_customer_algorithm: &str,
+    ) -> &mut Self {
         if !server_side_encryption_customer_algorithm.is_empty() {
             if server_side_encryption_customer_algorithm != "AES256" {
                 warn!("Only AES256 is supported for server_side_encryption_customer_algorithm, got {}", server_side_encryption_customer_algorithm);
             } else {
-                self.server_side_encryption_customer_algorithm = Some(server_side_encryption_customer_algorithm.to_string());
+                self.server_side_encryption_customer_algorithm =
+                    Some(server_side_encryption_customer_algorithm.to_string());
             }
         }
 
@@ -300,9 +312,12 @@ impl Builder for AzblobBuilder {
         map.get("endpoint").map(|v| builder.endpoint(v));
         map.get("account_name").map(|v| builder.account_name(v));
         map.get("account_key").map(|v| builder.account_key(v));
-        map.get("server_side_encryption_customer_key").map(|v| builder.server_side_encryption_customer_key(v));
-        map.get("server_side_encryption_customer_key_sha256").map(|v| builder.server_side_encryption_customer_key_sha256(v));
-        map.get("server_side_encryption_customer_algorithm").map(|v| builder.server_side_encryption_customer_algorithm(v));
+        map.get("server_side_encryption_customer_key")
+            .map(|v| builder.server_side_encryption_customer_key(v));
+        map.get("server_side_encryption_customer_key_sha256")
+            .map(|v| builder.server_side_encryption_customer_key_sha256(v));
+        map.get("server_side_encryption_customer_algorithm")
+            .map(|v| builder.server_side_encryption_customer_algorithm(v));
         map.get("sas_token").map(|v| builder.sas_token(v));
 
         builder
@@ -350,26 +365,29 @@ impl Builder for AzblobBuilder {
             ..Default::default()
         };
 
-        let server_side_encryption_customer_key = match &self.server_side_encryption_customer_key {
-            None => None,
-            Some(v) => Some(build_header_value(v).map_err(|err| {
-                err.with_context("key", "server_side_encryption_customer_key")
-            })?),
-        };
+        let server_side_encryption_customer_key =
+            match &self.server_side_encryption_customer_key {
+                None => None,
+                Some(v) => Some(build_header_value(v).map_err(|err| {
+                    err.with_context("key", "server_side_encryption_customer_key")
+                })?),
+            };
 
-        let server_side_encryption_customer_key_sha256 = match &self.server_side_encryption_customer_key_sha256 {
-            None => None,
-            Some(v) => Some(build_header_value(v).map_err(|err| {
-                err.with_context("key", "server_side_encryption_customer_key_sha256")
-            })?),
-        };
+        let server_side_encryption_customer_key_sha256 =
+            match &self.server_side_encryption_customer_key_sha256 {
+                None => None,
+                Some(v) => Some(build_header_value(v).map_err(|err| {
+                    err.with_context("key", "server_side_encryption_customer_key_sha256")
+                })?),
+            };
 
-        let server_side_encryption_customer_algorithm = match &self.server_side_encryption_customer_algorithm {
-            None => None,
-            Some(v) => Some(build_header_value(v).map_err(|err| {
-                err.with_context("key", "server_side_encryption_customer_algorithm")
-            })?),
-        };
+        let server_side_encryption_customer_algorithm =
+            match &self.server_side_encryption_customer_algorithm {
+                None => None,
+                Some(v) => Some(build_header_value(v).map_err(|err| {
+                    err.with_context("key", "server_side_encryption_customer_algorithm")
+                })?),
+            };
 
         let cred_loader = AzureStorageLoader::new(config_loader);
 

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -59,6 +59,9 @@ pub struct AzblobBuilder {
     endpoint: Option<String>,
     account_name: Option<String>,
     account_key: Option<String>,
+    server_side_encryption_customer_key: Option<String>,
+    server_side_encryption_customer_key_sha256: Option<String>,
+    server_side_encryption_customer_algorithm: Option<String>,
     sas_token: Option<String>,
     http_client: Option<HttpClient>,
 }

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -146,6 +146,33 @@ impl AzblobBuilder {
         self
     }
 
+    /// Set server_side_encryption_customer_key of this backend.
+    pub fn server_side_encryption_customer_key(&mut self, server_side_encryption_customer_key: &str) -> &mut Self {
+        if !server_side_encryption_customer_key.is_empty() {
+            self.server_side_encryption_customer_key = Some(server_side_encryption_customer_key.to_string());
+        }
+
+        self
+    }
+
+    /// Set server_side_encryption_customer_key_sha256 of this backend.
+    pub fn server_side_encryption_customer_key_sha256(&mut self, server_side_encryption_customer_key_sha256: &str) -> &mut Self {
+        if !server_side_encryption_customer_key_sha256.is_empty() {
+            self.server_side_encryption_customer_key_sha256 = Some(server_side_encryption_customer_key_sha256.to_string());
+        }
+
+        self
+    }
+
+    /// Set server_side_encryption_customer_algorithm of this backend.
+    pub fn server_side_encryption_customer_algorithm(&mut self, server_side_encryption_customer_algorithm: &str) -> &mut Self {
+        if !server_side_encryption_customer_algorithm.is_empty() {
+            self.server_side_encryption_customer_algorithm = Some(server_side_encryption_customer_algorithm.to_string());
+        }
+
+        self
+    }
+
     /// Set sas_token of this backend.
     ///
     /// - If sas_token is set, we will take user's input first.
@@ -269,6 +296,9 @@ impl Builder for AzblobBuilder {
         map.get("endpoint").map(|v| builder.endpoint(v));
         map.get("account_name").map(|v| builder.account_name(v));
         map.get("account_key").map(|v| builder.account_key(v));
+        map.get("server_side_encryption_customer_key").map(|v| builder.server_side_encryption_customer_key(v));
+        map.get("server_side_encryption_customer_key_sha256").map(|v| builder.server_side_encryption_customer_key_sha256(v));
+        map.get("server_side_encryption_customer_algorithm").map(|v| builder.server_side_encryption_customer_algorithm(v));
         map.get("sas_token").map(|v| builder.sas_token(v));
 
         builder
@@ -316,6 +346,27 @@ impl Builder for AzblobBuilder {
             ..Default::default()
         };
 
+        let server_side_encryption_customer_key = match &self.server_side_encryption_customer_key {
+            None => None,
+            Some(v) => Some(build_header_value(v).map_err(|err| {
+                err.with_context("key", "server_side_encryption_customer_key")
+            })?),
+        };
+
+        let server_side_encryption_customer_key_sha256 = match &self.server_side_encryption_customer_key_sha256 {
+            None => None,
+            Some(v) => Some(build_header_value(v).map_err(|err| {
+                err.with_context("key", "server_side_encryption_customer_key_sha256")
+            })?),
+        };
+
+        let server_side_encryption_customer_algorithm = match &self.server_side_encryption_customer_algorithm {
+            None => None,
+            Some(v) => Some(build_header_value(v).map_err(|err| {
+                err.with_context("key", "server_side_encryption_customer_algorithm")
+            })?),
+        };
+
         let cred_loader = AzureStorageLoader::new(config_loader);
 
         let signer = AzureStorageSigner::new();
@@ -326,6 +377,9 @@ impl Builder for AzblobBuilder {
             core: Arc::new(AzblobCore {
                 root,
                 endpoint,
+                server_side_encryption_customer_key,
+                server_side_encryption_customer_key_sha256,
+                server_side_encryption_customer_algorithm,
                 container: self.container.clone(),
 
                 client,

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use http::header::CONTENT_TYPE;
 use http::StatusCode;
-use log::debug;
+use log::{debug, warn};
 use reqsign::AzureStorageConfig;
 use reqsign::AzureStorageLoader;
 use reqsign::AzureStorageSigner;
@@ -167,7 +167,11 @@ impl AzblobBuilder {
     /// Set server_side_encryption_customer_algorithm of this backend.
     pub fn server_side_encryption_customer_algorithm(&mut self, server_side_encryption_customer_algorithm: &str) -> &mut Self {
         if !server_side_encryption_customer_algorithm.is_empty() {
-            self.server_side_encryption_customer_algorithm = Some(server_side_encryption_customer_algorithm.to_string());
+            if server_side_encryption_customer_algorithm != "AES256" {
+                warn!("Only AES256 is supported for server_side_encryption_customer_algorithm, got {}", server_side_encryption_customer_algorithm);
+            } else {
+                self.server_side_encryption_customer_algorithm = Some(server_side_encryption_customer_algorithm.to_string());
+            }
         }
 
         self

--- a/core/src/services/azblob/core.rs
+++ b/core/src/services/azblob/core.rs
@@ -52,9 +52,9 @@ pub struct AzblobCore {
     pub container: String,
     pub root: String,
     pub endpoint: String,
-    pub server_side_encryption_customer_key: Option<HeaderValue>,
-    pub server_side_encryption_customer_key_sha256: Option<HeaderValue>,
-    pub server_side_encryption_customer_algorithm: Option<HeaderValue>,
+    pub encryption_key: Option<HeaderValue>,
+    pub encryption_key_sha256: Option<HeaderValue>,
+    pub encryption_algorithm: Option<HeaderValue>,
     pub client: HttpClient,
     pub loader: AzureStorageLoader,
     pub signer: AzureStorageSigner,
@@ -115,14 +115,14 @@ impl AzblobCore {
     }
 
     pub fn insert_sse_headers(&self, mut req: http::request::Builder) -> http::request::Builder {
-        if let Some(v) = &self.server_side_encryption_customer_key {
+        if let Some(v) = &self.encryption_key {
             let mut v = v.clone();
             v.set_sensitive(true);
 
             req = req.header(HeaderName::from_static(constants::X_MS_ENCRYPTION_KEY), v)
         }
 
-        if let Some(v) = &self.server_side_encryption_customer_key_sha256 {
+        if let Some(v) = &self.encryption_key_sha256 {
             let mut v = v.clone();
             v.set_sensitive(true);
 
@@ -132,7 +132,7 @@ impl AzblobCore {
             )
         }
 
-        if let Some(v) = &self.server_side_encryption_customer_algorithm {
+        if let Some(v) = &self.encryption_algorithm {
             let mut v = v.clone();
             v.set_sensitive(true);
 

--- a/core/src/services/azblob/core.rs
+++ b/core/src/services/azblob/core.rs
@@ -26,6 +26,7 @@ use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
 use http::header::IF_MATCH;
 use http::header::IF_NONE_MATCH;
+use http::HeaderValue;
 use http::Request;
 use http::Response;
 use reqsign::AzureStorageCredential;
@@ -46,7 +47,9 @@ pub struct AzblobCore {
     pub container: String,
     pub root: String,
     pub endpoint: String,
-
+    pub server_side_encryption_customer_key: Option<HeaderValue>,
+    pub server_side_encryption_customer_key_sha256: Option<HeaderValue>,
+    pub server_side_encryption_customer_algorithm: Option<HeaderValue>,
     pub client: HttpClient,
     pub loader: AzureStorageLoader,
     pub signer: AzureStorageSigner,

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -148,7 +148,7 @@ impl S3Core {
     /// # Note
     ///
     /// header like X_AMZ_SERVER_SIDE_ENCRYPTION doesn't need to set while
-    //  get or stat.
+    /// get or stat.
     pub fn insert_sse_headers(
         &self,
         mut req: http::request::Builder,


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced by this PR. -->
- related issue: #183
- Reference: https://learn.microsoft.com/en-us/rest/api/storageservices/operations-on-blobs

## Changes Made
<!-- Describe the specific changes made in this PR. -->
Add SSE headers into these requests
- *azblob_get_blob_request*
- *azblob_put_blob_request*
- *azblob_init_appendable_blob_request*
- *azblob_append_blob_request*
- *azblob_head_blob_request*

## Additional Notes
<!-- Add any additional information or notes here. -->

### Helper Function Design
Hi @Xuanwo, what do you think about these two functions? Should we provide them separately or together? (Also, since azblob only support for AES256 as encryption algorithm, do we still need to provide setting options for user?)
```rust
builder.root("/")
    .container("test")
    .endpoint("http://127.0.0.1:10000/devstoreaccount1")
    .account_name("devstoreaccount1")
    .account_key("Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==")
    // separately
    .server_side_encryption_customer_key("S5D+fhPQjqxK7udHboDgMw==")
    .server_side_encryption_customer_key_sha256("18b04c198bb2ee7db24cc491dc9ebaf265be28bcf6796e85e0e27f7a9c39f8a9")
    .server_side_encryption_customer_algorithm("AES256");
```

```rust
builder.root("/")
    .container("test")
    .endpoint("http://127.0.0.1:10000/devstoreaccount1")
    .account_name("devstoreaccount1")
    .account_key("Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==")
    // together (Algorithm only support for AES256 for now)
    .encryption_with_customer_provided_key("S5D+fhPQjqxK7udHboDgMw==", "18b04c198bb2ee7db24cc491dc9ebaf265be28bcf6796e85e0e27f7a9c39f8a9");
```

### Test Case Design

I haven't implemented testing for this change, any suggestion? (I assume it can leverage Azurite in GitHub Actions)