### PR TITLE
feat(layer): add throttle layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,6 +1527,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c390a940a5d157878dd057c78680a33ce3415bcd05b4799509ea44210914b4d5"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot 0.12.1",
+ "quanta 0.9.3",
+ "rand 0.8.5",
+ "smallvec",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,7 +2352,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.1",
- "quanta",
+ "quanta 0.10.1",
  "rustc_version",
  "scheduled-thread-pool",
  "skeptic",
@@ -2427,6 +2445,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,6 +2459,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "normalize-line-endings"
@@ -2637,6 +2667,7 @@ dependencies = [
  "dotenvy",
  "flagset",
  "futures",
+ "governor",
  "hdrs",
  "http",
  "hyper",
@@ -3463,6 +3494,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quanta"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -75,6 +75,7 @@ layers-all = [
   "layers-prometheus",
   "layers-tracing",
   "layers-minitrace",
+  "layers-throttle",
 ]
 # Enable layers chaos support
 layers-chaos = ["dep:rand"]
@@ -90,6 +91,8 @@ layers-minitrace = ["dep:minitrace"]
 layers-tracing = ["dep:tracing"]
 # Enable layers oteltrace support.
 layers-otel-trace = ["dep:opentelemetry"]
+# Enable layers throttle support.
+layers-throttle = ["dep:governor"]
 
 services-azblob = [
   "dep:sha2",
@@ -175,6 +178,7 @@ dashmap = { version = "5.4", optional = true }
 dirs = { version = "5.0.1", optional = true }
 flagset = "0.4"
 futures = { version = "0.3", default-features = false, features = ["std"] }
+governor = { version = "0.5", optional = true, features = ["std"] }
 hdrs = { version = "0.2", optional = true, features = ["async_file"] }
 http = "0.2.5"
 hyper = "0.14"

--- a/core/src/layers/mod.rs
+++ b/core/src/layers/mod.rs
@@ -76,5 +76,11 @@ pub use self::madsim::MadsimServer;
 
 #[cfg(feature = "layers-otel-trace")]
 mod oteltrace;
+
+#[cfg(feature = "layers-throttle")]
+mod throttle;
+#[cfg(feature = "layers-throttle")]
+pub use self::throttle::ThrottleLayer;
+
 #[cfg(feature = "layers-otel-trace")]
 pub use self::oteltrace::OtelTraceLayer;

--- a/core/src/layers/throttle.rs
+++ b/core/src/layers/throttle.rs
@@ -1,0 +1,21 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::num::NonZeroU32;
+use governor::{Quota, RateLimiter};
+
+/// ThrottleLayer can help users to control the max bandwidth that used by OpenDAL.

--- a/core/src/layers/throttle.rs
+++ b/core/src/layers/throttle.rs
@@ -15,7 +15,318 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::io::SeekFrom;
 use std::num::NonZeroU32;
-use governor::{Quota, RateLimiter};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use chrono::Duration;
+use governor::clock::{Clock, DefaultClock, QuantaInstant};
+use governor::middleware::{RateLimitingMiddleware, StateInformationMiddleware, StateSnapshot};
+use governor::state::{InMemoryState, NotKeyed};
+use governor::{NegativeMultiDecision, NotUntil, Quota, RateLimiter, RatelimitedStream};
+
+use crate::raw::*;
+use crate::*;
 
 /// ThrottleLayer can help users to control the max bandwidth that used by OpenDAL.
+#[derive(Clone)]
+pub struct ThrottleLayer {
+    // TODO: NonZeroU32 or u32, since user enter 0 will cause panic
+    max_burst: u32,
+}
+
+impl ThrottleLayer {
+    /// Create a new ThrottleLayer will specify quota
+    pub fn new(max_burst: u32) -> Self {
+        Self { max_burst }
+    }
+}
+
+impl<A: Accessor> Layer<A> for ThrottleLayer {
+    type LayeredAccessor = ThrottleAccessor<A>;
+
+    fn layer(&self, accessor: A) -> Self::Output {
+        let rate_limiter = Arc::new(
+            RateLimiter::direct(Quota::per_second(NonZeroU32::new(self.max_burst).unwrap()))
+                // More info about middleware: https://docs.rs/governor/latest/governor/middleware/index.html
+                .with_middleware::<StateInformationMiddleware>(),
+        );
+        ThrottleAccessor {
+            inner: accessor,
+            rate_limiter,
+        }
+    }
+}
+
+type SharedRateLimiter =
+    Arc<RateLimiter<NotKeyed, InMemoryState, DefaultClock, StateInformationMiddleware>>;
+
+#[derive(Debug, Clone)]
+pub struct ThrottleAccessor<A: Accessor> {
+    inner: A,
+    rate_limiter: SharedRateLimiter,
+}
+
+#[async_trait]
+impl<A: Accessor> LayeredAccessor for ThrottleAccessor<A> {
+    type Inner = A;
+    type Reader = ThrottleWrapper<A::Reader>;
+    type BlockingReader = ThrottleWrapper<A::BlockingReader>;
+    type Writer = ThrottleWrapper<A::Writer>;
+    type BlockingWriter = ThrottleWrapper<A::BlockingWriter>;
+    type Appender = ThrottleWrapper<A::Appender>;
+    type Pager = A::Pager;
+    type BlockingPager = A::BlockingPager;
+
+    fn inner(&self) -> &Self::Inner {
+        &self.inner
+    }
+
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        let limiter = self.rate_limiter.clone();
+
+        self.inner
+            .read(path, args)
+            .await
+            .map(|(rp, r)| (rp, ThrottleWrapper::new(r, limiter)))
+    }
+
+    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
+        let limiter = self.rate_limiter.clone();
+
+        self.inner
+            .write(path, args)
+            .await
+            .map(|(rp, w)| (rp, ThrottleWrapper::new(w, limiter)))
+    }
+
+    async fn append(&self, path: &str, args: OpAppend) -> Result<(RpAppend, Self::Appender)> {
+        let limiter = self.rate_limiter.clone();
+
+        self.inner
+            .append(path, args)
+            .await
+            .map(|(rp, a)| (rp, ThrottleWrapper::new(a, limiter)))
+    }
+
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
+        self.inner.list(path, args).await
+    }
+
+    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
+        let limiter = self.rate_limiter.clone();
+
+        self.inner
+            .blocking_read(path, args)
+            .map(|(rp, r)| (rp, ThrottleWrapper::new(r, limiter)))
+    }
+
+    fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
+        let limiter = self.rate_limiter.clone();
+
+        self.inner
+            .blocking_write(path, args)
+            .map(|(rp, w)| (rp, ThrottleWrapper::new(w, limiter)))
+    }
+
+    fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
+        self.inner.blocking_list(path, args)
+    }
+}
+
+pub struct ThrottleWrapper<R> {
+    inner: R,
+    limiter: SharedRateLimiter,
+}
+
+impl<R> ThrottleWrapper<R> {
+    pub fn new(inner: R, rate_limiter: SharedRateLimiter) -> Self {
+        Self {
+            inner,
+            limiter: rate_limiter,
+        }
+    }
+}
+
+impl<R: oio::Read> oio::Read for ThrottleWrapper<R> {
+    fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
+        // TODO: How can we handle buffer reads with a limiter?
+        self.inner.poll_read(cx, buf)
+    }
+
+    fn poll_seek(&mut self, cx: &mut Context<'_>, pos: SeekFrom) -> Poll<Result<u64>> {
+        self.inner.poll_seek(cx, pos)
+    }
+
+    fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
+        self.inner.poll_next(cx)
+    }
+}
+
+impl<R: oio::BlockingRead> oio::BlockingRead for ThrottleWrapper<R> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        // TODO: How can we handle buffer reads with a limiter?
+        self.inner.read(buf)
+    }
+
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        self.inner.seek(pos)
+    }
+
+    fn next(&mut self) -> Option<Result<Bytes>> {
+        self.inner.next()
+    }
+}
+
+#[async_trait]
+impl<R: oio::Write> oio::Write for ThrottleWrapper<R> {
+    async fn write(&mut self, mut bs: Bytes) -> Result<()> {
+        // Note: for self.inner.write(bs), it's possible that the given bs length is less than the total content length.
+        // Users will call write multiple times to write the whole data.
+
+        let mut buf_length = NonZeroU32::new(bs.len() as u32).unwrap();
+
+        while !bs.is_empty() {
+            match self.limiter.check_n(buf_length) {
+                Ok(_) => self.inner.write(bs.split_to(buf_length as usize)).await,
+                Err(negative) => match negative {
+                    // the query is valid but the Decider can not accommodate them.
+                    NegativeMultiDecision::BatchNonConforming(_, not_until) => {
+                        // We can either change buf_length or we can wait until the rate limiter has enough capacity to accommodate the request.
+                        let wait_time = not_until
+                            .wait_time_from(DefaultClock::default().now())
+                            .as_secs();
+                        tokio::time::sleep(Duration::from_secs(wait_time)).await;
+                    }
+                    // the query was invalid as the rate limit parameters can "never" accommodate the number of cells queried for.
+                    NegativeMultiDecision::InsufficientCapacity(_) => {
+                        // Allow a single cell through the rate limiter.
+                        // If the rate limit is reached, check returns information about the earliest time that a cell might be allowed through again.
+                        buf_length: NonZeroU32 = match self.limiter.check() {
+                            Ok(snapshot) => {
+                                /// If this state snapshot is based on a negative rate limiting
+                                /// outcome, this method returns 0. (So unwrap() is safe here...right?)
+                                NonZeroU32::new(snapshot.remaining_burst_capacity()).unwrap()
+                            }
+                            Err(negative) => {
+                                // not a single cell can be allowed through the rate limiter for now
+                                let wait_time =
+                                    negative.wait_time_from(DefaultClock::default().now());
+                                tokio::time::sleep(Duration::from_secs(wait_time)).await;
+                            }
+                        }
+                    }
+                },
+            }
+        }
+        return Ok(());
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        self.inner.abort().await
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.inner.close().await
+    }
+}
+
+impl<R: oio::BlockingWrite> oio::BlockingWrite for ThrottleWrapper<R> {
+    fn write(&mut self, mut bs: Bytes) -> Result<()> {
+        // Note: for self.inner.write(bs), it's possible that the given bs length is less than the total content length.
+        // Users will call write multiple times to write the whole data.
+
+        let mut buf_length = NonZeroU32::new(bs.len() as u32).unwrap();
+
+        while !bs.is_empty() {
+            match self.limiter.check_n(buf_length) {
+                Ok(_) => self.inner.write(bs.split_to(buf_length as usize)),
+                Err(negative) => match negative {
+                    // the query is valid but the Decider can not accommodate them.
+                    NegativeMultiDecision::BatchNonConforming(_, not_until) => {
+                        // We can either change buf_length or we can wait until the rate limiter has enough capacity to accommodate the request.
+                        let wait_time = not_until
+                            .wait_time_from(DefaultClock::default().now())
+                            .as_secs();
+                        std::thread::sleep(Duration::from_secs(wait_time));
+                    }
+                    // the query was invalid as the rate limit parameters can "never" accommodate the number of cells queried for.
+                    NegativeMultiDecision::InsufficientCapacity(_) => {
+                        // Allow a single cell through the rate limiter.
+                        // If the rate limit is reached, check returns information about the earliest time that a cell might be allowed through again.
+                        buf_length: NonZeroU32 = match self.limiter.check() {
+                            Ok(snapshot) => {
+                                /// If this state snapshot is based on a negative rate limiting
+                                /// outcome, this method returns 0. (So unwrap() is safe here...right?)
+                                NonZeroU32::new(snapshot.remaining_burst_capacity()).unwrap()
+                            }
+                            Err(negative) => {
+                                // not a single cell can be allowed through the rate limiter for now
+                                let wait_time =
+                                    negative.wait_time_from(DefaultClock::default().now());
+                                std::thread::sleep(Duration::from_secs(wait_time));
+                            }
+                        }
+                    }
+                },
+            }
+        }
+        return Ok(());
+    }
+
+    fn close(&mut self) -> Result<()> {
+        self.inner.close()
+    }
+}
+
+#[async_trait]
+impl<R: oio::Append> oio::Append for ThrottleWrapper<R> {
+    async fn append(&mut self, mut bs: Bytes) -> Result<()> {
+        // Note: for self.inner.write(bs), it's possible that the given bs length is less than the total content length.
+        // Users will call write multiple times to write the whole data.
+
+        let mut buf_length = NonZeroU32::new(bs.len() as u32).unwrap();
+
+        while !bs.is_empty() {
+            match self.limiter.check_n(buf_length) {
+                Ok(_) => self.inner.append(bs.split_to(buf_length as usize)),
+                Err(negative) => match negative {
+                    // the query is valid but the Decider can not accommodate them.
+                    NegativeMultiDecision::BatchNonConforming(_, not_until) => {
+                        // We can either change buf_length or we can wait until the rate limiter has enough capacity to accommodate the request.
+                        let wait_time = not_until
+                            .wait_time_from(DefaultClock::default().now())
+                            .as_secs();
+                        tokio::time::sleep(Duration::from_secs(wait_time)).await;
+                    }
+                    // the query was invalid as the rate limit parameters can "never" accommodate the number of cells queried for.
+                    NegativeMultiDecision::InsufficientCapacity(_) => {
+                        // Allow a single cell through the rate limiter.
+                        // If the rate limit is reached, check returns information about the earliest time that a cell might be allowed through again.
+                        buf_length: NonZeroU32 = match self.limiter.check() {
+                            Ok(snapshot) => {
+                                /// If this state snapshot is based on a negative rate limiting
+                                /// outcome, this method returns 0. (So unwrap() is safe here...right?)
+                                NonZeroU32::new(snapshot.remaining_burst_capacity()).unwrap()
+                            }
+                            Err(negative) => {
+                                // not a single cell can be allowed through the rate limiter for now
+                                let wait_time =
+                                    negative.wait_time_from(DefaultClock::default().now());
+                                tokio::time::sleep(Duration::from_secs(wait_time)).await;
+                            }
+                        }
+                    }
+                },
+            }
+        }
+        return Ok(());
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.inner.close().await
+    }
+}


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced by this PR. -->
- related issue: #743

## Background
> ~~**NOTE: This is still a early stage of this PR, I open this PR for RFC and guidance.**~~

As there's no open-source repository that uses Governor to limit bandwidth so far, it's mostly used to limit the number of requests, e.g. [tower-governor](https://github.com/benwis/tower-governor) (although Governor can theoretically limit [any element](https://docs.rs/governor/latest/governor/_guide/index.html#quotas)). 

There's an [issue](https://github.com/antifuchs/governor/issues/154#issuecomment-1293731081) asked by [Quickwit](https://github.com/quickwit-oss/quickwit)'s author about how to use Governor to **limit IO throughput**, but he ended up using [async-speed-limit](https://github.com/tikv/async-speed-limit) for **Quickwit** ([PR](https://github.com/quickwit-oss/quickwit/pull/2205/files), which also seems to use a truncated byte stream implementation.).

My current implementation uses the answer provided in the above issue by the Governor author. However, it's rough and untested, and there are some uncertainties that I left comments inline. Things I need more information to confirm include:

- Is it possible to limit read (async/blocking) operations since the layer can't affect the `inner.read()` implementor's behavior?(I assume)?
- For my current implementations for Write (async/blocking) and Append operations, I use the Bytes truncation method to limit inner consumption. I don't know if this direction is the right approach so far.

I'm here to ask anyone for help or change/study suggestion. Any mentoring guide would be REALLY appreciated!