### PR TITLE
fix(services/s3): Fix s3 batch max operations

### DIFF
--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -82,6 +82,7 @@ pub struct S3Core {
     pub loader: AwsLoader,
     pub client: HttpClient,
     pub write_min_size: usize,
+    pub batch_max_operations: usize,
 }
 
 impl Debug for S3Core {


### PR DESCRIPTION
related issue #2228 
close #2354
according to pr #2414
This pr add new batch_max_operations config for s3 service and use default value (1000 )if not set.
