### PR TITLE
feat(bindings/java): save one jni call in the hot path

### DIFF
--- a/bindings/java/src/operator.rs
+++ b/bindings/java/src/operator.rs
@@ -254,18 +254,6 @@ async fn do_delete(op: &mut Operator, path: String) -> Result<()> {
     Ok(op.delete(&path).await?)
 }
 
-fn request_id(env: &mut JNIEnv) -> Result<jlong> {
-    let registry = env
-        .call_static_method(
-            "org/apache/opendal/Operator",
-            "registry",
-            "()Lorg/apache/opendal/Operator$AsyncRegistry;",
-            &[],
-        )?
-        .l()?;
-    Ok(env.call_method(registry, "requestId", "()J", &[])?.j()?)
-}
-
 fn make_object<'local>(
     env: &mut JNIEnv<'local>,
     value: JValueOwned<'local>,
@@ -312,18 +300,21 @@ fn complete_future(id: jlong, result: Result<JValueOwned>) {
     };
 }
 
-fn get_future<'local>(env: &mut JNIEnv<'local>, id: jlong) -> Result<JObject<'local>> {
-    let registry = env
+fn request_id(env: &mut JNIEnv) -> Result<jlong> {
+    Ok(env
         .call_static_method(
-            "org/apache/opendal/Operator",
-            "registry",
-            "()Lorg/apache/opendal/Operator$AsyncRegistry;",
+            "org/apache/opendal/Operator$AsyncRegistry",
+            "requestId",
+            "()J",
             &[],
         )?
-        .l()?;
+        .j()?)
+}
+
+fn get_future<'local>(env: &mut JNIEnv<'local>, id: jlong) -> Result<JObject<'local>> {
     Ok(env
-        .call_method(
-            registry,
+        .call_static_method(
+            "org/apache/opendal/Operator$AsyncRegistry",
             "get",
             "(J)Ljava/util/concurrent/CompletableFuture;",
             &[JValue::Long(id)],


### PR DESCRIPTION
This may not be necessary within single language scope since we can trust the compiler or JIT to inline code as much as possible.

But it's valuable when calls cross language boundaries since no optimization can happen here. Also, obtaining a future and getting it to complete is the hot path for all async ops. Thus I believe it is worth trading off some code style (static method over singleton and then call member method) for efficiency.