### PR TITLE
docs: Replace `create` with `new`

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -81,7 +81,7 @@ async fn main() -> Result<()> {
     builder.bucket("test");
 
     // Init an operator
-    let op = Operator::create(builder)?
+    let op = Operator::new(builder)?
         // Init with logging layer enabled.
         .layer(LoggingLayer::default())
         .finish();
@@ -102,6 +102,7 @@ async fn main() -> Result<()> {
 
     Ok(())
 }
+
 ```
 
 ## Contributing


### PR DESCRIPTION
Before this commit, I got the following error:

```
no function or associated item named `create` found for struct `opendal::Operator` in the current scope
function or associated item not found in `Operator`
```

So, I replaced the `create` method with the `new` method.
