### PR TITLE
feat(bindings/java): support load system lib

### DIFF
--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -57,7 +57,6 @@
 
         <assertj-version>3.23.1</assertj-version>
         <lombok.version>1.18.26</lombok.version>
-        <questdb.version>1.0.0</questdb.version>
 
         <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
@@ -99,12 +98,6 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.questdb</groupId>
-            <artifactId>jar-jni</artifactId>
-            <version>${questdb.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This closes https://github.com/apache/incubator-opendal/issues/2361.

I noticed that we don't need to add an argument for users to pass path to lib. But `java.library.path` can already change the search path.

Also, get rid of unnecessary jar-jni dependency.