### PR TITLE
feat: Add golang binding for OpenDAL

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -1,0 +1,17 @@
+# OpenDAL Golang Binding
+
+Build C binding first.
+
+cd `bindings/c`
+
+```shell
+cargo build
+```
+
+and than cd `bindings/go`
+
+```shell
+CGO_ENABLED=0 LD_LIBRARY_PATH=../../target/debug go test -v
+```
+
+We can call it without CGO (only work under linux).

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,0 +1,7 @@
+module opendal.apache.org/go
+
+go 1.20
+
+require github.com/ebitengine/purego v0.4.0-alpha.4
+
+require golang.org/x/sys v0.7.0 // indirect

--- a/bindings/go/go.sum
+++ b/bindings/go/go.sum
@@ -1,0 +1,4 @@
+github.com/ebitengine/purego v0.4.0-alpha.4 h1:Y7yIV06Yo5M2BAdD7EVPhfp6LZ0tEcQo5770OhYUVes=
+github.com/ebitengine/purego v0.4.0-alpha.4/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/bindings/go/init.go
+++ b/bindings/go/init.go
@@ -1,0 +1,21 @@
+package opendal
+
+import (
+	"github.com/ebitengine/purego"
+)
+
+var OPENDAL_LIB uintptr
+
+var opendal_operator_options_new func() uintptr
+var opendal_operator_new func(uintptr) uintptr
+
+func init() {
+	var err error
+	OPENDAL_LIB, err = openLibrary()
+	if err != nil {
+		panic(err)
+	}
+
+	purego.RegisterLibFunc(&opendal_operator_options_new, OPENDAL_LIB, "opendal_operator_options_new")
+	purego.RegisterLibFunc(&opendal_operator_new, OPENDAL_LIB, "opendal_operator_new")
+}

--- a/bindings/go/init_linux.go
+++ b/bindings/go/init_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package opendal
+
+import "github.com/ebitengine/purego"
+
+func openLibrary() (uintptr, error) {
+	return purego.Dlopen("libopendal_c.so", purego.RTLD_NOW|purego.RTLD_GLOBAL)
+}

--- a/bindings/go/opendal.go
+++ b/bindings/go/opendal.go
@@ -1,0 +1,16 @@
+package opendal
+
+import "unsafe"
+
+type Operator struct {
+	op uintptr
+}
+
+func NewOperator(scheme string) *Operator {
+	trick := append([]byte(scheme), 0)
+	op := opendal_operator_new(uintptr(unsafe.Pointer(&trick[0])))
+
+	return &Operator{
+		op: op,
+	}
+}

--- a/bindings/go/opendal_test.go
+++ b/bindings/go/opendal_test.go
@@ -1,0 +1,8 @@
+package opendal
+
+import "testing"
+
+func TestNew(t *testing.T) {
+	op := NewOperator("memory")
+	t.Logf("%v", op)
+}


### PR DESCRIPTION
PLEASE DON'T MERGE.

A PoC of opendal golang binding just to show how bad a golang binding could be. 

This PR is more like a question to both rust and golang community.

Can we make it better? Or is it simply because we didn't have a library like `jni-rs` to assist us in handling it? Can we avoid `CGO` entirely? How will the performance be compared to calling RPC?

## What's we did in this PR?

We can link against with `libopendal_c` and calling it.