### PR TITLE
feat(bindings/C): add support for list in C binding

### DIFF
--- a/bindings/c/CONTRIBUTING.md
+++ b/bindings/c/CONTRIBUTING.md
@@ -62,7 +62,7 @@ make clean
 ## Test
 To build and run the tests. (Note that you need to install GTest)
 ```shell
-make test
+make tests
 ```
 
 ```text

--- a/bindings/c/CONTRIBUTING.md
+++ b/bindings/c/CONTRIBUTING.md
@@ -1,16 +1,17 @@
 # Contributing
-- [Contributing](#contributing)
-   - [Setup](#setup)
-      - [Using a dev container environment](#using-a-dev-container-environment)
-      - [Bring your own toolbox](#bring-your-own-toolbox)
-   - [Build](#build)
-   - [Test](#test)
-   - [Docs](#docs)
-   - [Misc](#misc)
+
+1. [Contributing](#contributing)
+   1. [Setup](#setup)
+      1. [Using a dev container environment](#using-a-dev-container-environment)
+      2. [Bring your own toolbox](#bring-your-own-toolbox)
+   2. [Build](#build)
+   3. [Test](#test)
+   4. [Documentation](#documentation)
 
 ## Setup
 
 ### Using a dev container environment
+
 OpenDAL provides a pre-configured [dev container](https://containers.dev/) that could be used in [Github Codespaces](https://github.com/features/codespaces), [VSCode](https://code.visualstudio.com/), [JetBrains](https://www.jetbrains.com/remote-development/gateway/), [JuptyerLab](https://jupyterlab.readthedocs.io/en/stable/). Please pick up your favourite runtime environment.
 
 The fastest way is:
@@ -18,16 +19,20 @@ The fastest way is:
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/apache/incubator-opendal?quickstart=1&machine=standardLinux32gb)
 
 ### Bring your own toolbox
+
 To build OpenDAL C binding, the following is all you need:
-- **A C++ compiler** that supports **c++14**, *e.g.* clang++ and g++
+
+- **A C++ compiler** that supports **c++14**, _e.g._ clang++ and g++
 
 - To format the code, you need to install **clang-format**
-    - The `opendal.h` is not formatted by hands when you contribute, please do not format the file. **Use `make format` only.**
-    - If your contribution is related to the files under `./tests`, you may format it before submitting your pull request. But notice that different versions of `clang-format` may format the files differently.
+
+  - The `opendal.h` is not formatted by hands when you contribute, please do not format the file. **Use `make format` only.**
+  - If your contribution is related to the files under `./tests`, you may format it before submitting your pull request. But notice that different versions of `clang-format` may format the files differently.
 
 - **GTest(Google Test)** need to be installed to build the BDD (Behavior Driven Development) tests. To see how to build, check [here](https://github.com/google/googletest).
 
 For Ubuntu and Debian:
+
 ```shell
 # install C/C++ toolchain
 sudo apt install -y build-essential
@@ -46,43 +51,36 @@ sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
 ```
 
 ## Build
+
 To build the library and header file.
+
 ```shell
 make build
 ```
 
-- The header file `opendal.h` is under `./include` 
+- The header file `opendal.h` is under `./include`
 - The library is under `../../target/debug` after building.
 
 To clean the build results.
+
 ```shell
 make clean
 ```
 
 ## Test
+
 To build and run the tests. (Note that you need to install GTest)
+
 ```shell
-make tests
-```
-
-```text
-[==========] Running 1 test from 1 test suite.
-[----------] Global test environment set-up.
-[----------] 1 test from OpendalBddTest
-[ RUN      ] OpendalBddTest.FeatureTest
-[       OK ] OpendalBddTest.FeatureTest (0 ms)
-[----------] 1 test from OpendalBddTest (0 ms total)
-
-[----------] Global test environment tear-down
-[==========] 1 test from 1 test suite ran. (0 ms total)
-[  PASSED  ] 1 test.
+make test
 ```
 
 ## Documentation
+
 The documentation index page source is under `./docs/doxygen/html/index.html`.
 If you want to build the documentations yourself, you could use
+
 ```sh
 # this requires you to install doxygen
 make doc
 ```
-

--- a/bindings/c/Makefile
+++ b/bindings/c/Makefile
@@ -38,10 +38,12 @@ build:
 	mkdir -p $(OBJ_DIR)
 	cargo build
 
-.PHONY: test
-test:
+.PHONY: tests
+tests:
 	$(CXX) tests/bdd.cpp -o $(OBJ_DIR)/bdd $(CXXFLAGS) $(LDFLAGS) $(LIBS)
+	$(CXX) tests/list.cpp -o $(OBJ_DIR)/list $(CXXFLAGS) $(LDFLAGS) $(LIBS)
 	$(OBJ_DIR)/bdd
+	$(OBJ_DIR)/list
 
 .PHONY: doc
 doc:

--- a/bindings/c/Makefile
+++ b/bindings/c/Makefile
@@ -38,8 +38,8 @@ build:
 	mkdir -p $(OBJ_DIR)
 	cargo build
 
-.PHONY: tests
-tests:
+.PHONY: test
+test:
 	$(CXX) tests/bdd.cpp -o $(OBJ_DIR)/bdd $(CXXFLAGS) $(LDFLAGS) $(LIBS)
 	$(CXX) tests/list.cpp -o $(OBJ_DIR)/list $(CXXFLAGS) $(LDFLAGS) $(LIBS)
 	$(OBJ_DIR)/bdd

--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -97,7 +97,7 @@ sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
 - To build and run the **tests**. (Note that you need to install GTest)
 
   ```sh
-  make test
+  make tests
   ```
 
 - To build the **examples**

--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -3,7 +3,9 @@
 ![](https://github.com/apache/incubator-opendal/assets/5351546/87bbf6e5-f19e-449a-b368-3e283016c887)
 
 ## Example
+
 A simple read and write example
+
 ```C
 #include "assert.h"
 #include "opendal.h"
@@ -44,21 +46,25 @@ int main()
     opendal_operator_free(&op);
 }
 ```
+
 For more examples, please refer to `./examples`
 
 ## Prerequisites
 
 To build OpenDAL C binding, the following is all you need:
-- **A C++ compiler** that supports **c++14**, *e.g.* clang++ and g++
+
+- **A C++ compiler** that supports **c++14**, _e.g._ clang++ and g++
 
 - To format the code, you need to install **clang-format**
-    - The `opendal.h` is not formatted by hands when you contribute, please do not format the file. **Use `make format` only.**
-    - If your contribution is related to the files under `./tests`, you may format it before submitting your pull request. But notice that different versions of `clang-format` may format the files differently.
+
+  - The `opendal.h` is not formatted by hands when you contribute, please do not format the file. **Use `make format` only.**
+  - If your contribution is related to the files under `./tests`, you may format it before submitting your pull request. But notice that different versions of `clang-format` may format the files differently.
 
 - **GTest(Google Test)** need to be installed to build the BDD (Behavior Driven Development) tests. To see how to build, check [here](https://github.com/google/googletest).
 - (optional) **Doxygen** need to be installed to generate documentations.
 
 For Ubuntu and Debian:
+
 ```shell
 # install C/C++ toolchain
 sudo apt install -y build-essential
@@ -77,6 +83,7 @@ sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
 ```
 
 ## Makefile
+
 - To **build the library and header file**.
 
   ```sh
@@ -87,7 +94,6 @@ sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
 
   - The library is under `../../target/debug` after building.
 
-
 - To **clean** the build results.
 
   ```sh
@@ -97,7 +103,7 @@ sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
 - To build and run the **tests**. (Note that you need to install GTest)
 
   ```sh
-  make tests
+  make test
   ```
 
 - To build the **examples**
@@ -106,16 +112,15 @@ sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
   make examples
   ```
 
-
-
 ## Documentation
+
 The documentation index page source is under `./docs/doxygen/html/index.html`.
 If you want to build the documentations yourself, you could use
+
 ```sh
 # this requires you to install doxygen
 make doc
 ```
-
 
 ## License
 

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -560,18 +560,38 @@ struct opendal_result_stat opendal_operator_stat(const struct opendal_operator_p
 /**
  * \brief Blockingly list the objects in `path`.
  *
- * List the object in `path` blockingly by `op_ptr`
+ * List the object in `path` blockingly by `op_ptr`, return a result with a
+ * opendal_blocking_lister. Users should call opendal_lister_next() on the
+ * lister.
  *
  * @param ptr The opendal_operator_ptr created previously
  * @param path The designated path you want to delete
- * @see opendal_operator_ptr
- * @see opendal_code
+ * @see opendal_blocking_lister
  * @return
  *
  * # Example
  *
  * Following is an example
  * ```C
+ * // You have written some data into some files path "root/dir1"
+ * // Your opendal_operator_ptr was called ptr
+ * opendal_result_list l = opendal_operator_blocking_list(ptr, "root/dir1");
+ * assert(l.code == OPENDAL_OK);
+ *
+ * opendal_blocking_lister *lister = l.lister;
+ * opendal_list_entry *entry;
+ *
+ * while ((entry = opendal_lister_next(lister)) != NULL) {
+ *     const char* de_path = opendal_list_entry_path(entry);
+ *     const char* de_name = opendal_list_entry_name(entry);
+ *     // ...... your operations
+ *
+ *     // remember to free the entry after you are done using it
+ *     opendal_list_entry_free(entry);
+ * }
+ *
+ * // and remember to free the lister
+ * opendal_lister_free(lister);
  * ```
  *
  * # Safety

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -121,6 +121,11 @@ typedef struct BlockingLister BlockingLister;
  */
 typedef struct BlockingOperator BlockingOperator;
 
+/**
+ * Entry is the file/dir entry returned by `Lister`.
+ */
+typedef struct Entry Entry;
+
 typedef struct HashMap_String__String HashMap_String__String;
 
 /**
@@ -269,10 +274,18 @@ typedef struct opendal_result_stat {
   enum opendal_code code;
 } opendal_result_stat;
 
+typedef struct opendal_blocking_lister {
+  struct BlockingLister *inner;
+} opendal_blocking_lister;
+
 typedef struct opendal_result_list {
-  const struct BlockingLister *lister;
+  struct opendal_blocking_lister lister;
   enum opendal_code code;
 } opendal_result_list;
+
+typedef struct opendal_list_entry {
+  const struct Entry *inner;
+} opendal_list_entry;
 
 #ifdef __cplusplus
 extern "C" {
@@ -690,6 +703,15 @@ void opendal_operator_options_set(struct opendal_operator_options *self,
  * \brief Free the allocated memory used by [`opendal_operator_options`]
  */
 void opendal_operator_options_free(const struct opendal_operator_options *options);
+
+/**
+ * nullable
+ */
+const struct opendal_list_entry *opendal_lister_next(const struct opendal_blocking_lister *self);
+
+const char *opendal_list_entry_path(const struct opendal_list_entry *self);
+
+const char *opendal_list_entry_name(const struct opendal_list_entry *self);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -584,7 +584,7 @@ struct opendal_result_stat opendal_operator_stat(const struct opendal_operator_p
  *
  * * If the `path` points to NULL, this function panics, i.e. exits with information
  */
-struct opendal_result_list opendal_operator_blocking_list(struct opendal_operator_ptr ptr,
+struct opendal_result_list opendal_operator_blocking_list(const struct opendal_operator_ptr *ptr,
                                                           const char *path);
 
 /**

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -274,6 +274,15 @@ typedef struct opendal_result_stat {
   enum opendal_code code;
 } opendal_result_stat;
 
+/**
+ * \brief BlockingLister is designed to list entries at given path in a blocking
+ * manner.
+ *
+ * Users can construct Lister by `blocking_list` or `blocking_scan`(currently not supported in C binding)
+ *
+ * For examples, please see the comment section of opendal_operator_blocking_list()
+ * @see opendal_operator_blocking_list()
+ */
 typedef struct opendal_blocking_lister {
   struct BlockingLister *inner;
 } opendal_blocking_lister;
@@ -283,6 +292,14 @@ typedef struct opendal_result_list {
   enum opendal_code code;
 } opendal_result_list;
 
+/**
+ * \brief opendal_list_entry is the entry under a path, which is listed from the opendal_blocking_lister
+ *
+ * For examples, please see the comment section of opendal_operator_blocking_list()
+ * @see opendal_operator_blocking_list()
+ * @see opendal_list_entry_path()
+ * @see opendal_list_entry_name()
+ */
 typedef struct opendal_list_entry {
   struct Entry *inner;
 } opendal_list_entry;
@@ -724,14 +741,39 @@ void opendal_operator_options_set(struct opendal_operator_options *self,
  */
 void opendal_operator_options_free(const struct opendal_operator_options *options);
 
+/**
+ * \brief Return the next object to be listed
+ *
+ * Lister is an iterator of the objects under its path, this method is the same as
+ * calling next() on the iterator
+ *
+ * For examples, please see the comment section of opendal_operator_blocking_list()
+ * @see opendal_operator_blocking_list()
+ */
 struct opendal_list_entry *opendal_lister_next(const struct opendal_blocking_lister *self);
 
+/**
+ * \brief Free the heap-allocated metadata used by opendal_blocking_lister
+ */
 void opendal_lister_free(const struct opendal_blocking_lister *p);
 
+/**
+ * Path of entry. Path is relative to operator's root.
+ * Only valid in current operator.
+ */
 const char *opendal_list_entry_path(const struct opendal_list_entry *self);
 
+/**
+ * Name of entry. Name is the last segment of path.
+ *
+ * If this entry is a dir, `Name` MUST endswith `/`
+ * Otherwise, `Name` MUST NOT endswith `/`.
+ */
 const char *opendal_list_entry_name(const struct opendal_list_entry *self);
 
+/**
+ * \brief Frees the heap memory used by the opendal_list_entry
+ */
 void opendal_list_entry_free(const struct opendal_list_entry *p);
 
 #ifdef __cplusplus

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -704,10 +704,7 @@ void opendal_operator_options_set(struct opendal_operator_options *self,
  */
 void opendal_operator_options_free(const struct opendal_operator_options *options);
 
-/**
- * nullable
- */
-struct opendal_list_entry opendal_lister_next(const struct opendal_blocking_lister *self);
+struct opendal_list_entry *opendal_lister_next(const struct opendal_blocking_lister *self);
 
 const char *opendal_list_entry_path(const struct opendal_list_entry *self);
 

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -82,6 +82,14 @@ typedef enum opendal_code {
 } opendal_code;
 
 /**
+ * BlockingLister is designed to list entries at given path in a blocking
+ * manner.
+ *
+ * Users can construct Lister by `blocking_list` or `blocking_scan`.
+ */
+typedef struct BlockingLister BlockingLister;
+
+/**
  * BlockingOperator is the entry for all public blocking APIs.
  *
  * Read [`concepts`][docs::concepts] for know more about [`Operator`].
@@ -260,6 +268,11 @@ typedef struct opendal_result_stat {
    */
   enum opendal_code code;
 } opendal_result_stat;
+
+typedef struct opendal_result_list {
+  const struct BlockingLister *lister;
+  enum opendal_code code;
+} opendal_result_list;
 
 #ifdef __cplusplus
 extern "C" {
@@ -530,6 +543,36 @@ struct opendal_result_is_exist opendal_operator_is_exist(const struct opendal_op
  */
 struct opendal_result_stat opendal_operator_stat(const struct opendal_operator_ptr *ptr,
                                                  const char *path);
+
+/**
+ * \brief Blockingly list the objects in `path`.
+ *
+ * List the object in `path` blockingly by `op_ptr`
+ *
+ * @param ptr The opendal_operator_ptr created previously
+ * @param path The designated path you want to delete
+ * @see opendal_operator_ptr
+ * @see opendal_code
+ * @return
+ *
+ * # Example
+ *
+ * Following is an example
+ * ```C
+ * ```
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_result_list opendal_operator_blocking_list(struct opendal_operator_ptr ptr,
+                                                          const char *path);
 
 /**
  * \brief Free the heap-allocated operator pointed by opendal_operator_ptr.

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -287,6 +287,13 @@ typedef struct opendal_blocking_lister {
   struct BlockingLister *inner;
 } opendal_blocking_lister;
 
+/**
+ * \brief The result type returned by opendal_operator_blocking_list().
+ *
+ * The result type for opendal_operator_blocking_list(), the field `lister` contains the lister
+ * of the path, which is an iterator of the objects under the path. the field `code` represents
+ * whether the stat operation is successful.
+ */
 typedef struct opendal_result_list {
   struct opendal_blocking_lister *lister;
   enum opendal_code code;

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -279,7 +279,7 @@ typedef struct opendal_blocking_lister {
 } opendal_blocking_lister;
 
 typedef struct opendal_result_list {
-  struct opendal_blocking_lister lister;
+  struct opendal_blocking_lister *lister;
   enum opendal_code code;
 } opendal_result_list;
 

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -284,7 +284,7 @@ typedef struct opendal_result_list {
 } opendal_result_list;
 
 typedef struct opendal_list_entry {
-  const struct Entry *inner;
+  struct Entry *inner;
 } opendal_list_entry;
 
 #ifdef __cplusplus
@@ -707,7 +707,7 @@ void opendal_operator_options_free(const struct opendal_operator_options *option
 /**
  * nullable
  */
-const struct opendal_list_entry *opendal_lister_next(const struct opendal_blocking_lister *self);
+struct opendal_list_entry opendal_lister_next(const struct opendal_blocking_lister *self);
 
 const char *opendal_list_entry_path(const struct opendal_list_entry *self);
 

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -706,9 +706,13 @@ void opendal_operator_options_free(const struct opendal_operator_options *option
 
 struct opendal_list_entry *opendal_lister_next(const struct opendal_blocking_lister *self);
 
+void opendal_lister_free(const struct opendal_blocking_lister *p);
+
 const char *opendal_list_entry_path(const struct opendal_list_entry *self);
 
 const char *opendal_list_entry_name(const struct opendal_list_entry *self);
+
+void opendal_list_entry_free(const struct opendal_list_entry *p);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 #![allow(non_camel_case_types)]
+#![warn(missing_docs)]
 
 mod error;
 mod result;
@@ -26,6 +27,7 @@ use std::os::raw::c_char;
 use std::str::FromStr;
 
 use ::opendal as od;
+use result::opendal_result_list;
 
 use crate::error::opendal_code;
 use crate::result::opendal_result_is_exist;
@@ -415,3 +417,57 @@ pub unsafe extern "C" fn opendal_operator_stat(
         },
     }
 }
+
+/// \brief Blockingly list the objects in `path`.
+///
+/// List the object in `path` blockingly by `op_ptr`
+///
+/// @param ptr The opendal_operator_ptr created previously
+/// @param path The designated path you want to delete
+/// @see opendal_operator_ptr
+/// @see opendal_code
+/// @return
+///
+/// # Example
+///
+/// Following is an example
+/// ```C
+/// ```
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_blocking_list(
+    ptr: opendal_operator_ptr,
+    path: *const c_char,
+) -> opendal_result_list {
+    if path.is_null() {
+        panic!("The path given is pointing at NULL");
+    }
+
+    let op = ptr.as_ref();
+    let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
+    match op.list(path) {
+        Ok(lister) => {
+            opendal_result_list {
+                lister: Box::leak(Box::new(lister)),
+                code: opendal_code::OPENDAL_OK,
+            }
+        }
+
+        Err(e) => {
+            opendal_result_list {
+                lister: std::ptr::null(),
+                code: opendal_code::from_opendal_error(e),
+            }
+        }
+    }
+}
+

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -446,14 +446,14 @@ pub unsafe extern "C" fn opendal_operator_stat(
 /// * If the `path` points to NULL, this function panics, i.e. exits with information
 #[no_mangle]
 pub unsafe extern "C" fn opendal_operator_blocking_list(
-    ptr: opendal_operator_ptr,
+    ptr: *const opendal_operator_ptr,
     path: *const c_char,
 ) -> opendal_result_list {
     if path.is_null() {
         panic!("The path given is pointing at NULL");
     }
 
-    let op = ptr.as_ref();
+    let op = (*ptr).as_ref();
     let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
     match op.list(path) {
         Ok(lister) => opendal_result_list {

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -457,14 +457,13 @@ pub unsafe extern "C" fn opendal_operator_blocking_list(
     let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
     match op.list(path) {
         Ok(lister) => opendal_result_list {
-            lister: opendal_blocking_lister::from_inner(lister),
+            lister: opendal_blocking_lister::from_lister(lister),
             code: opendal_code::OPENDAL_OK,
         },
 
         Err(e) => opendal_result_list {
-            lister: std::ptr::null(),
+            lister: opendal_blocking_lister::null(),
             code: opendal_code::from_opendal_error(e),
         },
     }
 }
-

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -15,8 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![allow(non_camel_case_types)]
 #![warn(missing_docs)]
+#![allow(non_camel_case_types)]
+
+//! The OpenDAL C binding.
+//!
+//! The OpenDAL C binding allows users to utilize the OpenDAL's amazing storage accessing capability
+//! in the C programming language.
+//!
+//! For examples, you may see the examples subdirectory
 
 mod error;
 mod result;

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -457,12 +457,12 @@ pub unsafe extern "C" fn opendal_operator_blocking_list(
     let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
     match op.list(path) {
         Ok(lister) => opendal_result_list {
-            lister: opendal_blocking_lister::from_lister(lister),
+            lister: Box::into_raw(Box::new(opendal_blocking_lister::new(lister))),
             code: opendal_code::OPENDAL_OK,
         },
 
         Err(e) => opendal_result_list {
-            lister: opendal_blocking_lister::null(),
+            lister: std::ptr::null_mut(),
             code: opendal_code::from_opendal_error(e),
         },
     }

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -421,18 +421,38 @@ pub unsafe extern "C" fn opendal_operator_stat(
 
 /// \brief Blockingly list the objects in `path`.
 ///
-/// List the object in `path` blockingly by `op_ptr`
+/// List the object in `path` blockingly by `op_ptr`, return a result with a
+/// opendal_blocking_lister. Users should call opendal_lister_next() on the
+/// lister.
 ///
 /// @param ptr The opendal_operator_ptr created previously
 /// @param path The designated path you want to delete
-/// @see opendal_operator_ptr
-/// @see opendal_code
+/// @see opendal_blocking_lister
 /// @return
 ///
 /// # Example
 ///
 /// Following is an example
 /// ```C
+/// // You have written some data into some files path "root/dir1"
+/// // Your opendal_operator_ptr was called ptr
+/// opendal_result_list l = opendal_operator_blocking_list(ptr, "root/dir1");
+/// assert(l.code == OPENDAL_OK);
+///
+/// opendal_blocking_lister *lister = l.lister;
+/// opendal_list_entry *entry;
+///
+/// while ((entry = opendal_lister_next(lister)) != NULL) {
+///     const char* de_path = opendal_list_entry_path(entry);
+///     const char* de_name = opendal_list_entry_name(entry);
+///     // ...... your operations
+///
+///     // remember to free the entry after you are done using it
+///     opendal_list_entry_free(entry);
+/// }
+///
+/// // and remember to free the lister
+/// opendal_lister_free(lister);
 /// ```
 ///
 /// # Safety

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -111,9 +111,9 @@ pub unsafe extern "C" fn opendal_operator_new(
     };
 
     // this prevents the operator memory from being dropped by the Box
-    let op = opendal_operator_ptr::from(Box::leak(Box::new(op)));
+    let op = opendal_operator_ptr::from(Box::into_raw(Box::new(op)));
 
-    Box::leak(Box::new(op))
+    Box::into_raw(Box::new(op))
 }
 
 /// \brief Blockingly write raw bytes to `path`.

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -28,6 +28,7 @@ use std::str::FromStr;
 
 use ::opendal as od;
 use result::opendal_result_list;
+use types::opendal_blocking_lister;
 
 use crate::error::opendal_code;
 use crate::result::opendal_result_is_exist;
@@ -455,19 +456,15 @@ pub unsafe extern "C" fn opendal_operator_blocking_list(
     let op = ptr.as_ref();
     let path = unsafe { std::ffi::CStr::from_ptr(path).to_str().unwrap() };
     match op.list(path) {
-        Ok(lister) => {
-            opendal_result_list {
-                lister: Box::leak(Box::new(lister)),
-                code: opendal_code::OPENDAL_OK,
-            }
-        }
+        Ok(lister) => opendal_result_list {
+            lister: opendal_blocking_lister::from_inner(lister),
+            code: opendal_code::OPENDAL_OK,
+        },
 
-        Err(e) => {
-            opendal_result_list {
-                lister: std::ptr::null(),
-                code: opendal_code::from_opendal_error(e),
-            }
-        }
+        Err(e) => opendal_result_list {
+            lister: std::ptr::null(),
+            code: opendal_code::from_opendal_error(e),
+        },
     }
 }
 

--- a/bindings/c/src/result.rs
+++ b/bindings/c/src/result.rs
@@ -69,6 +69,6 @@ pub struct opendal_result_stat {
 
 #[repr(C)]
 pub struct opendal_result_list {
-    pub lister: opendal_blocking_lister,
+    pub lister: *mut opendal_blocking_lister,
     pub code: opendal_code,
 }

--- a/bindings/c/src/result.rs
+++ b/bindings/c/src/result.rs
@@ -20,6 +20,8 @@
 //! "opendal_result_opendal_operator_ptr", which is unacceptable. Therefore,
 //! we are defining all Result types here
 
+use ::opendal as od;
+
 use crate::error::opendal_code;
 use crate::types::opendal_bytes;
 use crate::types::opendal_metadata;
@@ -65,3 +67,10 @@ pub struct opendal_result_stat {
     /// The error code, should be OPENDAL_OK if succeeds
     pub code: opendal_code,
 }
+
+#[repr(C)]
+pub struct opendal_result_list {
+    pub lister: *const od::BlockingLister,
+    pub code: opendal_code,
+}
+

--- a/bindings/c/src/result.rs
+++ b/bindings/c/src/result.rs
@@ -20,9 +20,8 @@
 //! "opendal_result_opendal_operator_ptr", which is unacceptable. Therefore,
 //! we are defining all Result types here
 
-use ::opendal as od;
-
 use crate::error::opendal_code;
+use crate::types::opendal_blocking_lister;
 use crate::types::opendal_bytes;
 use crate::types::opendal_metadata;
 
@@ -70,7 +69,6 @@ pub struct opendal_result_stat {
 
 #[repr(C)]
 pub struct opendal_result_list {
-    pub lister: *const od::BlockingLister,
+    pub lister: opendal_blocking_lister,
     pub code: opendal_code,
 }
-

--- a/bindings/c/src/result.rs
+++ b/bindings/c/src/result.rs
@@ -67,6 +67,11 @@ pub struct opendal_result_stat {
     pub code: opendal_code,
 }
 
+/// \brief The result type returned by opendal_operator_blocking_list().
+///
+/// The result type for opendal_operator_blocking_list(), the field `lister` contains the lister
+/// of the path, which is an iterator of the objects under the path. the field `code` represents
+/// whether the stat operation is successful.
 #[repr(C)]
 pub struct opendal_result_list {
     pub lister: *mut opendal_blocking_lister,

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -338,6 +338,11 @@ impl opendal_blocking_lister {
             Err(_) => std::ptr::null_mut(),
         }
     }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_lister_free(p: *const opendal_blocking_lister) {
+        unsafe { let _ = Box::from_raw(p as *mut opendal_blocking_lister); }
+    }
 }
 
 #[repr(C)]
@@ -360,5 +365,10 @@ impl opendal_list_entry {
     #[no_mangle]
     pub unsafe extern "C" fn opendal_list_entry_name(&self) -> *const c_char {
         (*self.inner).name().as_ptr() as *const c_char
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_list_entry_free(p: *const opendal_list_entry ) {
+        unsafe { let _ = Box::from_raw(p as *mut opendal_list_entry); }
     }
 }

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -350,11 +350,11 @@ impl opendal_list_entry {
 
     #[no_mangle]
     pub unsafe extern "C" fn opendal_list_entry_path(&self) -> *const c_char {
-        unimplemented!()
+        (*self.inner).path().as_ptr() as *const c_char
     }
 
     #[no_mangle]
     pub unsafe extern "C" fn opendal_list_entry_name(&self) -> *const c_char {
-        unimplemented!()
+        (*self.inner).name().as_ptr() as *const c_char
     }
 }

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -326,17 +326,16 @@ impl opendal_blocking_lister {
         }
     }
 
-    /// nullable
     #[no_mangle]
-    pub unsafe extern "C" fn opendal_lister_next(&self) -> opendal_list_entry {
+    pub unsafe extern "C" fn opendal_lister_next(&self) -> *mut opendal_list_entry {
         let e = (*self.inner).next();
         if e.is_none() {
-            return opendal_list_entry::null();
+            return std::ptr::null_mut();
         }
 
         match e.unwrap() {
-            Ok(e) => opendal_list_entry::from_entry(e),
-            Err(_) => opendal_list_entry::null(),
+            Ok(e) => Box::into_raw(Box::new(opendal_list_entry::new(e))),
+            Err(_) => std::ptr::null_mut(),
         }
     }
 }
@@ -347,15 +346,9 @@ pub struct opendal_list_entry {
 }
 
 impl opendal_list_entry {
-    pub(crate) fn from_entry(entry: od::Entry) -> Self {
+    pub(crate) fn new(entry: od::Entry) -> Self {
         Self {
             inner: Box::leak(Box::new(entry)),
-        }
-    }
-
-    pub(crate) fn null() -> Self {
-        Self {
-            inner: std::ptr::null_mut(),
         }
     }
 

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -73,15 +73,15 @@ impl opendal_operator_ptr {
 }
 
 #[allow(clippy::from_over_into)]
-impl From<&od::BlockingOperator> for opendal_operator_ptr {
-    fn from(value: &od::BlockingOperator) -> Self {
+impl From<*const od::BlockingOperator> for opendal_operator_ptr {
+    fn from(value: *const od::BlockingOperator) -> Self {
         Self { ptr: value }
     }
 }
 
 #[allow(clippy::from_over_into)]
-impl From<&mut od::BlockingOperator> for opendal_operator_ptr {
-    fn from(value: &mut od::BlockingOperator) -> Self {
+impl From<*mut od::BlockingOperator> for opendal_operator_ptr {
+    fn from(value: *mut od::BlockingOperator) -> Self {
         Self { ptr: value }
     }
 }
@@ -256,10 +256,10 @@ impl opendal_operator_options {
     pub extern "C" fn opendal_operator_options_new() -> *mut Self {
         let map: HashMap<String, String> = HashMap::default();
         let options = Self {
-            inner: Box::leak(Box::new(map)),
+            inner: Box::into_raw(Box::new(map)),
         };
 
-        Box::leak(Box::new(options))
+        Box::into_raw(Box::new(options))
     }
 
     /// \brief Set a Key-Value pair inside opendal_operator_options
@@ -322,7 +322,7 @@ pub struct opendal_blocking_lister {
 impl opendal_blocking_lister {
     pub(crate) fn new(lister: od::BlockingLister) -> Self {
         Self {
-            inner: Box::leak(Box::new(lister)),
+            inner: Box::into_raw(Box::new(lister)),
         }
     }
 
@@ -353,7 +353,7 @@ pub struct opendal_list_entry {
 impl opendal_list_entry {
     pub(crate) fn new(entry: od::Entry) -> Self {
         Self {
-            inner: Box::leak(Box::new(entry)),
+            inner: Box::into_raw(Box::new(entry)),
         }
     }
 

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -313,3 +313,48 @@ impl opendal_operator_options {
         let _ = unsafe { Box::from_raw(options as *mut opendal_operator_options) };
     }
 }
+
+#[repr(C)]
+pub struct opendal_blocking_lister {
+    inner: *mut od::BlockingLister,
+}
+
+impl opendal_blocking_lister {
+    pub(crate) fn from_inner(lister: od::BlockingLister) -> *const Self {
+        Box::leak(Box::new(lister))
+    }
+
+    /// nullable
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_lister_next(&self) -> *const opendal_list_entry {
+        let e = (*self.inner).next().unwrap_or_else(|| {
+            return std::ptr::null();
+        });
+
+        match e {
+            Ok(e) => opendal_list_entry::from_inner(e),
+            Err(e) => std::ptr::null(),
+        }
+    }
+}
+
+#[repr(C)]
+pub struct opendal_list_entry {
+    inner: *const od::Entry,
+}
+
+impl opendal_list_entry {
+    pub(crate) fn from_inner(entry: od::Entry) -> *const Self {
+        Box::leak(Box::new(entry))
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_list_entry_path(&self) -> *const c_char {
+        unimplemented!()
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_list_entry_name(&self) -> *const c_char {
+        unimplemented!()
+    }
+}

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -341,7 +341,9 @@ impl opendal_blocking_lister {
 
     #[no_mangle]
     pub unsafe extern "C" fn opendal_lister_free(p: *const opendal_blocking_lister) {
-        unsafe { let _ = Box::from_raw(p as *mut opendal_blocking_lister); }
+        unsafe {
+            let _ = Box::from_raw(p as *mut opendal_blocking_lister);
+        }
     }
 }
 
@@ -368,7 +370,9 @@ impl opendal_list_entry {
     }
 
     #[no_mangle]
-    pub unsafe extern "C" fn opendal_list_entry_free(p: *const opendal_list_entry ) {
-        unsafe { let _ = Box::from_raw(p as *mut opendal_list_entry); }
+    pub unsafe extern "C" fn opendal_list_entry_free(p: *const opendal_list_entry) {
+        unsafe {
+            let _ = Box::from_raw(p as *mut opendal_list_entry);
+        }
     }
 }

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -320,15 +320,9 @@ pub struct opendal_blocking_lister {
 }
 
 impl opendal_blocking_lister {
-    pub(crate) fn from_lister(lister: od::BlockingLister) -> Self {
+    pub(crate) fn new(lister: od::BlockingLister) -> Self {
         Self {
             inner: Box::leak(Box::new(lister)),
-        }
-    }
-
-    pub(crate) fn null() -> Self {
-        Self {
-            inner: std::ptr::null_mut(),
         }
     }
 

--- a/bindings/c/tests/bdd.cpp
+++ b/bindings/c/tests/bdd.cpp
@@ -25,7 +25,7 @@ extern "C" {
 
 class OpendalBddTest : public ::testing::Test {
 protected:
-    const opendal_operator_ptr *p;
+    const opendal_operator_ptr* p;
 
     std::string scheme;
     std::string path;
@@ -37,7 +37,7 @@ protected:
         this->path = std::string("test");
         this->content = std::string("Hello, World!");
 
-        opendal_operator_options *options = opendal_operator_options_new();
+        opendal_operator_options* options = opendal_operator_options_new();
         opendal_operator_options_set(options, "root", "/myroot");
 
         // Given A new OpenDAL Blocking Operator
@@ -69,7 +69,7 @@ TEST_F(OpendalBddTest, FeatureTest)
     // The blocking file "test" entry mode must be file
     opendal_result_stat s = opendal_operator_stat(this->p, this->path.c_str());
     EXPECT_EQ(s.code, OPENDAL_OK);
-    opendal_metadata *meta = s.meta;
+    opendal_metadata* meta = s.meta;
     EXPECT_TRUE(opendal_metadata_is_file(meta));
 
     // The blocking file "test" content length must be 13

--- a/bindings/c/tests/common.hpp
+++ b/bindings/c/tests/common.hpp
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <vector>
+#include <random>
+
+std::vector<unsigned char> generateRandomBytes(std::size_t size) {
+  // Create a random device to generate random numbers
+  std::random_device rd;
+
+  // Create a random engine and seed it with the random device
+  std::mt19937_64 gen(rd());
+
+  // Create a distribution to produce random bytes
+  std::uniform_int_distribution<unsigned char> dist(0, 255);
+
+  // Create a vector to hold the random bytes
+  std::vector<unsigned char> randomBytes(size);
+
+  // Generate random bytes and store them in the vector
+  for (std::size_t i = 0; i < size; ++i) {
+    randomBytes[i] = dist(gen);
+  }
+
+  return randomBytes;
+}

--- a/bindings/c/tests/list.cpp
+++ b/bindings/c/tests/list.cpp
@@ -27,83 +27,90 @@ extern "C" {
 
 class OpendalListTest : public ::testing::Test {
 protected:
-  const opendal_operator_ptr *p;
+    const opendal_operator_ptr* p;
 
-  // set up a brand new operator
-  void SetUp() override {
-    opendal_operator_options *options = opendal_operator_options_new();
-    opendal_operator_options_set(options, "root", "/myroot");
+    // set up a brand new operator
+    void SetUp() override
+    {
+        opendal_operator_options* options = opendal_operator_options_new();
+        opendal_operator_options_set(options, "root", "/myroot");
 
-    this->p = opendal_operator_new("memory", options);
-    EXPECT_TRUE(this->p->ptr);
+        this->p = opendal_operator_new("memory", options);
+        EXPECT_TRUE(this->p->ptr);
 
-    opendal_operator_options_free(options);
-  }
+        opendal_operator_options_free(options);
+    }
 
-  void TearDown() override { opendal_operator_free(this->p); }
+    void TearDown() override { opendal_operator_free(this->p); }
 };
 
 // Basic usecase of list
-TEST_F(OpendalListTest, ListDirTest) {
-  std::string dname = "some_random_dir_name_152312dbfas";
-  std::string fname = "some_random_file_name_2138912rbf";
+TEST_F(OpendalListTest, ListDirTest)
+{
+    std::string dname = "some_random_dir_name_152312dbfas";
+    std::string fname = "some_random_file_name_2138912rbf";
 
-  // 4 MiB of random bytes
-  uintptr_t nbytes = 4 * 1024 * 1024;
-  auto rand = generateRandomBytes(4 * 1024 * 1024);
-  auto random_bytes = reinterpret_cast<uint8_t *>(rand.data());
+    // 4 MiB of random bytes
+    uintptr_t nbytes = 4 * 1024 * 1024;
+    auto rand = generateRandomBytes(4 * 1024 * 1024);
+    auto random_bytes = reinterpret_cast<uint8_t*>(rand.data());
 
-  std::string path = dname + "/" + fname;
-  opendal_bytes data = {
-      .data = random_bytes,
-      .len = nbytes,
-  };
+    std::string path = dname + "/" + fname;
+    opendal_bytes data = {
+        .data = random_bytes,
+        .len = nbytes,
+    };
 
-  EXPECT_EQ(opendal_operator_blocking_write(this->p, path.c_str(), data),
-            OPENDAL_OK);
+    // write must succeed
+    EXPECT_EQ(opendal_operator_blocking_write(this->p, path.c_str(), data),
+        OPENDAL_OK);
 
-  opendal_result_list l =
-      opendal_operator_blocking_list(this->p, (dname + "/").c_str());
-  EXPECT_EQ(l.code, OPENDAL_OK);
+    // list must succeed since the write succeeded
+    opendal_result_list l = opendal_operator_blocking_list(this->p, (dname + "/").c_str());
+    EXPECT_EQ(l.code, OPENDAL_OK);
 
-  opendal_blocking_lister *lister = l.lister;
+    opendal_blocking_lister* lister = l.lister;
 
-  // start checking the lister's result
-  bool found = false;
+    // start checking the lister's result
+    bool found = false;
 
-  opendal_list_entry entry = opendal_lister_next(lister);
-  while (entry.inner) {
-    const char *de_path = opendal_list_entry_path(&entry);
+    opendal_list_entry entry = opendal_lister_next(lister);
+    while (entry.inner) {
+        const char* de_path = opendal_list_entry_path(&entry);
 
-    opendal_result_stat s = opendal_operator_stat(this->p, de_path);
-    EXPECT_EQ(s.code, OPENDAL_OK);
+        // stat must succeed
+        opendal_result_stat s = opendal_operator_stat(this->p, de_path);
+        EXPECT_EQ(s.code, OPENDAL_OK);
 
-    opendal_metadata *meta = s.meta;
+        opendal_metadata* meta = s.meta;
 
-    if (!strcmp(de_path, path.c_str())) {
-      found = true;
+        if (!strcmp(de_path, path.c_str())) {
+            found = true;
 
-      EXPECT_TRUE(opendal_metadata_is_file(meta));
-      EXPECT_EQ(opendal_metadata_content_length(meta), nbytes);
+            // the path we found has to be a file, and the length must be coherent
+            EXPECT_TRUE(opendal_metadata_is_file(meta));
+            EXPECT_EQ(opendal_metadata_content_length(meta), nbytes);
+        }
+
+        entry = opendal_lister_next(lister);
     }
 
-    entry = opendal_lister_next(lister);
-  }
+    // we must have found the file we wrote
+    EXPECT_TRUE(found);
 
-  EXPECT_TRUE(found);
-
-  // delete
-  EXPECT_EQ(opendal_operator_blocking_delete(this->p, path.c_str()),
-            OPENDAL_OK);
+    // delete
+    EXPECT_EQ(opendal_operator_blocking_delete(this->p, path.c_str()),
+        OPENDAL_OK);
 }
 
-// Try list an empty directory
-TEST_F(OpendalListTest, ListEmptyDirTest) {}
+// todo: Try list an empty directory
+TEST_F(OpendalListTest, ListEmptyDirTest) { }
 
-// Try list a directory that does not exist
-TEST_F(OpendalListTest, ListNotExistDirTest) {}
+// todo: Try list a directory that does not exist
+TEST_F(OpendalListTest, ListNotExistDirTest) { }
 
-int main(int argc, char **argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/bindings/c/tests/list.cpp
+++ b/bindings/c/tests/list.cpp
@@ -27,20 +27,20 @@ extern "C" {
 
 class OpendalListTest : public ::testing::Test {
 protected:
-  opendal_operator_ptr p;
+  const opendal_operator_ptr *p;
 
   // set up a brand new operator
   void SetUp() override {
-    opendal_operator_options options = opendal_operator_options_new();
-    opendal_operator_options_set(&options, "root", "/myroot");
+    opendal_operator_options *options = opendal_operator_options_new();
+    opendal_operator_options_set(options, "root", "/myroot");
 
-    this->p = opendal_operator_new("memory", &options);
-    EXPECT_TRUE(this->p.ptr);
+    this->p = opendal_operator_new("memory", options);
+    EXPECT_TRUE(this->p->ptr);
 
-    opendal_operator_options_free(&options);
+    opendal_operator_options_free(options);
   }
 
-  void TearDown() override { opendal_operator_free(&this->p); }
+  void TearDown() override { opendal_operator_free(this->p); }
 };
 
 // Basic usecase of list
@@ -63,7 +63,7 @@ TEST_F(OpendalListTest, ListDirTest) {
             OPENDAL_OK);
 
   opendal_result_list l =
-      opendal_operator_blocking_list(this->p, (dname + "/").c_str());
+      opendal_operator_blocking_list(*this->p, (dname + "/").c_str());
   EXPECT_EQ(l.code, OPENDAL_OK);
 
   opendal_blocking_lister lister = l.lister;
@@ -78,13 +78,13 @@ TEST_F(OpendalListTest, ListDirTest) {
     opendal_result_stat s = opendal_operator_stat(this->p, de_path);
     EXPECT_EQ(s.code, OPENDAL_OK);
 
-    opendal_metadata meta = s.meta;
+    opendal_metadata *meta = s.meta;
 
     if (!strcmp(de_path, path.c_str())) {
       found = true;
 
-      EXPECT_TRUE(opendal_metadata_is_file(&meta));
-      EXPECT_EQ(opendal_metadata_content_length(&meta), nbytes);
+      EXPECT_TRUE(opendal_metadata_is_file(meta));
+      EXPECT_EQ(opendal_metadata_content_length(meta), nbytes);
     }
 
     entry = opendal_lister_next(&lister);

--- a/bindings/c/tests/list.cpp
+++ b/bindings/c/tests/list.cpp
@@ -66,12 +66,12 @@ TEST_F(OpendalListTest, ListDirTest) {
       opendal_operator_blocking_list(*this->p, (dname + "/").c_str());
   EXPECT_EQ(l.code, OPENDAL_OK);
 
-  opendal_blocking_lister lister = l.lister;
+  opendal_blocking_lister *lister = l.lister;
 
   // start checking the lister's result
   bool found = false;
 
-  opendal_list_entry entry = opendal_lister_next(&lister);
+  opendal_list_entry entry = opendal_lister_next(lister);
   while (entry.inner) {
     const char *de_path = opendal_list_entry_path(&entry);
 
@@ -87,7 +87,7 @@ TEST_F(OpendalListTest, ListDirTest) {
       EXPECT_EQ(opendal_metadata_content_length(meta), nbytes);
     }
 
-    entry = opendal_lister_next(&lister);
+    entry = opendal_lister_next(lister);
   }
 
   EXPECT_TRUE(found);

--- a/bindings/c/tests/list.cpp
+++ b/bindings/c/tests/list.cpp
@@ -63,7 +63,7 @@ TEST_F(OpendalListTest, ListDirTest) {
             OPENDAL_OK);
 
   opendal_result_list l =
-      opendal_operator_blocking_list(*this->p, (dname + "/").c_str());
+      opendal_operator_blocking_list(this->p, (dname + "/").c_str());
   EXPECT_EQ(l.code, OPENDAL_OK);
 
   opendal_blocking_lister *lister = l.lister;

--- a/bindings/c/tests/list.cpp
+++ b/bindings/c/tests/list.cpp
@@ -74,9 +74,9 @@ TEST_F(OpendalListTest, ListDirTest)
     // start checking the lister's result
     bool found = false;
 
-    opendal_list_entry entry = opendal_lister_next(lister);
-    while (entry.inner) {
-        const char* de_path = opendal_list_entry_path(&entry);
+    opendal_list_entry *entry = opendal_lister_next(lister);
+    while (entry) {
+        const char* de_path = opendal_list_entry_path(entry);
 
         // stat must succeed
         opendal_result_stat s = opendal_operator_stat(this->p, de_path);

--- a/bindings/c/tests/list.cpp
+++ b/bindings/c/tests/list.cpp
@@ -92,6 +92,7 @@ TEST_F(OpendalListTest, ListDirTest)
             EXPECT_EQ(opendal_metadata_content_length(meta), nbytes);
         }
 
+        opendal_list_entry_free(entry);
         entry = opendal_lister_next(lister);
     }
 
@@ -101,6 +102,8 @@ TEST_F(OpendalListTest, ListDirTest)
     // delete
     EXPECT_EQ(opendal_operator_blocking_delete(this->p, path.c_str()),
         OPENDAL_OK);
+    
+    opendal_lister_free(lister);
 }
 
 // todo: Try list an empty directory

--- a/bindings/c/tests/list.cpp
+++ b/bindings/c/tests/list.cpp
@@ -29,11 +29,10 @@ protected:
 
   // set up a brand new operator
   void SetUp() override {
-    this->scheme = std::string("memory");
     opendal_operator_options options = opendal_operator_options_new();
     opendal_operator_options_set(&options, "root", "/myroot");
 
-    this->p = opendal_operator_new(scheme.c_str(), &options);
+    this->p = opendal_operator_new("memory", &options);
     EXPECT_TRUE(this->p.ptr);
 
     opendal_operator_options_free(&options);
@@ -43,13 +42,13 @@ protected:
 };
 
 // Basic usecase of list
-TEST_F(OpendalBddTest, ListDirTest) {}
+TEST_F(OpendalListTest, ListDirTest) {}
 
 // Try list an empty directory
-TEST_F(OpendalBddTest, ListEmptyDirTest) {}
+TEST_F(OpendalListTest, ListEmptyDirTest) {}
 
 // Try list a directory that does not exist
-TEST_F(OpendalBddTest, ListNotExistDirTest) {}
+TEST_F(OpendalListTest, ListNotExistDirTest) {}
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/bindings/c/tests/list.cpp
+++ b/bindings/c/tests/list.cpp
@@ -74,7 +74,7 @@ TEST_F(OpendalListTest, ListDirTest)
     // start checking the lister's result
     bool found = false;
 
-    opendal_list_entry *entry = opendal_lister_next(lister);
+    opendal_list_entry* entry = opendal_lister_next(lister);
     while (entry) {
         const char* de_path = opendal_list_entry_path(entry);
 
@@ -102,7 +102,7 @@ TEST_F(OpendalListTest, ListDirTest)
     // delete
     EXPECT_EQ(opendal_operator_blocking_delete(this->p, path.c_str()),
         OPENDAL_OK);
-    
+
     opendal_lister_free(lister);
 }
 

--- a/bindings/c/tests/test_list.cpp
+++ b/bindings/c/tests/test_list.cpp
@@ -23,17 +23,33 @@ extern "C" {
 #include "opendal.h"
 }
 
-class OpendalBddTest : public ::testing::Test {
+class OpendalListTest : public ::testing::Test {
 protected:
   opendal_operator_ptr p;
 
-  void SetUp() override {}
+  // set up a brand new operator
+  void SetUp() override {
+    this->scheme = std::string("memory");
+    opendal_operator_options options = opendal_operator_options_new();
+    opendal_operator_options_set(&options, "root", "/myroot");
 
-  void TearDown() override {}
+    this->p = opendal_operator_new(scheme.c_str(), &options);
+    EXPECT_TRUE(this->p.ptr);
+
+    opendal_operator_options_free(&options);
+  }
+
+  void TearDown() override { opendal_operator_free(&this->p); }
 };
 
-// Scenario: OpenDAL Blocking Operations
-TEST_F(OpendalBddTest, FeatureTest) {}
+// Basic usecase of list
+TEST_F(OpendalBddTest, ListDirTest) {}
+
+// Try list an empty directory
+TEST_F(OpendalBddTest, ListEmptyDirTest) {}
+
+// Try list a directory that does not exist
+TEST_F(OpendalBddTest, ListNotExistDirTest) {}
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/bindings/c/tests/test_list.cpp
+++ b/bindings/c/tests/test_list.cpp
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "opendal.h"
+}
+
+class OpendalBddTest : public ::testing::Test {
+protected:
+  opendal_operator_ptr p;
+
+  void SetUp() override {}
+
+  void TearDown() override {}
+};
+
+// Scenario: OpenDAL Blocking Operations
+TEST_F(OpendalBddTest, FeatureTest) {}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
~~The PR will first be marked as WIP~~

This PR implements the `list()` method of the opendal in C binding.
note: we don't need to review the `opendal.h`, it is auto generated by the rust code.

- The functionality of `list()`
- A separate unit test for `list()`
- Fix some of the frees, previously it did not free the inner pointer, which is heap allocated.

todo:
- Maybe we should use macro to unify the implementation the `freeing` of the types, since the patterns are almost the same.
- Upon development, I found that multiple types and operations living in one single file is becoming more and more messy. Maybe a refactoring is needed as well.