### PR TITLE
fix(services/sftp): change default root config to remote server setting

### DIFF
--- a/.github/workflows/service_test_sftp.yml
+++ b/.github/workflows/service_test_sftp.yml
@@ -55,7 +55,7 @@ jobs:
           echo "sed -i -e 's#ForceCommand internal-sftp#ForceCommand internal-sftp -d /upload#' /etc/ssh/sshd_config" > "$tmpScript"
           chmod +x "$tmpScript"
           docker run \
-              -v "$tmpScript:/etc/sftp.d/change_root_dir"
+              -v "$tmpScript:/etc/sftp.d/change_root_dir" \
               -v `pwd`/target/ssh/id_rsa.pub:/home/foo/.ssh/keys/id_rsa.pub:ro \
               --ulimit nofile=65536:65536 \
               -p 2223:22 -d atmoz/sftp \

--- a/.github/workflows/service_test_sftp.yml
+++ b/.github/workflows/service_test_sftp.yml
@@ -39,7 +39,6 @@ concurrency:
 jobs:
   sftp-test:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - name: Setup sftp
@@ -51,16 +50,6 @@ jobs:
               --ulimit nofile=65536:65536 \
               -p 2222:22 -d atmoz/sftp \
               foo::::upload
-          tmpScript="$(mktemp)"
-          echo "sed -i -e 's#ForceCommand internal-sftp#ForceCommand internal-sftp -d /upload#' /etc/ssh/sshd_config" > "$tmpScript"
-          chmod +x "$tmpScript"
-          docker run \
-              -v "$tmpScript:/etc/sftp.d/change_root_dir" \
-              -v `pwd`/target/ssh/id_rsa.pub:/home/foo/.ssh/keys/id_rsa.pub:ro \
-              --ulimit nofile=65536:65536 \
-              -p 2223:22 -d atmoz/sftp \
-              foo::::upload
-
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
         with:
@@ -77,14 +66,36 @@ jobs:
           OPENDAL_SFTP_USER: foo
           OPENDAL_SFTP_KEY: ${{ github.workspace }}/target/ssh/id_rsa
           OPENDAL_SFTP_KNOWN_HOSTS_STRATEGY: accept
-      - name: Test (with default root)
+
+  sftp-test-default-root:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup sftp
+        run: |
+          mkdir -p target/ssh
+          ssh-keygen -t rsa -b 4096 -f target/ssh/id_rsa -q -N "" < /dev/null
+          tmpScript="$(mktemp)"
+          echo "sed -i -e 's#ForceCommand internal-sftp#ForceCommand internal-sftp -d /upload#' /etc/ssh/sshd_config" > "$tmpScript"
+          chmod +x "$tmpScript"
+          docker run \
+              -v "$tmpScript:/etc/sftp.d/change_root_dir" \
+              -v `pwd`/target/ssh/id_rsa.pub:/home/foo/.ssh/keys/id_rsa.pub:ro \
+              --ulimit nofile=65536:65536 \
+              -p 2222:22 -d atmoz/sftp \
+              foo::::upload
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup
+        with:
+          need-nextest: true
+      - name: Test
         shell: bash
         timeout-minutes: 10
         working-directory: core
         run: cargo nextest run sftp --features services-sftp
         env:
           OPENDAL_SFTP_TEST: on
-          OPENDAL_SFTP_ENDPOINT: ssh://127.0.0.1:2223
+          OPENDAL_SFTP_ENDPOINT: ssh://127.0.0.1:2222
           OPENDAL_SFTP_USER: foo
           OPENDAL_SFTP_KEY: ${{ github.workspace }}/target/ssh/id_rsa
           OPENDAL_SFTP_KNOWN_HOSTS_STRATEGY: accept

--- a/.github/workflows/service_test_sftp.yml
+++ b/.github/workflows/service_test_sftp.yml
@@ -51,6 +51,15 @@ jobs:
               --ulimit nofile=65536:65536 \
               -p 2222:22 -d atmoz/sftp \
               foo::::upload
+          tmpScript="$(mktemp)"
+          echo "sed -i -e 's#ForceCommand internal-sftp#ForceCommand internal-sftp -d /upload#' /etc/ssh/sshd_config" > "$tmpScript"
+          chmod +x "$tmpScript"
+          docker run \
+              -v "$tmpScript:/etc/sftp.d/change_root_dir"
+              -v `pwd`/target/ssh/id_rsa.pub:/home/foo/.ssh/keys/id_rsa.pub:ro \
+              --ulimit nofile=65536:65536 \
+              -p 2223:22 -d atmoz/sftp \
+              foo::::upload
 
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
@@ -68,3 +77,15 @@ jobs:
           OPENDAL_SFTP_USER: foo
           OPENDAL_SFTP_KEY: ${{ github.workspace }}/target/ssh/id_rsa
           OPENDAL_SFTP_KNOWN_HOSTS_STRATEGY: accept
+      - name: Test (with default root)
+        shell: bash
+        timeout-minutes: 10
+        working-directory: core
+        run: cargo nextest run sftp --features services-sftp
+        env:
+          OPENDAL_SFTP_TEST: on
+          OPENDAL_SFTP_ENDPOINT: ssh://127.0.0.1:2223
+          OPENDAL_SFTP_USER: foo
+          OPENDAL_SFTP_KEY: ${{ github.workspace }}/target/ssh/id_rsa
+          OPENDAL_SFTP_KNOWN_HOSTS_STRATEGY: accept
+          OPENDAL_DISABLE_RANDOM_ROOT: true

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -535,12 +535,11 @@ async fn connect_sftp(
     let sftp = Sftp::from_session(session, SftpOptions::default()).await?;
 
     let mut fs = sftp.fs();
-    fs.set_cwd("/");
 
     let paths = Path::new(&root).components();
-    let mut current = PathBuf::from("/");
+    let mut current = PathBuf::new();
     for p in paths {
-        current = current.join(p);
+        current.push(p);
         let res = fs.create_dir(p).await;
 
         if let Err(e) = res {

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -78,6 +78,7 @@ impl SftpBuilder {
     }
 
     /// set root path for sftp backend.
+    /// It uses the default directory set by the remote `sftp-server` as default.
     pub fn root(&mut self, root: &str) -> &mut Self {
         self.root = if root.is_empty() {
             None

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -21,7 +21,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::path::Path;
 use std::path::PathBuf;
-use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -155,7 +154,7 @@ impl Builder for SftpBuilder {
             .root
             .clone()
             .map(|r| normalize_root(r.as_str()))
-            .unwrap_or(format!("/home/{}/", user));
+            .unwrap_or_default();
 
         let known_hosts_strategy = match &self.known_hosts_strategy {
             Some(v) => {
@@ -527,28 +526,29 @@ async fn connect_sftp(
         session.control_directory("/private/tmp/.opendal/");
     }
 
-    session.server_alive_interval(Duration::from_secs(5));
     session.known_hosts_check(known_hosts_strategy);
 
     let session = session.connect(&endpoint).await?;
 
     let sftp = Sftp::from_session(session, SftpOptions::default()).await?;
 
-    let mut fs = sftp.fs();
+    if !root.is_empty() {
+        let mut fs = sftp.fs();
 
-    let paths = Path::new(&root).components();
-    let mut current = PathBuf::new();
-    for p in paths {
-        current.push(p);
-        let res = fs.create_dir(p).await;
+        let paths = Path::new(&root).components();
+        let mut current = PathBuf::new();
+        for p in paths {
+            current.push(p);
+            let res = fs.create_dir(p).await;
 
-        if let Err(e) = res {
-            // ignore error if dir already exists
-            if !is_sftp_protocol_error(&e) {
-                return Err(e.into());
+            if let Err(e) = res {
+                // ignore error if dir already exists
+                if !is_sftp_protocol_error(&e) {
+                    return Err(e.into());
+                }
             }
+            fs.set_cwd(&current);
         }
-        fs.set_cwd(&current);
     }
 
     debug!("sftp connection created at {}", root);

--- a/core/src/services/sftp/docs.md
+++ b/core/src/services/sftp/docs.md
@@ -18,7 +18,7 @@ This service can be used to:
 ## Configuration
 
 - `endpoint`: Set the endpoint for connection
-- `root`: Set the work directory for backend, default to `/home/$USER/`
+- `root`: Set the work directory for backend. It uses the default directory set by the remote `sftp-server` as default
 - `user`: Set the login user
 - `key`: Set the public key for login
 - `known_hosts_strategy`: Set the strategy for known hosts, default to `Strict`


### PR DESCRIPTION
Previously, sftp root config only supports absolute path. This patch is mentioned in https://github.com/apache/incubator-opendal/pull/2192.