### PR TITLE
chore: protect branch gh-pages

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,6 +34,8 @@ github:
     main:
       required_pull_request_reviews:
         required_approving_review_count: 1
+    gh-pages:
+      whatever: Just a placeholder to make it take effects
 
 notifications:
   commits:      commits@opendal.apache.org


### PR DESCRIPTION
As a source of our site deployments and as a documentation archive for versions, we should protect this branch.