### PR TITLE
feat: Implement test harness via libtest-mimic instead

### DIFF
--- a/.github/workflows/service_test_hdfs.yml
+++ b/.github/workflows/service_test_hdfs.yml
@@ -62,7 +62,7 @@ jobs:
         working-directory: core
         run: |
           export CLASSPATH=$(find $HADOOP_HOME -iname "*.jar" | xargs echo | tr ' ' ':')
-          cargo nextest run services_hdfs --features services-hdfs
+          cargo test services_hdfs --features services-hdfs
         env:
           HADOOP_HOME: "/home/runner/hadoop-3.3.5"
           LD_LIBRARY_PATH: ${{ env.JAVA_HOME }}/lib/server:${{ env.LD_LIBRARY_PATH }}
@@ -120,7 +120,7 @@ jobs:
         run: |
           export CLASSPATH=$(find $HADOOP_HOME -iname "*.jar" | xargs echo | tr ' ' ':')
 
-          cargo nextest run services_hdfs --features services-hdfs
+          cargo test services_hdfs --features services-hdfs
         env:
           HADOOP_HOME: "/home/runner/hadoop-3.1.3"
           LD_LIBRARY_PATH: ${{ env.JAVA_HOME }}/lib/server:${{ env.LD_LIBRARY_PATH }}

--- a/.github/workflows/service_test_rocksdb.yml
+++ b/.github/workflows/service_test_rocksdb.yml
@@ -45,12 +45,11 @@ jobs:
         uses: ./.github/actions/setup
         with:
           need-rocksdb: true
-          need-nextest: true
 
       - name: Test
         shell: bash
         working-directory: core
-        run: cargo nextest run rocksdb --features services-rocksdb -j=1
+        run: cargo test rocksdb --features services-rocksdb -j=1
         env:
           OPENDAL_ROCKSDB_TEST: on
           OPENDAL_ROCKSDB_ROOT: /

--- a/.github/workflows/service_test_sled.yml
+++ b/.github/workflows/service_test_sled.yml
@@ -43,12 +43,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
-        with:
-          need-nextest: true
       - name: Test
         shell: bash
         working-directory: core
-        run: cargo nextest run sled --features services-sled -j=1
+        run: cargo test sled --features services-sled -j=1
         env:
           RUST_BACKTRACE: full
           RUST_LOG: debug

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a1f23fa97e1d1641371b51f35535cb26959b8e27ab50d167a8b996b5bada819"
 dependencies = [
  "clap_builder",
+ "clap_derive",
+ "once_cell",
 ]
 
 [[package]]
@@ -742,6 +744,18 @@ dependencies = [
  "clap_lex 0.4.1",
  "once_cell",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2078,6 +2092,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libtest-mimic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8de370f98a6cb8a4606618e53e802f93b094ddec0f96988eaec2c27e6e9ce7"
+dependencies = [
+ "clap 4.2.5",
+ "termcolor",
+ "threadpool",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2727,6 +2752,7 @@ dependencies = [
  "http",
  "hyper",
  "lazy-regex",
+ "libtest-mimic",
  "log",
  "madsim",
  "md-5",

--- a/bindings/haskell/Cargo.toml
+++ b/bindings/haskell/Cargo.toml
@@ -31,5 +31,5 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
-opendal.workspace = true
 chrono = "0.4"
+opendal.workspace = true

--- a/bindings/lua/Cargo.toml
+++ b/bindings/lua/Cargo.toml
@@ -27,7 +27,6 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -111,6 +111,7 @@ services-cos = [
   "reqsign?/reqwest_request",
 ]
 services-dashmap = ["dep:dashmap"]
+services-dropbox = []
 services-fs = ["tokio/fs"]
 services-ftp = ["dep:suppaftp", "dep:lazy-regex", "dep:bb8", "dep:async-tls"]
 services-gcs = [
@@ -118,7 +119,6 @@ services-gcs = [
   "reqsign?/services-google",
   "reqsign?/reqwest_request",
 ]
-services-dropbox = []
 services-gdrive = []
 services-ghac = []
 services-hdfs = ["dep:hdrs"]
@@ -164,6 +164,10 @@ bench = false
 [[bench]]
 harness = false
 name = "ops"
+
+[[test]]
+harness = false
+name = "behavior"
 
 [dependencies]
 anyhow = { version = "1.0.30", features = ["std"] }
@@ -228,6 +232,7 @@ uuid = { version = "1", features = ["serde", "v4"] }
 [dev-dependencies]
 criterion = { version = "0.4", features = ["async", "async_tokio"] }
 dotenvy = "0.15"
+libtest-mimic = "0.6"
 opentelemetry = { version = "0.19", default-features = false, features = [
   "trace",
 ] }

--- a/core/src/services/memory/backend.rs
+++ b/core/src/services/memory/backend.rs
@@ -17,6 +17,7 @@
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -64,9 +65,15 @@ impl Builder for MemoryBuilder {
 /// Backend is used to serve `Accessor` support in memory.
 pub type MemoryBackend = typed_kv::Backend<Adapter>;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Adapter {
     inner: Arc<Mutex<BTreeMap<String, typed_kv::Value>>>,
+}
+
+impl Debug for Adapter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryBackend").finish_non_exhaustive()
+    }
 }
 
 #[async_trait]

--- a/core/tests/behavior/append.rs
+++ b/core/tests/behavior/append.rs
@@ -26,7 +26,7 @@ use sha2::Sha256;
 
 use crate::*;
 
-pub fn behavior_append_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
+pub fn behavior_append_tests(op: &Operator) -> Vec<Trial> {
     let cap = op.info().capability();
 
     if !(cap.read && cap.write && cap.append) {
@@ -34,7 +34,6 @@ pub fn behavior_append_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
     }
 
     async_trials!(
-        runtime,
         op,
         test_append_create_append,
         test_append_with_dir_path,

--- a/core/tests/behavior/append.rs
+++ b/core/tests/behavior/append.rs
@@ -15,68 +15,35 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::vec;
+
 use anyhow::Result;
 use futures::io::BufReader;
 use futures::io::Cursor;
 use log::warn;
-use opendal::EntryMode;
-use opendal::ErrorKind;
-use opendal::Operator;
 use sha2::Digest;
 use sha2::Sha256;
 
-use super::utils::*;
+use crate::*;
 
-/// Test services that meet the following capability:
-///
-/// - can_read
-/// - can_write
-/// - can_append
-macro_rules! behavior_append_test {
-    ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
-        paste::item! {
-            $(
-                #[test]
-                $(
-                    #[$meta]
-                )*
-                fn [<append_ $test >]() -> anyhow::Result<()> {
-                    match OPERATOR.as_ref() {
-                        Some(op) if op.info().can_read()
-                            && op.info().can_write()
-                            && op.info().can_append() => RUNTIME.block_on($crate::append::$test(op.clone())),
-                        Some(_) => {
-                            log::warn!("service {} doesn't support append, ignored", opendal::Scheme::$service);
-                            Ok(())
-                        },
-                        None => {
-                            Ok(())
-                        }
-                    }
-                }
-            )*
-        }
-    };
-}
+pub fn behavior_append_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
+    let cap = op.info().capability();
 
-#[macro_export]
-macro_rules! behavior_append_tests {
-     ($($service:ident),*) => {
-        $(
-            behavior_append_test!(
-                $service,
+    if !(cap.read && cap.write && cap.append) {
+        return vec![];
+    }
 
-                test_append_create_append,
-                test_append_with_dir_path,
-                test_append_with_cache_control,
-                test_append_with_content_type,
-                test_append_with_content_disposition,
-
-                test_appender_futures_copy,
-                test_fuzz_appender,
-            );
-        )*
-    };
+    async_trials!(
+        runtime,
+        op,
+        test_append_create_append,
+        test_append_with_dir_path,
+        test_append_with_cache_control,
+        test_append_with_content_type,
+        test_append_with_content_disposition,
+        test_appender_futures_copy,
+        test_fuzz_appender
+    )
 }
 
 /// Test append to a file must success.

--- a/core/tests/behavior/blocking_list.rs
+++ b/core/tests/behavior/blocking_list.rs
@@ -35,7 +35,7 @@ pub fn behavior_blocking_list_tests(op: &Operator) -> Vec<Trial> {
         test_blocking_list_dir,
         test_blocking_list_non_exist_dir,
         test_blocking_scan,
-        test_remove_all
+        test_blocking_remove_all
     )
 }
 
@@ -120,7 +120,7 @@ pub fn test_blocking_scan(op: BlockingOperator) -> Result<()> {
 }
 
 // Remove all should remove all in this path.
-pub fn test_remove_all(op: BlockingOperator) -> Result<()> {
+pub fn test_blocking_remove_all(op: BlockingOperator) -> Result<()> {
     let parent = uuid::Uuid::new_v4().to_string();
 
     let expected = vec![

--- a/core/tests/behavior/blocking_read.rs
+++ b/core/tests/behavior/blocking_read.rs
@@ -16,64 +16,31 @@
 // under the License.
 
 use anyhow::Result;
-use opendal::BlockingOperator;
-use opendal::EntryMode;
-use opendal::ErrorKind;
 use sha2::Digest;
 use sha2::Sha256;
 
-/// Test services that meet the following capability:
-///
-/// - can_read
-/// - !can_write
-/// - can_blocking
-macro_rules! behavior_blocking_read_test {
-    ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
-        paste::item! {
-            $(
-                #[test]
-                $(
-                    #[$meta]
-                )*
-                fn [<blocking_read_ $test >]() -> anyhow::Result<()> {
-                    match OPERATOR.as_ref() {
-                        Some(op) if op.info().can_read()
-                            && !op.info().can_write()
-                            && op.info().can_blocking() => $crate::blocking_read::$test(op.blocking()),
-                        Some(_) => {
-                            log::warn!("service {} doesn't support blocking_read, ignored", opendal::Scheme::$service);
-                            Ok(())
-                        },
-                        None => {
-                            Ok(())
-                        }
-                    }
-                }
-            )*
-        }
-    };
-}
+use crate::*;
 
-#[macro_export]
-macro_rules! behavior_blocking_read_tests {
-     ($($service:ident),*) => {
-        $(
-            behavior_blocking_read_test!(
-                $service,
+pub fn behavior_blocking_read_tests(op: &Operator) -> Vec<Trial> {
+    let cap = op.info().capability();
 
-                test_stat_file_and_dir,
-                test_stat_special_chars,
-                test_stat_not_exist,
-                test_read_full,
-                test_read_range,
-                test_read_not_exist,
-            );
-        )*
-    };
+    if !(cap.read && cap.write && cap.blocking) {
+        return vec![];
+    }
+
+    blocking_trials!(
+        op,
+        test_blocking_stat_file_and_dir,
+        test_blocking_stat_special_chars,
+        test_blocking_stat_not_exist,
+        test_blocking_read_full,
+        test_blocking_read_range,
+        test_blocking_read_not_exist
+    )
 }
 
 /// Stat normal file and dir should return metadata
-pub fn test_stat_file_and_dir(op: BlockingOperator) -> Result<()> {
+pub fn test_blocking_stat_file_and_dir(op: BlockingOperator) -> Result<()> {
     let meta = op.stat("normal_file")?;
     assert_eq!(meta.mode(), EntryMode::FILE);
     assert_eq!(meta.content_length(), 262144);
@@ -85,7 +52,7 @@ pub fn test_stat_file_and_dir(op: BlockingOperator) -> Result<()> {
 }
 
 /// Stat special file and dir should return metadata
-pub fn test_stat_special_chars(op: BlockingOperator) -> Result<()> {
+pub fn test_blocking_stat_special_chars(op: BlockingOperator) -> Result<()> {
     let meta = op.stat("special_file  !@#$%^&()_+-=;',")?;
     assert_eq!(meta.mode(), EntryMode::FILE);
     assert_eq!(meta.content_length(), 262144);
@@ -97,7 +64,7 @@ pub fn test_stat_special_chars(op: BlockingOperator) -> Result<()> {
 }
 
 /// Stat not exist file should return NotFound
-pub fn test_stat_not_exist(op: BlockingOperator) -> Result<()> {
+pub fn test_blocking_stat_not_exist(op: BlockingOperator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
     let meta = op.stat(&path);
@@ -108,7 +75,7 @@ pub fn test_stat_not_exist(op: BlockingOperator) -> Result<()> {
 }
 
 /// Read full content should match.
-pub fn test_read_full(op: BlockingOperator) -> Result<()> {
+pub fn test_blocking_read_full(op: BlockingOperator) -> Result<()> {
     let bs = op.read("normal_file")?;
     assert_eq!(bs.len(), 262144, "read size");
     assert_eq!(
@@ -121,7 +88,7 @@ pub fn test_read_full(op: BlockingOperator) -> Result<()> {
 }
 
 /// Read full content should match.
-pub fn test_read_range(op: BlockingOperator) -> Result<()> {
+pub fn test_blocking_read_range(op: BlockingOperator) -> Result<()> {
     let bs = op.range_read("normal_file", 1024..2048)?;
     assert_eq!(bs.len(), 1024, "read size");
     assert_eq!(
@@ -134,7 +101,7 @@ pub fn test_read_range(op: BlockingOperator) -> Result<()> {
 }
 
 /// Read not exist file should return NotFound
-pub fn test_read_not_exist(op: BlockingOperator) -> Result<()> {
+pub fn test_blocking_read_not_exist(op: BlockingOperator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
     let bs = op.read(&path);

--- a/core/tests/behavior/blocking_read_only.rs
+++ b/core/tests/behavior/blocking_read_only.rs
@@ -21,26 +21,26 @@ use sha2::Sha256;
 
 use crate::*;
 
-pub fn behavior_blocking_read_tests(op: &Operator) -> Vec<Trial> {
+pub fn behavior_blocking_read_only_tests(op: &Operator) -> Vec<Trial> {
     let cap = op.info().capability();
 
-    if !(cap.read && cap.write && cap.blocking) {
+    if !(cap.read && !cap.write && cap.blocking) {
         return vec![];
     }
 
     blocking_trials!(
         op,
-        test_blocking_stat_file_and_dir,
-        test_blocking_stat_special_chars,
-        test_blocking_stat_not_exist,
-        test_blocking_read_full,
-        test_blocking_read_range,
-        test_blocking_read_not_exist
+        test_blocking_read_only_stat_file_and_dir,
+        test_blocking_read_only_stat_special_chars,
+        test_blocking_read_only_stat_not_exist,
+        test_blocking_read_only_read_full,
+        test_blocking_read_only_read_range,
+        test_blocking_read_only_read_not_exist
     )
 }
 
 /// Stat normal file and dir should return metadata
-pub fn test_blocking_stat_file_and_dir(op: BlockingOperator) -> Result<()> {
+pub fn test_blocking_read_only_stat_file_and_dir(op: BlockingOperator) -> Result<()> {
     let meta = op.stat("normal_file")?;
     assert_eq!(meta.mode(), EntryMode::FILE);
     assert_eq!(meta.content_length(), 262144);
@@ -52,7 +52,7 @@ pub fn test_blocking_stat_file_and_dir(op: BlockingOperator) -> Result<()> {
 }
 
 /// Stat special file and dir should return metadata
-pub fn test_blocking_stat_special_chars(op: BlockingOperator) -> Result<()> {
+pub fn test_blocking_read_only_stat_special_chars(op: BlockingOperator) -> Result<()> {
     let meta = op.stat("special_file  !@#$%^&()_+-=;',")?;
     assert_eq!(meta.mode(), EntryMode::FILE);
     assert_eq!(meta.content_length(), 262144);
@@ -64,7 +64,7 @@ pub fn test_blocking_stat_special_chars(op: BlockingOperator) -> Result<()> {
 }
 
 /// Stat not exist file should return NotFound
-pub fn test_blocking_stat_not_exist(op: BlockingOperator) -> Result<()> {
+pub fn test_blocking_read_only_stat_not_exist(op: BlockingOperator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
     let meta = op.stat(&path);
@@ -75,7 +75,7 @@ pub fn test_blocking_stat_not_exist(op: BlockingOperator) -> Result<()> {
 }
 
 /// Read full content should match.
-pub fn test_blocking_read_full(op: BlockingOperator) -> Result<()> {
+pub fn test_blocking_read_only_read_full(op: BlockingOperator) -> Result<()> {
     let bs = op.read("normal_file")?;
     assert_eq!(bs.len(), 262144, "read size");
     assert_eq!(
@@ -88,7 +88,7 @@ pub fn test_blocking_read_full(op: BlockingOperator) -> Result<()> {
 }
 
 /// Read full content should match.
-pub fn test_blocking_read_range(op: BlockingOperator) -> Result<()> {
+pub fn test_blocking_read_only_read_range(op: BlockingOperator) -> Result<()> {
     let bs = op.range_read("normal_file", 1024..2048)?;
     assert_eq!(bs.len(), 1024, "read size");
     assert_eq!(
@@ -101,7 +101,7 @@ pub fn test_blocking_read_range(op: BlockingOperator) -> Result<()> {
 }
 
 /// Read not exist file should return NotFound
-pub fn test_blocking_read_not_exist(op: BlockingOperator) -> Result<()> {
+pub fn test_blocking_read_only_read_not_exist(op: BlockingOperator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
     let bs = op.read(&path);

--- a/core/tests/behavior/copy.rs
+++ b/core/tests/behavior/copy.rs
@@ -19,7 +19,7 @@ use anyhow::Result;
 
 use crate::*;
 
-pub fn behavior_copy_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
+pub fn behavior_copy_tests(op: &Operator) -> Vec<Trial> {
     let cap = op.info().capability();
 
     if !(cap.read && cap.write && cap.copy) {
@@ -27,7 +27,6 @@ pub fn behavior_copy_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
     }
 
     async_trials!(
-        runtime,
         op,
         test_copy_file,
         test_copy_non_existing_source,

--- a/core/tests/behavior/list.rs
+++ b/core/tests/behavior/list.rs
@@ -23,67 +23,32 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use log::debug;
-use opendal::EntryMode;
-use opendal::ErrorKind;
-use opendal::Operator;
 
-use super::utils::*;
+use crate::*;
 
-/// Test services that meet the following capability:
-///
-/// - can_read
-/// - can_write
-/// - can_list or can_scan
-macro_rules! behavior_list_test {
-    ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
-        paste::item! {
-            $(
-                #[test]
-                $(
-                    #[$meta]
-                )*
-                fn [<list_ $test >]() -> anyhow::Result<()> {
-                    match OPERATOR.as_ref() {
-                        Some(op) if op.info().can_read()
-                            && op.info().can_write()
-                            && op.info().can_list()
-                                 => RUNTIME.block_on($crate::list::$test(op.clone())),
-                        Some(_) => {
-                            log::warn!("service {} doesn't support list, ignored", opendal::Scheme::$service);
-                            Ok(())
-                        },
-                        None => {
-                            Ok(())
-                        }
-                    }
-                }
-            )*
-        }
-    };
-}
+pub fn behavior_list_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
+    let cap = op.info().capability();
 
-#[macro_export]
-macro_rules! behavior_list_tests {
-     ($($service:ident),*) => {
-        $(
-            behavior_list_test!(
-                $service,
+    if !(cap.read && cap.write && cap.list) {
+        return vec![];
+    }
 
-                test_check,
-                test_list_dir,
-                test_list_rich_dir,
-                test_list_empty_dir,
-                test_list_non_exist_dir,
-                test_list_sub_dir,
-                test_list_nested_dir,
-                test_list_dir_with_file_path,
-                test_list_with_start_after,
-                test_scan,
-                test_scan_root,
-                test_remove_all,
-            );
-        )*
-    };
+    async_trials!(
+        runtime,
+        op,
+        test_check,
+        test_list_dir,
+        test_list_rich_dir,
+        test_list_empty_dir,
+        test_list_non_exist_dir,
+        test_list_sub_dir,
+        test_list_nested_dir,
+        test_list_dir_with_file_path,
+        test_list_with_start_after,
+        test_scan,
+        test_scan_root,
+        test_remove_all
+    )
 }
 
 /// Check should be OK.

--- a/core/tests/behavior/list.rs
+++ b/core/tests/behavior/list.rs
@@ -26,7 +26,7 @@ use log::debug;
 
 use crate::*;
 
-pub fn behavior_list_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
+pub fn behavior_list_tests(op: &Operator) -> Vec<Trial> {
     let cap = op.info().capability();
 
     if !(cap.read && cap.write && cap.list) {
@@ -34,7 +34,6 @@ pub fn behavior_list_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
     }
 
     async_trials!(
-        runtime,
         op,
         test_check,
         test_list_dir,

--- a/core/tests/behavior/list_only.rs
+++ b/core/tests/behavior/list_only.rs
@@ -22,14 +22,14 @@ use futures::TryStreamExt;
 
 use crate::*;
 
-pub fn behavior_list_only_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
+pub fn behavior_list_only_tests(op: &Operator) -> Vec<Trial> {
     let cap = op.info().capability();
 
     if !cap.list || cap.write {
         return vec![];
     }
 
-    async_trials!(runtime, op, test_list_only)
+    async_trials!(op, test_list_only)
 }
 
 /// Stat normal file and dir should return metadata

--- a/core/tests/behavior/main.rs
+++ b/core/tests/behavior/main.rs
@@ -55,7 +55,6 @@ use blocking_write::behavior_blocking_write_tests;
 use libtest_mimic::{Arguments, Trial};
 use once_cell::sync::Lazy;
 use opendal::*;
-use tokio::runtime::Runtime;
 
 static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
     tokio::runtime::Builder::new_multi_thread()
@@ -65,7 +64,6 @@ static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
 });
 
 fn behavior_test<B: Builder>() -> Vec<Trial> {
-    let runtime = &RUNTIME;
     let operator = match init_service::<B>() {
         Some(op) => op,
         None => return Vec::new(),
@@ -79,14 +77,14 @@ fn behavior_test<B: Builder>() -> Vec<Trial> {
     trials.extend(behavior_blocking_rename_tests(&operator));
     trials.extend(behavior_blocking_write_tests(&operator));
     // Async tests
-    trials.extend(behavior_append_tests(runtime, &operator));
-    trials.extend(behavior_copy_tests(runtime, &operator));
-    trials.extend(behavior_list_only_tests(runtime, &operator));
-    trials.extend(behavior_list_tests(runtime, &operator));
-    trials.extend(behavior_presign_tests(runtime, &operator));
-    trials.extend(behavior_read_only_tests(runtime, &operator));
-    trials.extend(behavior_rename_tests(runtime, &operator));
-    trials.extend(behavior_write_tests(runtime, &operator));
+    trials.extend(behavior_append_tests(&operator));
+    trials.extend(behavior_copy_tests(&operator));
+    trials.extend(behavior_list_only_tests(&operator));
+    trials.extend(behavior_list_tests(&operator));
+    trials.extend(behavior_presign_tests(&operator));
+    trials.extend(behavior_read_only_tests(&operator));
+    trials.extend(behavior_rename_tests(&operator));
+    trials.extend(behavior_write_tests(&operator));
 
     trials
 }

--- a/core/tests/behavior/main.rs
+++ b/core/tests/behavior/main.rs
@@ -53,14 +53,19 @@ use blocking_write::behavior_blocking_write_tests;
 
 // External dependences
 use libtest_mimic::{Arguments, Trial};
+use once_cell::sync::Lazy;
 use opendal::*;
 use tokio::runtime::Runtime;
 
-fn behavior_test<B: Builder>() -> Vec<Trial> {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
+static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
-        .unwrap();
+        .unwrap()
+});
+
+fn behavior_test<B: Builder>() -> Vec<Trial> {
+    let runtime = &RUNTIME;
     let operator = match init_service::<B>() {
         Some(op) => op,
         None => return Vec::new(),
@@ -74,14 +79,14 @@ fn behavior_test<B: Builder>() -> Vec<Trial> {
     trials.extend(behavior_blocking_rename_tests(&operator));
     trials.extend(behavior_blocking_write_tests(&operator));
     // Async tests
-    trials.extend(behavior_append_tests(&runtime, &operator));
-    trials.extend(behavior_copy_tests(&runtime, &operator));
-    trials.extend(behavior_list_only_tests(&runtime, &operator));
-    trials.extend(behavior_list_tests(&runtime, &operator));
-    trials.extend(behavior_presign_tests(&runtime, &operator));
-    trials.extend(behavior_read_only_tests(&runtime, &operator));
-    trials.extend(behavior_rename_tests(&runtime, &operator));
-    trials.extend(behavior_write_tests(&runtime, &operator));
+    trials.extend(behavior_append_tests(runtime, &operator));
+    trials.extend(behavior_copy_tests(runtime, &operator));
+    trials.extend(behavior_list_only_tests(runtime, &operator));
+    trials.extend(behavior_list_tests(runtime, &operator));
+    trials.extend(behavior_presign_tests(runtime, &operator));
+    trials.extend(behavior_read_only_tests(runtime, &operator));
+    trials.extend(behavior_rename_tests(runtime, &operator));
+    trials.extend(behavior_write_tests(runtime, &operator));
 
     trials
 }

--- a/core/tests/behavior/main.rs
+++ b/core/tests/behavior/main.rs
@@ -15,139 +15,142 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// utils that used by tests
 #[macro_use]
-mod blocking_copy;
-#[macro_use]
-mod blocking_list;
-#[macro_use]
-mod blocking_rename;
-#[macro_use]
-mod blocking_read;
-#[macro_use]
-mod blocking_write;
-#[macro_use]
-mod append;
-#[macro_use]
-mod copy;
-#[macro_use]
-mod list;
-#[macro_use]
-mod list_only;
-#[macro_use]
-mod presign;
-#[macro_use]
-mod read_only;
-#[macro_use]
-mod rename;
-#[macro_use]
-mod write;
-
 mod utils;
 
-/// Generate real test cases.
-/// Update function list while changed.
-macro_rules! behavior_tests {
-    ($($service:ident),*) => {
-        paste::item! {
-            $(
-                mod [<services_ $service:snake>] {
-                    use once_cell::sync::Lazy;
+pub use utils::*;
 
-                    static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
-                       tokio::runtime::Builder::new_multi_thread()
-                            .enable_all()
-                            .build()
-                            .unwrap()
-                    });
-                    static OPERATOR: Lazy<Option<opendal::Operator>> = Lazy::new(||
-                        $crate::utils::init_service::<opendal::services::$service>()
-                    );
+// Async test cases
+mod append;
+mod copy;
+mod list;
+mod list_only;
+mod presign;
+mod read_only;
+mod rename;
+mod write;
+use append::behavior_append_tests;
+use copy::behavior_copy_tests;
+use list::behavior_list_tests;
+use list_only::behavior_list_only_tests;
+use presign::behavior_presign_tests;
+use read_only::behavior_read_only_tests;
+use rename::behavior_rename_tests;
+use write::behavior_write_tests;
 
-                    // can_read && !can_write
-                    behavior_read_tests!($service);
-                    // can_read && !can_write && can_blocking
-                    behavior_blocking_read_tests!($service);
-                    // can_read && can_write
-                    behavior_write_tests!($service);
-                    // can_read && can_write && can_blocking
-                    behavior_blocking_write_tests!($service);
-                    // can_read && can_write && can_append
-                    behavior_append_tests!($service);
-                    // can_read && can_write && can_copy
-                    behavior_copy_tests!($service);
-                    // can read && can_write && can_blocking && can_copy
-                    behavior_blocking_copy_tests!($service);
-                    // can_read && can_write && can_move
-                    behavior_rename_tests!($service);
-                    // can_read && can_write && can_blocking && can_move
-                    behavior_blocking_rename_tests!($service);
-                    // can_read && can_write && can_list
-                    behavior_list_tests!($service);
-                    // can_read && can_write && can_presign
-                    behavior_presign_tests!($service);
-                    // can_read && can_write && can_blocking && can_list
-                    behavior_blocking_list_tests!($service);
-                    // can_list && !can_write
-                    behavior_list_only_tests!($service);
-                }
-         )*
-        }
+// Blocking test cases
+mod blocking_copy;
+mod blocking_list;
+mod blocking_read;
+mod blocking_rename;
+mod blocking_write;
+use blocking_copy::behavior_blocking_copy_tests;
+use blocking_list::behavior_blocking_list_tests;
+use blocking_read::behavior_blocking_read_tests;
+use blocking_rename::behavior_blocking_rename_tests;
+use blocking_write::behavior_blocking_write_tests;
+
+// External dependences
+use libtest_mimic::{Arguments, Trial};
+use opendal::*;
+use tokio::runtime::Runtime;
+
+fn behavior_test<B: Builder>() -> Vec<Trial> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let operator = match init_service::<B>() {
+        Some(op) => op,
+        None => return Vec::new(),
     };
+
+    let mut trials = vec![];
+    // Blocking tests
+    trials.extend(behavior_blocking_copy_tests(&operator));
+    trials.extend(behavior_blocking_list_tests(&operator));
+    trials.extend(behavior_blocking_read_tests(&operator));
+    trials.extend(behavior_blocking_rename_tests(&operator));
+    trials.extend(behavior_blocking_write_tests(&operator));
+    // Async tests
+    trials.extend(behavior_append_tests(&runtime, &operator));
+    trials.extend(behavior_copy_tests(&runtime, &operator));
+    trials.extend(behavior_list_only_tests(&runtime, &operator));
+    trials.extend(behavior_list_tests(&runtime, &operator));
+    trials.extend(behavior_presign_tests(&runtime, &operator));
+    trials.extend(behavior_read_only_tests(&runtime, &operator));
+    trials.extend(behavior_rename_tests(&runtime, &operator));
+    trials.extend(behavior_write_tests(&runtime, &operator));
+
+    trials
 }
 
-#[cfg(feature = "services-azblob")]
-behavior_tests!(Azblob);
-#[cfg(feature = "services-azdfs")]
-behavior_tests!(Azdfs);
-#[cfg(feature = "services-cos")]
-behavior_tests!(Cos);
-#[cfg(feature = "services-dashmap")]
-behavior_tests!(Dashmap);
-#[cfg(feature = "services-fs")]
-behavior_tests!(Fs);
-#[cfg(feature = "services-ftp")]
-behavior_tests!(Ftp);
-#[cfg(feature = "services-memcached")]
-behavior_tests!(Memcached);
-#[cfg(feature = "services-memory")]
-behavior_tests!(Memory);
-#[cfg(feature = "services-moka")]
-behavior_tests!(Moka);
-#[cfg(feature = "services-gcs")]
-behavior_tests!(Gcs);
-#[cfg(feature = "services-ghac")]
-behavior_tests!(Ghac);
-#[cfg(feature = "services-ipfs")]
-behavior_tests!(Ipfs);
-#[cfg(feature = "services-ipmfs")]
-behavior_tests!(Ipmfs);
-#[cfg(feature = "services-hdfs")]
-behavior_tests!(Hdfs);
-#[cfg(feature = "services-http")]
-behavior_tests!(Http);
-#[cfg(feature = "services-obs")]
-behavior_tests!(Obs);
-#[cfg(feature = "services-redis")]
-behavior_tests!(Redis);
-#[cfg(feature = "services-rocksdb")]
-behavior_tests!(Rocksdb);
-#[cfg(feature = "services-oss")]
-behavior_tests!(Oss);
-#[cfg(feature = "services-s3")]
-behavior_tests!(S3);
-#[cfg(feature = "services-sftp")]
-behavior_tests!(Sftp);
-#[cfg(feature = "services-supabase")]
-behavior_tests!(Supabase);
-#[cfg(feature = "services-sled")]
-behavior_tests!(Sled);
-#[cfg(feature = "services-vercel-artifacts")]
-behavior_tests!(VercelArtifacts);
-#[cfg(feature = "services-wasabi")]
-behavior_tests!(Wasabi);
-#[cfg(feature = "services-webdav")]
-behavior_tests!(Webdav);
-#[cfg(feature = "services-webhdfs")]
-behavior_tests!(Webhdfs);
-#[cfg(feature = "services-onedrive")]
-behavior_tests!(Onedrive);
+fn main() -> anyhow::Result<()> {
+    let args = Arguments::from_args();
+
+    let mut tests = Vec::new();
+
+    #[cfg(feature = "services-azblob")]
+    tests.extend(behavior_test::<services::Azblob>());
+    #[cfg(feature = "services-azdfs")]
+    tests.extend(behavior_test::<services::Azdfs>());
+    #[cfg(feature = "services-cos")]
+    tests.extend(behavior_test::<services::Cos>());
+    #[cfg(feature = "services-dashmap")]
+    tests.extend(behavior_test::<services::Dashmap>());
+    #[cfg(feature = "services-fs")]
+    tests.extend(behavior_test::<services::Fs>());
+    #[cfg(feature = "services-ftp")]
+    tests.extend(behavior_test::<services::Ftp>());
+    #[cfg(feature = "services-gcs")]
+    tests.extend(behavior_test::<services::Gcs>());
+    #[cfg(feature = "services-ghac")]
+    tests.extend(behavior_test::<services::Ghac>());
+    #[cfg(feature = "services-hdfs")]
+    tests.extend(behavior_test::<services::Hdfs>());
+    #[cfg(feature = "services-http")]
+    tests.extend(behavior_test::<services::Http>());
+    #[cfg(feature = "services-ipfs")]
+    tests.extend(behavior_test::<services::Ipfs>());
+    #[cfg(feature = "services-ipmfs")]
+    tests.extend(behavior_test::<services::Ipmfs>());
+    #[cfg(feature = "services-memcached")]
+    tests.extend(behavior_test::<services::Memcached>());
+    #[cfg(feature = "services-memory")]
+    tests.extend(behavior_test::<services::Memory>());
+    #[cfg(feature = "services-moka")]
+    tests.extend(behavior_test::<services::Moka>());
+    #[cfg(feature = "services-obs")]
+    tests.extend(behavior_test::<services::Obs>());
+    #[cfg(feature = "services-onedrive")]
+    tests.extend(behavior_test::<services::Onedrive>());
+    #[cfg(feature = "services-gdrive")]
+    tests.extend(behavior_test::<services::Gdrive>());
+    #[cfg(feature = "services-dropbox")]
+    tests.extend(behavior_test::<services::Dropbox>());
+    #[cfg(feature = "services-oss")]
+    tests.extend(behavior_test::<services::Oss>());
+    #[cfg(feature = "services-redis")]
+    tests.extend(behavior_test::<services::Redis>());
+    #[cfg(feature = "services-rocksdb")]
+    tests.extend(behavior_test::<services::Rocksdb>());
+    #[cfg(feature = "services-s3")]
+    tests.extend(behavior_test::<services::S3>());
+    #[cfg(feature = "services-sftp")]
+    tests.extend(behavior_test::<services::Sftp>());
+    #[cfg(feature = "services-sled")]
+    tests.extend(behavior_test::<services::Sled>());
+    #[cfg(feature = "services-supabase")]
+    tests.extend(behavior_test::<services::Supabase>());
+    #[cfg(feature = "services-vercel-artifacts")]
+    tests.extend(behavior_test::<services::VercelArtifacts>());
+    #[cfg(feature = "services-wasabi")]
+    tests.extend(behavior_test::<services::Wasabi>());
+    #[cfg(feature = "services-webdav")]
+    tests.extend(behavior_test::<services::Webdav>());
+    #[cfg(feature = "services-webhdfs")]
+    tests.extend(behavior_test::<services::Webhdfs>());
+
+    libtest_mimic::run(&args, tests).exit();
+}

--- a/core/tests/behavior/main.rs
+++ b/core/tests/behavior/main.rs
@@ -152,5 +152,13 @@ fn main() -> anyhow::Result<()> {
     #[cfg(feature = "services-webhdfs")]
     tests.extend(behavior_test::<services::Webhdfs>());
 
+    // Don't init logging while building operator which may break cargo
+    // nextest output
+    let _ = tracing_subscriber::fmt()
+        .pretty()
+        .with_test_writer()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
     libtest_mimic::run(&args, tests).exit();
 }

--- a/core/tests/behavior/main.rs
+++ b/core/tests/behavior/main.rs
@@ -42,12 +42,12 @@ use write::behavior_write_tests;
 // Blocking test cases
 mod blocking_copy;
 mod blocking_list;
-mod blocking_read;
+mod blocking_read_only;
 mod blocking_rename;
 mod blocking_write;
 use blocking_copy::behavior_blocking_copy_tests;
 use blocking_list::behavior_blocking_list_tests;
-use blocking_read::behavior_blocking_read_tests;
+use blocking_read_only::behavior_blocking_read_only_tests;
 use blocking_rename::behavior_blocking_rename_tests;
 use blocking_write::behavior_blocking_write_tests;
 
@@ -70,7 +70,7 @@ fn behavior_test<B: Builder>() -> Vec<Trial> {
     // Blocking tests
     trials.extend(behavior_blocking_copy_tests(&operator));
     trials.extend(behavior_blocking_list_tests(&operator));
-    trials.extend(behavior_blocking_read_tests(&operator));
+    trials.extend(behavior_blocking_read_only_tests(&operator));
     trials.extend(behavior_blocking_rename_tests(&operator));
     trials.extend(behavior_blocking_write_tests(&operator));
     // Async tests

--- a/core/tests/behavior/presign.rs
+++ b/core/tests/behavior/presign.rs
@@ -28,20 +28,14 @@ use sha2::Sha256;
 
 use crate::*;
 
-pub fn behavior_presign_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
+pub fn behavior_presign_tests(op: &Operator) -> Vec<Trial> {
     let cap = op.info().capability();
 
     if !(cap.list && cap.write && cap.presign) {
         return vec![];
     }
 
-    async_trials!(
-        runtime,
-        op,
-        test_presign_write,
-        test_presign_read,
-        test_presign_stat
-    )
+    async_trials!(op, test_presign_write, test_presign_read, test_presign_stat)
 }
 
 /// Presign write should succeed.

--- a/core/tests/behavior/read_only.rs
+++ b/core/tests/behavior/read_only.rs
@@ -22,7 +22,7 @@ use sha2::Sha256;
 
 use crate::*;
 
-pub fn behavior_read_only_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
+pub fn behavior_read_only_tests(op: &Operator) -> Vec<Trial> {
     let cap = op.info().capability();
 
     if !cap.read || cap.write {
@@ -30,7 +30,6 @@ pub fn behavior_read_only_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> 
     }
 
     async_trials!(
-        runtime,
         op,
         test_read_only_stat_file_and_dir,
         test_read_only_stat_special_chars,

--- a/core/tests/behavior/read_only.rs
+++ b/core/tests/behavior/read_only.rs
@@ -17,72 +17,43 @@
 
 use anyhow::Result;
 use futures::AsyncReadExt;
-use opendal::EntryMode;
-use opendal::ErrorKind;
-use opendal::Operator;
 use sha2::Digest;
 use sha2::Sha256;
 
-/// Test services that meet the following capability:
-///
-/// - can_read
-/// - !can_write
-macro_rules! behavior_read_test {
-    ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
-        paste::item! {
-            $(
-                #[test]
-                $(
-                    #[$meta]
-                )*
-                fn [<read_only_ $test >]() -> anyhow::Result<()> {
-                    match OPERATOR.as_ref() {
-                        Some(op) if op.info().can_read() && !op.info().can_write() => RUNTIME.block_on($crate::read_only::$test(op.clone())),
-                        Some(_) => {
-                            log::warn!("service {} doesn't support read_only, ignored", opendal::Scheme::$service);
-                            Ok(())
-                        },
-                        None => {
-                            Ok(())
-                        }
-                    }
-                }
-            )*
-        }
-    };
-}
+use crate::*;
 
-#[macro_export]
-macro_rules! behavior_read_tests {
-     ($($service:ident),*) => {
-        $(
-            behavior_read_test!(
-                $service,
+pub fn behavior_read_only_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
+    let cap = op.info().capability();
 
-                test_stat_file_and_dir,
-                test_stat_special_chars,
-                test_stat_not_cleaned_path,
-                test_stat_not_exist,
-                test_stat_with_if_match,
-                test_stat_with_if_none_match,
-                test_stat_root,
-                test_read_full,
-                test_read_full_with_special_chars,
-                test_read_range,
-                test_reader_range,
-                test_reader_from,
-                test_reader_tail,
-                test_read_not_exist,
-                test_read_with_dir_path,
-                test_read_with_if_match,
-                test_read_with_if_none_match,
-            );
-        )*
-    };
+    if !cap.read || cap.write {
+        return vec![];
+    }
+
+    async_trials!(
+        runtime,
+        op,
+        test_read_only_stat_file_and_dir,
+        test_read_only_stat_special_chars,
+        test_read_only_stat_not_cleaned_path,
+        test_read_only_stat_not_exist,
+        test_read_only_stat_with_if_match,
+        test_read_only_stat_with_if_none_match,
+        test_read_only_stat_root,
+        test_read_only_read_full,
+        test_read_only_read_full_with_special_chars,
+        test_read_only_read_range,
+        test_read_only_reader_range,
+        test_read_only_reader_from,
+        test_read_only_reader_tail,
+        test_read_only_read_not_exist,
+        test_read_only_read_with_dir_path,
+        test_read_only_read_with_if_match,
+        test_read_only_read_with_if_none_match
+    )
 }
 
 /// Stat normal file and dir should return metadata
-pub async fn test_stat_file_and_dir(op: Operator) -> Result<()> {
+pub async fn test_read_only_stat_file_and_dir(op: Operator) -> Result<()> {
     let meta = op.stat("normal_file").await?;
     assert_eq!(meta.mode(), EntryMode::FILE);
     assert_eq!(meta.content_length(), 262144);
@@ -94,7 +65,7 @@ pub async fn test_stat_file_and_dir(op: Operator) -> Result<()> {
 }
 
 /// Stat special file and dir should return metadata
-pub async fn test_stat_special_chars(op: Operator) -> Result<()> {
+pub async fn test_read_only_stat_special_chars(op: Operator) -> Result<()> {
     let meta = op.stat("special_file  !@#$%^&()_+-=;',").await?;
     assert_eq!(meta.mode(), EntryMode::FILE);
     assert_eq!(meta.content_length(), 262144);
@@ -106,7 +77,7 @@ pub async fn test_stat_special_chars(op: Operator) -> Result<()> {
 }
 
 /// Stat not cleaned path should also succeed.
-pub async fn test_stat_not_cleaned_path(op: Operator) -> Result<()> {
+pub async fn test_read_only_stat_not_cleaned_path(op: Operator) -> Result<()> {
     let meta = op.stat("//normal_file").await?;
     assert_eq!(meta.mode(), EntryMode::FILE);
     assert_eq!(meta.content_length(), 262144);
@@ -115,7 +86,7 @@ pub async fn test_stat_not_cleaned_path(op: Operator) -> Result<()> {
 }
 
 /// Stat not exist file should return NotFound
-pub async fn test_stat_not_exist(op: Operator) -> Result<()> {
+pub async fn test_read_only_stat_not_exist(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
     let meta = op.stat(&path).await;
@@ -126,7 +97,7 @@ pub async fn test_stat_not_exist(op: Operator) -> Result<()> {
 }
 
 /// Stat with if_match should succeed, else get a ConditionNotMatch error.
-pub async fn test_stat_with_if_match(op: Operator) -> Result<()> {
+pub async fn test_read_only_stat_with_if_match(op: Operator) -> Result<()> {
     if !op.info().capability().stat_with_if_match {
         return Ok(());
     }
@@ -151,7 +122,7 @@ pub async fn test_stat_with_if_match(op: Operator) -> Result<()> {
 }
 
 /// Stat with if_none_match should succeed, else get a ConditionNotMatch.
-pub async fn test_stat_with_if_none_match(op: Operator) -> Result<()> {
+pub async fn test_read_only_stat_with_if_none_match(op: Operator) -> Result<()> {
     if !op.info().capability().stat_with_if_none_match {
         return Ok(());
     }
@@ -177,7 +148,7 @@ pub async fn test_stat_with_if_none_match(op: Operator) -> Result<()> {
 }
 
 /// Root should be able to stat and returns DIR.
-pub async fn test_stat_root(op: Operator) -> Result<()> {
+pub async fn test_read_only_stat_root(op: Operator) -> Result<()> {
     let meta = op.stat("").await?;
     assert_eq!(meta.mode(), EntryMode::DIR);
 
@@ -188,7 +159,7 @@ pub async fn test_stat_root(op: Operator) -> Result<()> {
 }
 
 /// Read full content should match.
-pub async fn test_read_full(op: Operator) -> Result<()> {
+pub async fn test_read_only_read_full(op: Operator) -> Result<()> {
     let bs = op.read("normal_file").await?;
     assert_eq!(bs.len(), 262144, "read size");
     assert_eq!(
@@ -201,7 +172,7 @@ pub async fn test_read_full(op: Operator) -> Result<()> {
 }
 
 /// Read full content should match.
-pub async fn test_read_full_with_special_chars(op: Operator) -> Result<()> {
+pub async fn test_read_only_read_full_with_special_chars(op: Operator) -> Result<()> {
     let bs = op.read("special_file  !@#$%^&()_+-=;',").await?;
     assert_eq!(bs.len(), 262144, "read size");
     assert_eq!(
@@ -214,7 +185,7 @@ pub async fn test_read_full_with_special_chars(op: Operator) -> Result<()> {
 }
 
 /// Read full content should match.
-pub async fn test_read_range(op: Operator) -> Result<()> {
+pub async fn test_read_only_read_range(op: Operator) -> Result<()> {
     let bs = op.range_read("normal_file", 1024..2048).await?;
     assert_eq!(bs.len(), 1024, "read size");
     assert_eq!(
@@ -227,7 +198,7 @@ pub async fn test_read_range(op: Operator) -> Result<()> {
 }
 
 /// Read range should match.
-pub async fn test_reader_range(op: Operator) -> Result<()> {
+pub async fn test_read_only_reader_range(op: Operator) -> Result<()> {
     let mut r = op.range_reader("normal_file", 1024..2048).await?;
 
     let mut bs = Vec::new();
@@ -244,7 +215,7 @@ pub async fn test_reader_range(op: Operator) -> Result<()> {
 }
 
 /// Read from should match.
-pub async fn test_reader_from(op: Operator) -> Result<()> {
+pub async fn test_read_only_reader_from(op: Operator) -> Result<()> {
     let mut r = op.range_reader("normal_file", 261120..).await?;
 
     let mut bs = Vec::new();
@@ -261,7 +232,7 @@ pub async fn test_reader_from(op: Operator) -> Result<()> {
 }
 
 /// Read tail should match.
-pub async fn test_reader_tail(op: Operator) -> Result<()> {
+pub async fn test_read_only_reader_tail(op: Operator) -> Result<()> {
     let mut r = op.range_reader("normal_file", ..1024).await?;
 
     let mut bs = Vec::new();
@@ -278,7 +249,7 @@ pub async fn test_reader_tail(op: Operator) -> Result<()> {
 }
 
 /// Read not exist file should return NotFound
-pub async fn test_read_not_exist(op: Operator) -> Result<()> {
+pub async fn test_read_only_read_not_exist(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
 
     let bs = op.read(&path).await;
@@ -289,7 +260,7 @@ pub async fn test_read_not_exist(op: Operator) -> Result<()> {
 }
 
 /// Read with dir path should return an error.
-pub async fn test_read_with_dir_path(op: Operator) -> Result<()> {
+pub async fn test_read_only_read_with_dir_path(op: Operator) -> Result<()> {
     let path = format!("{}/", uuid::Uuid::new_v4());
 
     let result = op.read(&path).await;
@@ -300,7 +271,7 @@ pub async fn test_read_with_dir_path(op: Operator) -> Result<()> {
 }
 
 /// Read with if_match should match, else get a ConditionNotMatch error.
-pub async fn test_read_with_if_match(op: Operator) -> Result<()> {
+pub async fn test_read_only_read_with_if_match(op: Operator) -> Result<()> {
     if !op.info().capability().read_with_if_match {
         return Ok(());
     }
@@ -329,7 +300,7 @@ pub async fn test_read_with_if_match(op: Operator) -> Result<()> {
 }
 
 /// Read with if_none_match should match, else get a ConditionNotMatch error.
-pub async fn test_read_with_if_none_match(op: Operator) -> Result<()> {
+pub async fn test_read_only_read_with_if_none_match(op: Operator) -> Result<()> {
     if !op.info().capability().read_with_if_none_match {
         return Ok(());
     }

--- a/core/tests/behavior/rename.rs
+++ b/core/tests/behavior/rename.rs
@@ -19,7 +19,7 @@ use anyhow::Result;
 
 use crate::*;
 
-pub fn behavior_rename_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
+pub fn behavior_rename_tests(op: &Operator) -> Vec<Trial> {
     let cap = op.info().capability();
 
     if !(cap.read && cap.write && cap.rename) {
@@ -27,7 +27,6 @@ pub fn behavior_rename_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
     }
 
     async_trials!(
-        runtime,
         op,
         test_rename_file,
         test_rename_non_existing_source,

--- a/core/tests/behavior/rename.rs
+++ b/core/tests/behavior/rename.rs
@@ -16,61 +16,27 @@
 // under the License.
 
 use anyhow::Result;
-use opendal::ErrorKind;
-use opendal::Operator;
 
-use super::utils::*;
+use crate::*;
 
-/// Test services that meet the following capability:
-///
-/// - can_read
-/// - can_write
-/// - can_rename
-macro_rules! behavior_rename_test {
-    ($service:ident, $($(#[$meta:meta])* $test:ident),*,) => {
-        paste::item! {
-            $(
-                #[test]
-                $(
-                    #[$meta]
-                )*
-                fn [<rename_ $test >]() -> anyhow::Result<()> {
-                    match OPERATOR.as_ref() {
-                        Some(op) if op.info().can_read()
-                            && op.info().can_write()
-                            && op.info().can_rename() => RUNTIME.block_on($crate::rename::$test(op.clone())),
-                        Some(_) => {
-                            log::warn!("service {} doesn't support rename, ignored", opendal::Scheme::$service);
-                            Ok(())
-                        },
-                        None => {
-                            Ok(())
-                        }
-                    }
-                }
-            )*
-        }
-    };
-}
+pub fn behavior_rename_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
+    let cap = op.info().capability();
 
-#[macro_export]
-macro_rules! behavior_rename_tests {
-     ($($service:ident),*) => {
-        $(
-            behavior_rename_test!(
-                $service,
+    if !(cap.read && cap.write && cap.rename) {
+        return vec![];
+    }
 
-                test_rename_file,
-                test_rename_non_existing_source,
-                test_rename_source_dir,
-                test_rename_target_dir,
-                test_rename_self,
-                test_rename_nested,
-                test_rename_overwrite,
-
-            );
-        )*
-    };
+    async_trials!(
+        runtime,
+        op,
+        test_rename_file,
+        test_rename_non_existing_source,
+        test_rename_source_dir,
+        test_rename_target_dir,
+        test_rename_self,
+        test_rename_nested,
+        test_rename_overwrite
+    )
 }
 
 /// Rename a file and test with stat.

--- a/core/tests/behavior/utils.rs
+++ b/core/tests/behavior/utils.rs
@@ -28,7 +28,6 @@ use futures::Future;
 use libtest_mimic::Failed;
 use libtest_mimic::Trial;
 use log::debug;
-use log::warn;
 use opendal::layers::LoggingLayer;
 use opendal::layers::RetryLayer;
 use opendal::layers::TimeoutLayer;
@@ -44,11 +43,6 @@ use tokio::runtime::Runtime;
 /// - If `opendal_{schema}_test` is on, construct a new Operator with given root.
 /// - Else, returns a `None` to represent no valid config for operator.
 pub fn init_service<B: Builder>() -> Option<Operator> {
-    let _ = tracing_subscriber::fmt()
-        .pretty()
-        .with_test_writer()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .try_init();
     let _ = dotenvy::dotenv();
 
     let prefix = format!("opendal_{}_", B::SCHEME);
@@ -64,7 +58,6 @@ pub fn init_service<B: Builder>() -> Option<Operator> {
     let turn_on_test = cfg.get("test").cloned().unwrap_or_default();
 
     if turn_on_test != "on" && turn_on_test != "true" {
-        warn!("service {} not initiated, ignored", B::SCHEME);
         return None;
     }
 

--- a/core/tests/behavior/write.rs
+++ b/core/tests/behavior/write.rs
@@ -34,7 +34,7 @@ use sha2::Sha256;
 
 use crate::*;
 
-pub fn behavior_write_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
+pub fn behavior_write_tests(op: &Operator) -> Vec<Trial> {
     let cap = op.info().capability();
 
     if !(cap.read && cap.write && cap.rename) {
@@ -42,7 +42,6 @@ pub fn behavior_write_tests(runtime: &Runtime, op: &Operator) -> Vec<Trial> {
     }
 
     async_trials!(
-        runtime,
         op,
         test_create_dir,
         test_create_dir_existing,


### PR DESCRIPTION
This PR implement the test harness via [libtest-mimic](https://github.com/LukasKalbertodt/libtest-mimic).

In the future, we will re-org our tests based on our new test harness. But in this PR, we just change the runner.