### PR TITLE
build(bindings/ruby): fix compile rb-sys on Apple M1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "c6720a8b7b2d39dd533285ed438d458f65b31b5c257e6ac7bb3d7e82844dd722"
 dependencies = [
  "bitflags 1.3.2",
  "cexpr",
@@ -452,6 +452,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3628,20 +3629,20 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.72"
+version = "0.9.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e36bdb8be5f395264fb4345a5f6c13dac307ed3be3bccf6305b57835981c605"
+checksum = "91447d8cbb45afb5c915bad4dd44bd4b4e9be37648122409ceca75302cb81683"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.72"
+version = "0.9.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b56f8993adac385ed6208f0dc62f99181eb0676dea50bac7bc3d36a86bb9429b"
+checksum = "20673c1cfbd57b2db6c066b796352f07d241c45b210fd15b269dec54fa240380"
 dependencies = [
- "bindgen 0.60.1",
+ "bindgen 0.62.0",
  "lazy_static",
  "proc-macro2",
  "quote",

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -35,7 +35,7 @@ name = "opendal_ruby"
 [dependencies]
 magnus = { version = "0.5", features = ["bytes-crate"] }
 opendal.workspace = true
-rb-sys = { version = "0.9.72", default-features = false }
+rb-sys = { version = "0.9.77", default-features = false }
 
 [build-dependencies]
 rb-sys-env = "0.1.2"


### PR DESCRIPTION
I don't dive into details too much. But https://github.com/oxidize-rb/rb-sys/issues/216#issuecomment-1561941332 suggests a newer version may help and it does.

FWIW, without this patch compilation on M1 failed with:

<details>
<summary>console output</summary>
error: failed to run custom build command for `rb-sys v0.9.72`

Caused by:
  process didn't exit successfully: `/Users/tison/Brittani/opendal/target/debug/build/rb-sys-817a78bd99051881/build-script-main` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=RUBY
  cargo:rerun-if-env-changed=RBCONFIG_ruby_version
  cargo:rerun-if-env-changed=RBCONFIG_platform
  cargo:rerun-if-env-changed=RBCONFIG_arch
  cargo:rerun-if-env-changed=RUBY_ROOT
  cargo:rerun-if-env-changed=RUBY_VERSION
  cargo:rerun-if-env-changed=RUBY
  cargo:rerun-if-changed=build/features.rs
  cargo:rerun-if-changed=build/version.rs
  cargo:rerun-if-changed=build/ruby_macros.rs
  cargo:rerun-if-changed=build/main.rs
  cargo:rerun-if-env-changed=RUBY_STATIC
  cargo:rerun-if-env-changed=RBCONFIG_ENABLE_SHARED
  cargo:rerun-if-env-changed=RBCONFIG_rubyhdrdir
  cargo:rerun-if-env-changed=RBCONFIG_rubyarchhdrdir
  cargo:rerun-if-env-changed=RBCONFIG_CPPFLAGS
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/ruby.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/universal-darwin22/ruby/config.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/defines.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/universal-darwin22/ruby/config.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/stdio.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_stdio.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_symbol_aliasing.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_posix_availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/AvailabilityVersions.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/AvailabilityInternal.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/arm/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_va_list.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/arm/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/arm/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_int8_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_int16_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_int32_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_int64_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_u_int8_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_u_int16_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_u_int32_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_u_int64_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_intptr_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_uintptr_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_size_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_null.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/stdio.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_ctermid.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_off_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_ssize_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/secure/_stdio.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/secure/_common.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/appleapiopts.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/endian.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/arm/endian.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_endian.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/libkern/_OSByteOrder.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/libkern/arm/OSByteOrder.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/stdint.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/stdint.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_int8_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_int16_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_int32_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_int64_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types/_uint8_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types/_uint16_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types/_uint32_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types/_uint64_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_intptr_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_uintptr_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types/_intmax_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types/_uintmax_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/arm/arch.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_u_char.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_u_short.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_u_int.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_caddr_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_dev_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_blkcnt_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_blksize_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_gid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_in_addr_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_in_port_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_ino_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_ino64_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_key_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_mode_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_nlink_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_id_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_pid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_off_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_uid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_clock_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_size_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_ssize_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_time_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_useconds_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_suseconds_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_rsize_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_errno_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_def.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_setsize.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_set.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_clr.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_zero.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_isset.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_copy.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_attr_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_cond_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_condattr_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_mutex_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_mutexattr_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_once_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_rwlock_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_rwlockattr_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_key_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fsblkcnt_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fsfilcnt_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/stat.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_timespec.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_blkcnt_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_blksize_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_dev_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_ino_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_ino64_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_mode_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_nlink_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_uid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_gid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_off_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_time_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_s_ifmt.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_filesec_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/stdlib.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/wait.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_pid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_id_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/signal.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/appleapiopts.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/signal.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/arm/signal.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/_mcontext.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/arm/_mcontext.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/appleapiopts.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/mach/machine/_structs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/mach/arm/_structs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_pthread/_pthread_attr_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_sigaltstack.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_ucontext.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/_mcontext.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_sigaltstack.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_pid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_sigset_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_size_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_uid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/resource.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/appleapiopts.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/stdint.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_timeval.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_id_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/endian.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/alloca.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_size_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_size_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_ct_rune_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_rune_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_wchar_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_null.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/malloc/_malloc.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_size_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_dev_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_mode_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types/_uint32_t.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/stddef.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/__stddef_max_align_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/string.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_size_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_null.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_rsize_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_errno_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_ssize_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/strings.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_size_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/string.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/secure/_strings.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/secure/_common.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/secure/_string.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/secure/_common.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/strings.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/inttypes.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/inttypes.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_wchar_t.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/stdint.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/stdint.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/stdalign.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/unistd.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/unistd.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_posix_vdisable.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_seek_set.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_size_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_ssize_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types/_uint64_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_types/_uint32_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_size_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_ssize_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_uid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_gid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_gid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_intptr_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_off_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_pid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_size_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_ssize_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_uid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_useconds_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_null.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/_ctermid.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/select.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/appleapiopts.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_def.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_timespec.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_timeval.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_time_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_suseconds_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_sigset_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_setsize.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_set.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_clr.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_isset.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_zero.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_copy.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_select.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_fd_def.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_timeval.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_dev_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_mode_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_uuid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/gethostuuid.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_timespec.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_uuid_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/select.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/missing.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/universal-darwin22/ruby/config.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/stddef.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/math.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/Availability.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/stdarg.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/limits.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/limits.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/machine/limits.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/arm/limits.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/arm/_limits.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/syslimits.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/intern.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/defines.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/stdarg.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/st.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/defines.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/subst.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/backward.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/defines.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/encoding.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/stdarg.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/ruby.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/oniguruma.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/onigmo.h
  cargo:rerun-if-changed=/opt/homebrew/Cellar/llvm/16.0.5/lib/clang/16/include/stddef.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/intern.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/io.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/stdio.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/encoding.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/universal-darwin22/ruby/config.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/errno.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/errno.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/_types/_errno_t.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/poll.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/poll.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/missing.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/oniguruma.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/re.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/types.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/stdio.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/regex.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/oniguruma.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/regex.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/ruby.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/st.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/thread.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/intern.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/util.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/defines.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/version.h
  cargo:rerun-if-changed=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/vm.h

  --- stderr
  Using bindgen with clang args: ["-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0", "-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/universal-darwin22", "-fms-extensions", "-g", "-D_XOPEN_SOURCE", "-D_DARWIN_C_SOURCE", "-D_DARWIN_UNLIMITED_SELECT", "-D_REENTRANT"]
  thread 'main' panicked at '"RObject_union_(unnamed_at_/Library/Developer/CommandLineTools/SDKs/MacOSX_sdk/System/Library/Frameworks/Ruby_framework/Versions/2_6/usr/include/ruby-2_6_0/ruby/ruby_h_917_5)" is not a valid Ident', /Users/tison/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.58/src/fallback.rs:811:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
</details>