### PR TITLE
Bump to version 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### CI
 
 - build(bindings/java): prepare for snapshot release (#2301)
-- build(bindings/java): prepare for snapshot release (#2301)
 - build(bindings/java): support multiple platform java bindings  (#2324)
 - ci(binding/nodejs): Use docker to build nodejs binding (#2328)
 - build(bindings/java): prepare for automatically multiple platform deploy (#2335)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,83 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v0.36.0] - 2023-05-30
+
+### Added
+
+- feat(service/fs): add append support for fs (#2296)
+- feat(services/sftp): add append support for sftp (#2297)
+- RFC-2299: Chain based Operator API (#2299)
+- feat(services/azblob): add append support (#2302)
+- feat(bindings/nodejs): add append support (#2322)
+- feat(bindings/C): opendal_operator_ptr construction using kvs (#2329)
+- feat(services/cos): append support (#2332)
+- feat(bindings/java): implement Operator#delete (#2345)
+- feat(bindings/java): support append (#2350)
+- feat(bindings/java): save one jni call in the hot path (#2353)
+- feat: server side encryption support for azblob (#2347)
+
+### Changed
+
+- refactor(core): Implement RFC-2299 for stat_with (#2303)
+- refactor(core): Implement RFC-2299 for BlockingOperator::write_with (#2305)
+- refactor(core): Implement RFC-2299 for appender_with (#2307)
+- refactor(core): Implement RFC-2299 for read_with (#2308)
+- refactor(core): Implement RFC-2299 for read_with (#2308)
+- refactor(core): Implement RFC-2299 for append_with (#2312)
+- refactor(core): Implement RFC-2299 for write_with (#2315)
+- refactor(core): Implement RFC-2299 for reader_with (#2316)
+- refactor(core): Implement RFC-2299 for writer_with (#2317)
+- refactor(core): Implement RFC-2299 for presign_read_with (#2314)
+- refactor(core): Implement RFC-2299 for presign_write_with (#2320)
+- refactor(core): Implement RFC-2299 for list_with (#2323)
+- refactor: Move `ops` to `raw::ops` (#2325)
+- refactor(bindings/C): align bdd test with the feature tests (#2340)
+- refactor(bindings/java): narrow unsafe boundary (#2351)
+
+### Fixed
+
+- fix(services/supabase): correctly set retryable (#2295)
+- fix(core): appender complete check (#2298)
+
+### Docs
+
+- docs: add service doc for azdfs (#2310)
+- docs(bidnings/java): how to deploy snapshots (#2311)
+- docs(bidnings/java): how to deploy snapshots (#2311)
+- docs: Fixed links of languages to open in same tab (#2327)
+- docs: Adopt docusaurus pathname protocol (#2330)
+- docs(bindings/nodejs): update lib desc (#2331)
+- docs(bindings/java): update the README file (#2338)
+- docs: add service doc for fs (#2337)
+- docs: add service doc for cos (#2341)
+- docs: add service doc for dashmap (#2342)
+- docs(bindings/java): for BlockingOperator (#2344)
+
+### CI
+
+- build(bindings/java): prepare for snapshot release (#2301)
+- build(bindings/java): prepare for snapshot release (#2301)
+- build(bindings/java): support multiple platform java bindings  (#2324)
+- ci(binding/nodejs): Use docker to build nodejs binding (#2328)
+- build(bindings/java): prepare for automatically multiple platform deploy (#2335)
+- ci: add bindings java docs and integrate with website (#2346)
+- ci: avoid copy gitignore to site folder (#2348)
+- ci(bindings/c): Add diff check (#2359)
+- ci: Cache librocksdb to speed up CI (#2360)
+- ci: Don't load rocksdb for all workflows (#2362)
+- ci: Fix Node.js 12 actions deprecated warning (#2363)
+- ci: Speed up python docs build (#2364)
+- ci: Adopt setup-node's cache logic instead (#2365)
+
+### Chore
+
+- chore(test): Avoid test names becoming prefixes of other tests (#2333)
+- chore(bindings/java): improve OpenDALException tests and docs (#2343)
+- chore(bindings/java): post release 0.1.0 (#2352)
+- chore(docs): split docs build into small jobs (#2356)'
+- chore: protect branch gh-pages (#2358)
+
 ## [v0.35.0] - 2023-05-23
 
 ### Added
@@ -2160,6 +2237,7 @@ ing large files (#2231)
 
 Hello, OpenDAL!
 
+[v0.36.0]: https://github.com/apache/incubator-opendal/compare/v0.35.0...v0.36.0
 [v0.35.0]: https://github.com/apache/incubator-opendal/compare/v0.34.0...v0.35.0
 [v0.34.0]: https://github.com/apache/incubator-opendal/compare/v0.33.3...v0.34.0
 [v0.33.3]: https://github.com/apache/incubator-opendal/compare/v0.33.2...v0.33.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "oay"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_opendal"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "oli"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2619,7 +2619,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-c"
-version = "0.1.0"
+version = "0.36.0"
 dependencies = [
  "bytes",
  "cbindgen",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-java"
-version = "0.1.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "jni",
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-nodejs"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "futures",
  "napi",
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-python"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "futures",
  "opendal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-opendal"
 rust-version = "1.65"
-version = "0.35.0"
+version = "0.36.0"
 
 [workspace.dependencies]
-opendal = { version = "0.35", path = "core" }
+opendal = { version = "0.36", path = "core" }

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -18,7 +18,6 @@
 [package]
 name = "opendal-c"
 publish = false
-version = "0.1.0"
 
 authors.workspace = true
 edition.workspace = true
@@ -26,6 +25,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+version.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -209,7 +209,6 @@ extern "C" {
  opendal_operator_options_set(&options, "root", "/myroot");
 
  opendal_operator_ptr ptr = opendal_operator_new("memory", options);
-
  opendal_operator_options_free(&options);
 
  // ... your operations

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -47,7 +47,6 @@ use crate::types::opendal_operator_ptr;
 /// opendal_operator_options_set(&options, "root", "/myroot");
 ///
 /// opendal_operator_ptr ptr = opendal_operator_new("memory", options);
-///
 // free the options right away since the options is not used later on
 /// opendal_operator_options_free(&options);
 ///

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -15,9 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use ::opendal as od;
+use std::collections::HashMap;
+use std::os::raw::c_char;
 
-use std::{collections::HashMap, os::raw::c_char};
+use ::opendal as od;
 
 /// The [`opendal_operator_ptr`] owns a pointer to a [`od::BlockingOperator`].
 /// It is also the key struct that OpenDAL's APIs access the real

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -18,7 +18,6 @@
 [package]
 name = "opendal-java"
 publish = false
-version = "0.1.0"
 
 authors.workspace = true
 edition.workspace = true
@@ -26,6 +25,7 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+version.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
@@ -36,6 +36,6 @@ opendal.workspace = true
 
 anyhow = "1.0.71"
 jni = "0.21.1"
+num_cpus = "1.15.0"
 once_cell = "1.17.1"
 tokio = { version = "1.28.1", features = ["full"] }
-num_cpus = "1.15.0"

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal-java</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.36.0-SNAPSHOT</version>
 
     <url>https://opendal.apache.org</url>
     <mailingLists>

--- a/bindings/java/src/blocking_operator.rs
+++ b/bindings/java/src/blocking_operator.rs
@@ -17,9 +17,10 @@
 
 use std::str::FromStr;
 
+use jni::objects::JByteArray;
+use jni::objects::JClass;
 use jni::objects::JObject;
 use jni::objects::JString;
-use jni::objects::{JByteArray, JClass};
 use jni::sys::jlong;
 use jni::sys::jstring;
 use jni::JNIEnv;

--- a/bindings/java/src/operator.rs
+++ b/bindings/java/src/operator.rs
@@ -17,20 +17,21 @@
 
 use std::str::FromStr;
 
+use jni::objects::JByteArray;
+use jni::objects::JClass;
 use jni::objects::JObject;
 use jni::objects::JString;
 use jni::objects::JValue;
 use jni::objects::JValueOwned;
-use jni::objects::{JByteArray, JClass};
 use jni::sys::jlong;
 use jni::JNIEnv;
-
 use opendal::Operator;
 use opendal::Scheme;
 
+use crate::get_current_env;
+use crate::get_global_runtime;
 use crate::jmap_to_hashmap;
 use crate::Result;
-use crate::{get_current_env, get_global_runtime};
 
 #[no_mangle]
 pub extern "system" fn Java_org_apache_opendal_Operator_constructor(

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-arm64",
   "repository": "git@github.com/apache/incubator-opendal.git",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-x64",
   "repository": "git@github.com/apache/incubator-opendal.git",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "repository": "git@github.com/apache/incubator-opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "repository": "git@github.com/apache/incubator-opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "OpenDAL Contributors <dev@opendal.apache.org>",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",

--- a/core/src/docs/upgrade.md
+++ b/core/src/docs/upgrade.md
@@ -1,3 +1,55 @@
+# Upgarde to v0.36
+
+## Public API
+
+In v0.36, OpenDAL improving the `xxx_with` API by allow it to be called in chain:
+
+After this change, all `xxx_with` alike call will be changed from
+
+```rust
+let bs = op.read_with(
+  "path/to/file",
+  OpRead::new()
+    .with_range(0..=1024)
+    .with_if_match("<etag>")
+    .with_if_none_match("<etag>")
+    .with_override_cache_control("<cache_control>")
+    .with_override_content_disposition("<content_disposition>")
+  ).await?;
+```
+
+to
+
+```rust
+let bs = op.read_with("path/to/file")
+  .range(0..=1024)
+  .if_match("<etag>")
+  .if_none_match("<etag>")
+  .override_cache_control("<cache_control>")
+  .override_content_disposition("<content_disposition>")
+  .await?;
+```
+
+For blocking API calls, we will need a `call()` at the end:
+
+```rust
+let bs = bop.read_with("path/to/file")
+  .range(0..=1024)
+  .if_match("<etag>")
+  .if_none_match("<etag>")
+  .override_cache_control("<cache_control>")
+  .override_content_disposition("<content_disposition>")
+  .call()?;
+```
+
+Along with this change, users don't need to call `OpXxx` anymore so we moved it to `raw` API.
+
+More detailes could be found at [RFC: Chain Based Operator API][crate::docs::rfcs::rfc_2299_chain_based_operator_api].
+
+## Raw API
+
+Migrated `opendal::ops` to `opendal::raw::ops`.
+
 # Upgrade to v0.35
 
 ## Public API

--- a/core/src/docs/upgrade.md
+++ b/core/src/docs/upgrade.md
@@ -1,4 +1,4 @@
-# Upgarde to v0.36
+# Upgrade to v0.36
 
 ## Public API
 

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -36,7 +36,6 @@ use crate::services::cos::appender::CosAppender;
 use crate::*;
 
 /// Huawei Cloud COS services support.
-///
 #[doc = include_str!("docs.md")]
 #[derive(Default, Clone)]
 pub struct CosBuilder {

--- a/core/src/services/dashmap/backend.rs
+++ b/core/src/services/dashmap/backend.rs
@@ -25,7 +25,6 @@ use crate::raw::adapters::typed_kv;
 use crate::*;
 
 /// [dashmap](https://github.com/xacrimon/dashmap) backend support.
-///
 #[doc = include_str!("docs.md")]
 #[derive(Default)]
 pub struct DashmapBuilder {

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -35,7 +35,6 @@ use crate::raw::*;
 use crate::*;
 
 /// POSIX file system support.
-///
 #[doc = include_str!("docs.md")]
 #[derive(Default, Debug)]
 pub struct FsBuilder {


### PR DESCRIPTION
### Added

- feat(service/fs): add append support for fs (#2296)
- feat(services/sftp): add append support for sftp (#2297)
- RFC-2299: Chain based Operator API (#2299)
- feat(services/azblob): add append support (#2302)
- feat(bindings/nodejs): add append support (#2322)
- feat(bindings/C): opendal_operator_ptr construction using kvs (#2329)
- feat(services/cos): append support (#2332)
- feat(bindings/java): implement Operator#delete (#2345)
- feat(bindings/java): support append (#2350)
- feat(bindings/java): save one jni call in the hot path (#2353)
- feat: server side encryption support for azblob (#2347)

### Changed

- refactor(core): Implement RFC-2299 for stat_with (#2303)
- refactor(core): Implement RFC-2299 for BlockingOperator::write_with (#2305)
- refactor(core): Implement RFC-2299 for appender_with (#2307)
- refactor(core): Implement RFC-2299 for read_with (#2308)
- refactor(core): Implement RFC-2299 for read_with (#2308)
- refactor(core): Implement RFC-2299 for append_with (#2312)
- refactor(core): Implement RFC-2299 for write_with (#2315)
- refactor(core): Implement RFC-2299 for reader_with (#2316)
- refactor(core): Implement RFC-2299 for writer_with (#2317)
- refactor(core): Implement RFC-2299 for presign_read_with (#2314)
- refactor(core): Implement RFC-2299 for presign_write_with (#2320)
- refactor(core): Implement RFC-2299 for list_with (#2323)
- refactor: Move `ops` to `raw::ops` (#2325)
- refactor(bindings/C): align bdd test with the feature tests (#2340)
- refactor(bindings/java): narrow unsafe boundary (#2351)

### Fixed

- fix(services/supabase): correctly set retryable (#2295)
- fix(core): appender complete check (#2298)

### Docs

- docs: add service doc for azdfs (#2310)
- docs(bidnings/java): how to deploy snapshots (#2311)
- docs(bidnings/java): how to deploy snapshots (#2311)
- docs: Fixed links of languages to open in same tab (#2327)
- docs: Adopt docusaurus pathname protocol (#2330)
- docs(bindings/nodejs): update lib desc (#2331)
- docs(bindings/java): update the README file (#2338)
- docs: add service doc for fs (#2337)
- docs: add service doc for cos (#2341)
- docs: add service doc for dashmap (#2342)
- docs(bindings/java): for BlockingOperator (#2344)

### CI

- build(bindings/java): prepare for snapshot release (#2301)
- build(bindings/java): support multiple platform java bindings  (#2324)
- ci(binding/nodejs): Use docker to build nodejs binding (#2328)
- build(bindings/java): prepare for automatically multiple platform deploy (#2335)
- ci: add bindings java docs and integrate with website (#2346)
- ci: avoid copy gitignore to site folder (#2348)
- ci(bindings/c): Add diff check (#2359)
- ci: Cache librocksdb to speed up CI (#2360)
- ci: Don't load rocksdb for all workflows (#2362)
- ci: Fix Node.js 12 actions deprecated warning (#2363)
- ci: Speed up python docs build (#2364)
- ci: Adopt setup-node's cache logic instead (#2365)

### Chore

- chore(test): Avoid test names becoming prefixes of other tests (#2333)
- chore(bindings/java): improve OpenDALException tests and docs (#2343)
- chore(bindings/java): post release 0.1.0 (#2352)
- chore(docs): split docs build into small jobs (#2356)'
- chore: protect branch gh-pages (#2358)
