### PR TITLE
docs: update readme.md to match the output

### DIFF
--- a/examples/rust/01-init-operator/README.md
+++ b/examples/rust/01-init-operator/README.md
@@ -99,6 +99,7 @@ fn init_operator_via_builder() -> Result<Operator> {
     builder.bucket("example");
     builder.access_key_id("access_key_id");
     builder.secret_access_key("secret_access_key");
+    builder.region("us-east-1");
 
     let op = Operator::new(builder)?.finish();
     Ok(op)
@@ -130,6 +131,7 @@ fn init_operator_via_map() -> Result<Operator> {
         "secret_access_key".to_string(),
         "secret_access_key".to_string(),
     );
+    map.insert("region".to_string(), "us-east-1".to_string());
 
     let op = Operator::via_map(Scheme::S3, map)?;
     Ok(op)

--- a/examples/rust/01-init-operator/README.md
+++ b/examples/rust/01-init-operator/README.md
@@ -96,7 +96,7 @@ Let's take look over `init_operator_via_builder` function first.
 ```rust
 fn init_operator_via_builder() -> Result<Operator> {
     let mut builder = S3::default();
-    builder.bucket("exampl");
+    builder.bucket("example");
     builder.access_key_id("access_key_id");
     builder.secret_access_key("secret_access_key");
 


### PR DESCRIPTION
the output in README.md is 
```
 :) cargo run
   Compiling init-operator v0.1.0 (/home/xuanwo/Code/apache/incubator-opendal/examples/rust/01-init-operator)
    Finished dev [unoptimized + debuginfo] target(s) in 0.38s
     Running `target/debug/init-operator`
operator from builder: Operator { accessor: S3Backend { core: S3Core { bucket: "example", endpoint: "https://s3.us-east-1.amazonaws.com/example", root: "/", .. } }, limit: 1000 }
operator from map: Operator { accessor: S3Backend { core: S3Core { bucket: "example", endpoint: "https://s3.us-east-1.amazonaws.com/example", root: "/", .. } }, limit: 1000 }
```

ref: [lets-go](https://github.com/apache/incubator-opendal/blob/main/examples/rust/01-init-operator/README.md#lets-go)