### PR TITLE
docs: fix a typo on the landing page

### DIFF
--- a/website/src/components/HomepageFeatures/_feature_languages.mdx
+++ b/website/src/components/HomepageFeatures/_feature_languages.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 ```rust
 use opendal::Operator;
 
-let op = Operator::via_map(Scheme::Fs, HashMap::new()?;
+let op = Operator::via_map(Scheme::Fs, HashMap::new())?;
 op.read("path/to/file").await?;
 ```
 


### PR DESCRIPTION
This PR just fixes a small typo on the landing page.