### PR TITLE
feat(bindings/haskell): support `is_exist` `create_dir` `copy` `rename` `delete`

### DIFF
--- a/bindings/haskell/CONTRIBUTING.md
+++ b/bindings/haskell/CONTRIBUTING.md
@@ -80,14 +80,14 @@ Test suite logged to:
 If you don't want to specify `LIBRARY_PATH` and `LD_LIBRARY_PATH` every time, you can use [`direnv`](https://direnv.net/) to set the environment variable automatically. Add the following to your `.envrc`:
 
 ```shell
-export LIBRARY_PATH=../../target/debug:LIBRARY_PATH
-export LD_LIBRARY_PATH=../../target/debug:LD_LIBRARY_PATH
+export LIBRARY_PATH=../../target/debug:$LIBRARY_PATH
+export LD_LIBRARY_PATH=../../target/debug:$LD_LIBRARY_PATH
 ```
 
 If you are using [`Haskell`](https://marketplace.visualstudio.com/items?itemName=haskell.haskell) in VSCode, you may need to add the following configuration to your `settings.json`:
 
 ```json
 "haskell.serverEnvironment": {
-    "LIBRARY_PATH": "../../target/debug:LIBRARY_PATH"
+    "LIBRARY_PATH": "../../target/debug:$LIBRARY_PATH"
 },
 ```

--- a/bindings/haskell/haskell-src/OpenDAL.hs
+++ b/bindings/haskell/haskell-src/OpenDAL.hs
@@ -17,9 +17,14 @@
 
 module OpenDAL (
   Operator,
-  createOp,
+  newOp,
   readOp,
   writeOp,
+  isExistOp,
+  createDirOp,
+  copyOp,
+  renameOp,
+  deleteOp,
 ) where
 
 import Data.ByteString (ByteString)
@@ -28,16 +33,48 @@ import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Foreign
 import Foreign.C.String
+import Foreign.C.Types (CChar)
 import OpenDAL.FFI
 
-newtype Operator = Operator (Ptr RawOperator)
+newtype Operator = Operator (ForeignPtr RawOperator)
+
+data ErrorCode
+  = FFIError
+  | Unexpected
+  | Unsupported
+  | ConfigInvalid
+  | NotFound
+  | PermissionDenied
+  | IsADirectory
+  | NotADirectory
+  | AlreadyExists
+  | RateLimited
+  | IsSameFile
+  deriving (Eq, Show)
+
+data OpenDALError = OpenDALError {errorCode :: ErrorCode, message :: String}
+  deriving (Eq, Show)
 
 byteSliceToByteString :: ByteSlice -> IO ByteString
 byteSliceToByteString (ByteSlice bsDataPtr len) = BS.packCStringLen (bsDataPtr, fromIntegral len)
 
+parseErrorCode :: Int -> ErrorCode
+parseErrorCode 1 = FFIError
+parseErrorCode 2 = Unexpected
+parseErrorCode 3 = Unsupported
+parseErrorCode 4 = ConfigInvalid
+parseErrorCode 5 = NotFound
+parseErrorCode 6 = PermissionDenied
+parseErrorCode 7 = IsADirectory
+parseErrorCode 8 = NotADirectory
+parseErrorCode 9 = AlreadyExists
+parseErrorCode 10 = RateLimited
+parseErrorCode 11 = IsSameFile
+parseErrorCode _ = FFIError
+
 -- | Create a new Operator.
-createOp :: String -> HashMap String String -> IO (Either String Operator)
-createOp scheme hashMap = do
+newOp :: String -> HashMap String String -> IO (Either OpenDALError Operator)
+newOp scheme hashMap = do
   let keysAndValues = HashMap.toList hashMap
   withCString scheme $ \cScheme ->
     withMany withCString (map fst keysAndValues) $ \cKeys ->
@@ -49,39 +86,113 @@ createOp scheme hashMap = do
               pokeArray cValuesPtr cValues
               c_via_map_ffi cScheme cKeysPtr cValuesPtr (fromIntegral $ length keysAndValues) ffiResultPtr
               ffiResult <- peek ffiResultPtr
-              if success ffiResult
+              if ffiCode ffiResult == 0
                 then do
-                  let op = Operator (castPtr $ dataPtr ffiResult)
+                  op <- Operator <$> (newForeignPtr c_free_operator $ castPtr $ dataPtr ffiResult)
                   return $ Right op
                 else do
+                  let code = parseErrorCode $ fromIntegral $ ffiCode ffiResult
                   errMsg <- peekCString (errorMessage ffiResult)
-                  return $ Left errMsg
+                  return $ Left $ OpenDALError code errMsg
 
-readOp :: Operator -> String -> IO (Either String ByteString)
-readOp (Operator op) path = (flip ($)) op $ \opptr ->
+readOp :: Operator -> String -> IO (Either OpenDALError ByteString)
+readOp (Operator op) path = withForeignPtr op $ \opptr ->
   withCString path $ \cPath ->
     alloca $ \ffiResultPtr -> do
       c_blocking_read opptr cPath ffiResultPtr
       ffiResult <- peek ffiResultPtr
-      if success ffiResult
+      if ffiCode ffiResult == 0
         then do
           byteslice <- peek (castPtr $ dataPtr ffiResult)
           byte <- byteSliceToByteString byteslice
           c_free_byteslice (bsData byteslice) (bsLen byteslice)
           return $ Right byte
         else do
+          let code = parseErrorCode $ fromIntegral $ ffiCode ffiResult
           errMsg <- peekCString (errorMessage ffiResult)
-          return $ Left errMsg
+          return $ Left $ OpenDALError code errMsg
 
-writeOp :: Operator -> String -> ByteString -> IO (Either String ())
-writeOp (Operator op) path byte = (flip ($)) op $ \opptr ->
+writeOp :: Operator -> String -> ByteString -> IO (Either OpenDALError ())
+writeOp (Operator op) path byte = withForeignPtr op $ \opptr ->
   withCString path $ \cPath ->
     BS.useAsCStringLen byte $ \(cByte, len) ->
       alloca $ \ffiResultPtr -> do
         c_blocking_write opptr cPath cByte (fromIntegral len) ffiResultPtr
         ffiResult <- peek ffiResultPtr
-        if success ffiResult
+        if ffiCode ffiResult == 0
           then return $ Right ()
           else do
+            let code = parseErrorCode $ fromIntegral $ ffiCode ffiResult
             errMsg <- peekCString (errorMessage ffiResult)
-            return $ Left errMsg
+            return $ Left $ OpenDALError code errMsg
+
+isExistOp :: Operator -> String -> IO (Either OpenDALError Bool)
+isExistOp (Operator op) path = withForeignPtr op $ \opptr ->
+  withCString path $ \cPath ->
+    alloca $ \ffiResultPtr -> do
+      c_blocking_is_exist opptr cPath ffiResultPtr
+      ffiResult <- peek ffiResultPtr
+      if ffiCode ffiResult == 0
+        then do
+          -- For Bool type, the memory layout is different between C and Haskell.
+          val <- peek ((castPtr $ dataPtr ffiResult) :: Ptr CChar)
+          let isExist = val /= 0
+          return $ Right isExist
+        else do
+          let code = parseErrorCode $ fromIntegral $ ffiCode ffiResult
+          errMsg <- peekCString (errorMessage ffiResult)
+          return $ Left $ OpenDALError code errMsg
+
+createDirOp :: Operator -> String -> IO (Either OpenDALError ())
+createDirOp (Operator op) path = withForeignPtr op $ \opptr ->
+  withCString path $ \cPath ->
+    alloca $ \ffiResultPtr -> do
+      c_blocking_create_dir opptr cPath ffiResultPtr
+      ffiResult <- peek ffiResultPtr
+      if ffiCode ffiResult == 0
+        then return $ Right ()
+        else do
+          let code = parseErrorCode $ fromIntegral $ ffiCode ffiResult
+          errMsg <- peekCString (errorMessage ffiResult)
+          return $ Left $ OpenDALError code errMsg
+
+copyOp :: Operator -> String -> String -> IO (Either OpenDALError ())
+copyOp (Operator op) srcPath dstPath = withForeignPtr op $ \opptr ->
+  withCString srcPath $ \cSrcPath ->
+    withCString dstPath $ \cDstPath ->
+      alloca $ \ffiResultPtr -> do
+        c_blocking_copy opptr cSrcPath cDstPath ffiResultPtr
+        ffiResult <- peek ffiResultPtr
+        if ffiCode ffiResult == 0
+          then return $ Right ()
+          else do
+            let code = parseErrorCode $ fromIntegral $ ffiCode ffiResult
+            errMsg <- peekCString (errorMessage ffiResult)
+            return $ Left $ OpenDALError code errMsg
+
+renameOp :: Operator -> String -> String -> IO (Either OpenDALError ())
+renameOp (Operator op) srcPath dstPath = withForeignPtr op $ \opptr ->
+  withCString srcPath $ \cSrcPath ->
+    withCString dstPath $ \cDstPath ->
+      alloca $ \ffiResultPtr -> do
+        c_blocking_rename opptr cSrcPath cDstPath ffiResultPtr
+        ffiResult <- peek ffiResultPtr
+        if ffiCode ffiResult == 0
+          then return $ Right ()
+          else do
+            let code = parseErrorCode $ fromIntegral $ ffiCode ffiResult
+            errMsg <- peekCString (errorMessage ffiResult)
+            return $ Left $ OpenDALError code errMsg
+
+deleteOp :: Operator -> String -> IO (Either OpenDALError ())
+deleteOp (Operator op) path = withForeignPtr op $ \opptr ->
+  withCString path $ \cPath ->
+    alloca $ \ffiResultPtr -> do
+      c_blocking_delete opptr cPath ffiResultPtr
+      ffiResult <- peek ffiResultPtr
+      if ffiCode ffiResult == 0
+        then return $ Right ()
+        else do
+          let code = parseErrorCode $ fromIntegral $ ffiCode ffiResult
+          errMsg <- peekCString (errorMessage ffiResult)
+          return $ Left $ OpenDALError code errMsg

--- a/bindings/haskell/haskell-src/OpenDAL.hs
+++ b/bindings/haskell/haskell-src/OpenDAL.hs
@@ -17,6 +17,8 @@
 
 module OpenDAL (
   Operator,
+  OpenDALError,
+  ErrorCode (..),
   newOp,
   readOp,
   writeOp,

--- a/bindings/haskell/opendal-hs.cabal
+++ b/bindings/haskell/opendal-hs.cabal
@@ -40,7 +40,7 @@ library
     default-language: Haskell2010
     extra-libraries:  opendal_hs
     ghc-options:      -Wall
-    build-depends:    
+    build-depends:
         base >=4.10.0.0 && <5,
         unordered-containers >=0.2.0.0, 
         bytestring >=0.11.0.0

--- a/bindings/haskell/test/BasicTest.hs
+++ b/bindings/haskell/test/BasicTest.hs
@@ -27,26 +27,11 @@ basicTests :: TestTree
 basicTests =
   testGroup
     "Basic Tests"
-    [ testCase "test-memory" testMemory
-    , testCase "test-fs" testFs
+    [ testCase "testBasicOperation" testBasicOperation
     ]
 
-testMemory :: Assertion
-testMemory = do
-  Right op <- newOp "memory" $ HashMap.empty
-  writeOp op "key1" "value1" >>= (@?= Right ())
-  writeOp op "key2" "value2" >>= (@?= Right ())
-  readOp op "key1" >>= (@?= Right "value1")
-  readOp op "key2" >>= (@?= Right "value2")
-  isExistOp op "key1" >>= (@?= Right True)
-  isExistOp op "key2" >>= (@?= Right True)
-  createDirOp op "dir1/" >>= (@?= Right ())
-  isExistOp op "dir1/" >>= (@?= Right True)
-  deleteOp op "key1" >>= (@?= Right ())
-  isExistOp op "key1" >>= (@?= Right False)
-
-testFs :: Assertion
-testFs = do
+testBasicOperation :: Assertion
+testBasicOperation = do
   Right op <- newOp "fs" $ HashMap.fromList [("root", "/tmp/opendal-test")]
   writeOp op "key1" "value1" >>= (@?= Right ())
   writeOp op "key2" "value2" >>= (@?= Right ())


### PR DESCRIPTION
Update:
- support `is_exist` `create_dir` `copy` `rename` `delete`
- fix `ByteSlice` invalid ownership
- refactor `Operation` to `ForeignPtr` to enable haskell GC automatic free
- add `OpenDALError` to provide detailed error info
- add tests about `Fs`

Now we still leave `stat`, `list`, `scan` to complete.