### PR TITLE
Bump to version 0.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v0.36.1] - 2023-06-02
+
+### Added
+- feat(services/webdav): support redirection when get 302/307 response during read operation by @Yansongsongsong in https://github.com/apache/incubator-opendal/pull/2256
+- feat: Add Zig Bindings Module by @kassane in https://github.com/apache/incubator-opendal/pull/2374
+- feat: Implement Timeout Layer by @Xuanwo in https://github.com/apache/incubator-opendal/pull/2395
+
+### Changed
+- refactor(bindings/zig): enable tests and more by @tisonkun in https://github.com/apache/incubator-opendal/pull/2375
+- refactor(bindings/zig): add errors handler and module test by @kassane in https://github.com/apache/incubator-opendal/pull/2381
+- refactor(http_util): Adopt reqwest's redirect support by @Xuanwo in https://github.com/apache/incubator-opendal/pull/2390
+
+### Fixed
+- fix(bindings/zig): reflect C interface changes by @tisonkun in https://github.com/apache/incubator-opendal/pull/2378
+- fix(services/azblob): Fix batch delete doesn't work on azure by @Xuanwo in https://github.com/apache/incubator-opendal/pull/2382
+
+### Docs
+- docs: service doc for s3 by @suyanhanx in https://github.com/apache/incubator-opendal/pull/2376
+- docs(bindings/C): The documentation for OpenDAL C binding by @Ji-Xinyou in https://github.com/apache/incubator-opendal/pull/2373
+- docs: add link for c binding by @suyanhanx in https://github.com/apache/incubator-opendal/pull/2380
+- docs: docs for kv services by @suyanhanx in https://github.com/apache/incubator-opendal/pull/2396
+- docs: docs for fs related services by @suyanhanx in https://github.com/apache/incubator-opendal/pull/2397
+- docs(bindings/java): do not release snapshot versions anymore by @tisonkun in https://github.com/apache/incubator-opendal/pull/2398
+
+### CI
+- ci: Enable semantic PRs by @Xuanwo in https://github.com/apache/incubator-opendal/pull/2370
+- ci: improve licenserc settings by @tisonkun in https://github.com/apache/incubator-opendal/pull/2377
+- build(deps): bump reqwest from 0.11.15 to 0.11.18 by @dependabot in https://github.com/apache/incubator-opendal/pull/2389
+- build(deps): bump pyo3 from 0.18.2 to 0.18.3 by @dependabot in https://github.com/apache/incubator-opendal/pull/2388
+- ci: Enable nextest for all behavior tests by @Xuanwo in https://github.com/apache/incubator-opendal/pull/2400
+
+### Chore
+- chore(bindings/python): upgrade maturin to 1.0 by @messense in https://github.com/apache/incubator-opendal/pull/2369
+- chore: Fix license headers for release/labler by @Xuanwo in https://github.com/apache/incubator-opendal/pull/2371
+
 ## [v0.36.0] - 2023-05-30
 
 ### Added
@@ -2236,6 +2271,7 @@ ing large files (#2231)
 
 Hello, OpenDAL!
 
+[v0.36.1]: https://github.com/apache/incubator-opendal/compare/v0.36.0...v0.36.1
 [v0.36.0]: https://github.com/apache/incubator-opendal/compare/v0.35.0...v0.36.0
 [v0.35.0]: https://github.com/apache/incubator-opendal/compare/v0.34.0...v0.35.0
 [v0.34.0]: https://github.com/apache/incubator-opendal/compare/v0.33.3...v0.34.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "oay"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_opendal"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "oli"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2619,7 +2619,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-c"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "bytes",
  "cbindgen",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-java"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "anyhow",
  "jni",
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-nodejs"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "futures",
  "napi",
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-python"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "futures",
  "opendal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-opendal"
 rust-version = "1.65"
-version = "0.36.0"
+version = "0.36.1"
 
 [workspace.dependencies]
 opendal = { version = "0.36", path = "core" }

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal-java</artifactId>
-    <version>0.36.0-SNAPSHOT</version>
+    <version>0.36.1</version>
 
     <url>https://opendal.apache.org</url>
     <mailingLists>

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-arm64",
   "repository": "git@github.com/apache/incubator-opendal.git",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-x64",
   "repository": "git@github.com/apache/incubator-opendal.git",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "repository": "git@github.com/apache/incubator-opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "repository": "git@github.com/apache/incubator-opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "OpenDAL Contributors <dev@opendal.apache.org>",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
### Added
- feat(services/webdav): support redirection when get 302/307 response during read operation by @Yansongsongsong in https://github.com/apache/incubator-opendal/pull/2256
- feat: Add Zig Bindings Module by @kassane in https://github.com/apache/incubator-opendal/pull/2374
- feat: Implement Timeout Layer by @Xuanwo in https://github.com/apache/incubator-opendal/pull/2395

### Changed
- refactor(bindings/zig): enable tests and more by @tisonkun in https://github.com/apache/incubator-opendal/pull/2375
- refactor(bindings/zig): add errors handler and module test by @kassane in https://github.com/apache/incubator-opendal/pull/2381
- refactor(http_util): Adopt reqwest's redirect support by @Xuanwo in https://github.com/apache/incubator-opendal/pull/2390

### Fixed
- fix(bindings/zig): reflect C interface changes by @tisonkun in https://github.com/apache/incubator-opendal/pull/2378
- fix(services/azblob): Fix batch delete doesn't work on azure by @Xuanwo in https://github.com/apache/incubator-opendal/pull/2382

### Docs
- docs: service doc for s3 by @suyanhanx in https://github.com/apache/incubator-opendal/pull/2376
- docs(bindings/C): The documentation for OpenDAL C binding by @Ji-Xinyou in https://github.com/apache/incubator-opendal/pull/2373
- docs: add link for c binding by @suyanhanx in https://github.com/apache/incubator-opendal/pull/2380
- docs: docs for kv services by @suyanhanx in https://github.com/apache/incubator-opendal/pull/2396
- docs: docs for fs related services by @suyanhanx in https://github.com/apache/incubator-opendal/pull/2397
- docs(bindings/java): do not release snapshot versions anymore by @tisonkun in https://github.com/apache/incubator-opendal/pull/2398

### CI
- ci: Enable semantic PRs by @Xuanwo in https://github.com/apache/incubator-opendal/pull/2370
- ci: improve licenserc settings by @tisonkun in https://github.com/apache/incubator-opendal/pull/2377
- build(deps): bump reqwest from 0.11.15 to 0.11.18 by @dependabot in https://github.com/apache/incubator-opendal/pull/2389
- build(deps): bump pyo3 from 0.18.2 to 0.18.3 by @dependabot in https://github.com/apache/incubator-opendal/pull/2388
- ci: Enable nextest for all behavior tests by @Xuanwo in https://github.com/apache/incubator-opendal/pull/2400

### Chore
- chore(bindings/python): upgrade maturin to 1.0 by @messense in https://github.com/apache/incubator-opendal/pull/2369
- chore: Fix license headers for release/labler by @Xuanwo in https://github.com/apache/incubator-opendal/pull/2371
