### PR TITLE
docs(services/redis): fix redis via config example

### DIFF
--- a/website/docs/services/redis.mdx
+++ b/website/docs/services/redis.mdx
@@ -28,6 +28,10 @@ use opendal::Operator;
 async fn main() -> Result<()> {
     let mut map = HashMap::new();
     map.insert("root".to_string(), "/path/to/dir".to_string());
+    map.insert("endpoint".to_string(), "tcp://127.0.0.1:6379".to_string());
+    map.insert("username".to_string(), "your_username".to_string());
+    map.insert("password".to_string(), "your_password".to_string());
+    map.insert("db".to_string(), "0".to_string());
 
     let op: Operator = Operator::via_map(Scheme::Redis, map)?;
     Ok(())
@@ -43,6 +47,10 @@ import { Operator } from "opendal";
 async function main() {
   const op = new Operator("redis", {
     root: "/path/to/dir",
+    endpoint: "tcp://127.0.0.1:6379",
+    username: "your_username",
+    password: "your_password",
+    db: "0",
   });
 }
 ```
@@ -55,6 +63,10 @@ import opendal
 
 op = opendal.Operator("redis",
   root="/path/to/dir",
+  endpoint="tcp://127.0.0.1:6379",
+  username="your_username",
+  password="your_password",
+  db="0",
 )
 ```
 


### PR DESCRIPTION
close issue #2432 
fix redis via config example by adding more configuration 

<img width="1136" alt="image" src="https://github.com/apache/incubator-opendal/assets/48410497/06693c18-d3df-4169-a6c7-13a20c912219">
