### PR TITLE
fix(service/webhdfs): fix webhdfs config builder for disable_list_batch

### DIFF
--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -130,8 +130,8 @@ impl Builder for WebhdfsBuilder {
         map.get("endpoint").map(|v| builder.endpoint(v));
         map.get("delegation").map(|v| builder.delegation(v));
         map.get("disable_list_batch")
-            .map(|v| v == "true")
-            .map(|_v| builder.disable_list_batch());
+            .filter(|v| v == &"true")
+            .map(|_| builder.disable_list_batch());
 
         builder
     }


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced by this PR. -->
In my recent PR, I tried to avoid compiler else error and I accidentally [miss-used map condition flow](https://github.com/apache/incubator-opendal/pull/2499/commits/b2231f6d1377006e01f4b427129bfdc7777aa705). So current code will always execute `disable_list_batch`. I apologize for the mistake, and here's a PR fix for it.