### PR TITLE
chore(bindings/java): post release 0.1.0

### DIFF
--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -1,41 +1,59 @@
 # OpenDAL Java Bindings
 
-## Usage
+[![Maven Central](https://img.shields.io/maven-central/v/org.apache.opendal/opendal-java.svg?logo=Apache+Maven&logoColor=blue)](https://central.sonatype.com/search?q=opendal-java&smo=true)
+[![Website](https://img.shields.io/badge/opendal-OpenDAL_Website-red?logo=Apache&logoColor=red)](https://opendal.apache.org/docs/java/)
 
-You can use the package by adding the dependency as following:
+
+## Getting Started
+
+This project is built upon the native OpenDAL lib. And it is released for multiple platforms that you can use a classifier to specify the platform you are building the application on.
+
+Generally, you can first add the `os-maven-plugin` for automatically detect the classifier based on your platform:
 
 ```xml
-<project>
-  <repositories>
+<build>
+    <extensions>
+        <extension>
+            <groupId>kr.motd.maven</groupId>
+            <artifactId>os-maven-plugin</artifactId>
+            <version>1.7.0</version>
+        </extension>
+    </extensions>
+</build>
+```
+
+Then add the dependency to `opendal-java` as following:
+
+```xml
+<dependency>
+  <groupId>org.apache.opendal</groupId>
+  <artifactId>opendal-java</artifactId>
+  <version>${opendal.version}</version>
+  <classifier>${os.detected.classifier}</classifier>
+</dependency>
+```
+
+If you'd rather like the latest snapshots of the upcoming major version, use ASF Maven snapshot repository:
+
+```xml
+<repositories>
     <repository>
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>https://repository.apache.org/snapshots</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
+        <id>apache.snapshots</id>
+        <name>Apache Snapshot Repository</name>
+        <url>https://repository.apache.org/snapshots</url>
     </repository>
-  </repositories>
+</repositories>
+```
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.opendal</groupId>
-      <artifactId>opendal-java</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
-      <classifier>${os.detected.classifier}</classifier>
-    </dependency>
-  </dependencies>
+... and declare the appropriate dependency version:
 
-  <build>
-      <extensions>
-          <extension>
-              <groupId>kr.motd.maven</groupId>
-              <artifactId>os-maven-plugin</artifactId>
-              <version>1.7.0</version>
-          </extension>
-      </extensions>
-  </build>
-</project>
+```xml
+<dependency>
+  <groupId>org.apache.opendal</groupId>
+  <artifactId>opendal-java</artifactId>
+  <version>${opendal.snapshot-version}</version>
+  <classifier>${os.detected.classifier}</classifier>
+</dependency>
 ```
 
 ## Build

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal-java</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
 
     <url>https://opendal.apache.org</url>
     <mailingLists>
@@ -61,6 +61,7 @@
 
         <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
+        <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <spotless.version>2.37.0</spotless.version>
     </properties>
 
@@ -151,7 +152,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.7.0</version>
+                <version>${os-maven-plugin.version}</version>
             </extension>
         </extensions>
 


### PR DESCRIPTION
The automation is still at [tisonkun/ci-opendal](https://github.com/tisonkun/ci-opendal). We may add a release manual later and keep the snapshot deploy process unofficial.

The released artifacts can be found at https://repository.apache.org/content/repositories/releases/org/apache/opendal/opendal-java/0.1.0/.

Although, it can take some time to propagate among the network and other mirror sites. Let's keep it as a draft until I can build an application properly. 

This closes https://github.com/apache/incubator-opendal/issues/2339.