### PR TITLE
feat(bindings/haskell): support list and scan

### DIFF
--- a/bindings/haskell/haskell-src/OpenDAL.hs
+++ b/bindings/haskell/haskell-src/OpenDAL.hs
@@ -40,7 +40,6 @@ module OpenDAL (
   listOpRaw,
   scanOpRaw,
   nextLister,
-  allLister,
 ) where
 
 import Control.Monad.Except (ExceptT, runExceptT, throwError)
@@ -391,14 +390,3 @@ nextLister (Lister lister) = withForeignPtr lister $ \listerptr ->
         let code = parseErrorCode $ fromIntegral $ ffiCode ffiResult
         errMsg <- peekCString (errorMessage ffiResult)
         return $ Left $ OpenDALError code errMsg
-
-allLister :: Lister -> IO (Either OpenDALError [String])
-allLister = flip loop []
- where
-  loop :: Lister -> [String] -> IO (Either OpenDALError [String])
-  loop lister acc = do
-    next <- nextLister lister
-    case next of
-      Left err -> return $ Left err
-      Right Nothing -> return $ Right acc
-      Right (Just path) -> loop lister (path : acc)

--- a/bindings/haskell/haskell-src/OpenDAL.hs
+++ b/bindings/haskell/haskell-src/OpenDAL.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances #-}
 -- Licensed to the Apache Software Foundation (ASF) under one
 -- or more contributor license agreements.  See the NOTICE file
 -- distributed with this work for additional information
@@ -15,9 +16,11 @@
 -- specific language governing permissions and limitations
 -- under the License.
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 module OpenDAL (
   Operator,
+  Lister,
   OpenDALError (..),
   ErrorCode (..),
   EntryMode (..),
@@ -34,10 +37,14 @@ module OpenDAL (
   renameOpRaw,
   deleteOpRaw,
   statOpRaw,
+  listOpRaw,
+  scanOpRaw,
+  nextLister,
+  allLister,
 ) where
 
-import Control.Monad.Except (ExceptT, MonadError, runExceptT, throwError)
-import Control.Monad.Reader (MonadIO, MonadReader, ReaderT, ask, liftIO, runReaderT)
+import Control.Monad.Except (ExceptT, runExceptT, throwError)
+import Control.Monad.Reader (ReaderT, ask, liftIO, runReaderT)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.HashMap.Strict (HashMap)
@@ -49,6 +56,8 @@ import Foreign.C.String
 import OpenDAL.FFI
 
 newtype Operator = Operator (ForeignPtr RawOperator)
+
+newtype Lister = Lister (ForeignPtr RawLister)
 
 data ErrorCode
   = FFIError
@@ -81,15 +90,7 @@ data Metadata = Metadata
   }
   deriving (Eq, Show)
 
-newtype OpMonad a = OpMonad (ReaderT Operator (ExceptT OpenDALError IO) a)
-  deriving
-    ( Functor
-    , Applicative
-    , Monad
-    , MonadReader Operator
-    , MonadError OpenDALError
-    , MonadIO
-    )
+type OpMonad = ReaderT Operator (ExceptT OpenDALError IO)
 
 class (Monad m) => MonadOperation m where
   readOp :: String -> m ByteString
@@ -100,6 +101,8 @@ class (Monad m) => MonadOperation m where
   renameOp :: String -> String -> m ()
   deleteOp :: String -> m ()
   statOp :: String -> m Metadata
+  listOp :: String -> m Lister
+  scanOp :: String -> m Lister
 
 instance MonadOperation OpMonad where
   readOp path = do
@@ -133,6 +136,14 @@ instance MonadOperation OpMonad where
   statOp path = do
     op <- ask
     result <- liftIO $ statOpRaw op path
+    either throwError return result
+  listOp path = do
+    op <- ask
+    result <- liftIO $ listOpRaw op path
+    either throwError return result
+  scanOp path = do
+    op <- ask
+    result <- liftIO $ scanOpRaw op path
     either throwError return result
 
 -- helper functions
@@ -194,7 +205,7 @@ parseFFIMetadata (FFIMetadata mode cacheControl contentDisposition contentLength
 -- Exported functions
 
 runOp :: Operator -> OpMonad a -> IO (Either OpenDALError a)
-runOp operator (OpMonad op) = runExceptT $ runReaderT op operator
+runOp operator op = runExceptT $ runReaderT op operator
 
 newOp :: String -> HashMap String String -> IO (Either OpenDALError Operator)
 newOp scheme hashMap = do
@@ -334,3 +345,60 @@ statOpRaw (Operator op) path = withForeignPtr op $ \opptr ->
           let code = parseErrorCode $ fromIntegral $ ffiCode ffiResult
           errMsg <- peekCString (errorMessage ffiResult)
           return $ Left $ OpenDALError code errMsg
+
+listOpRaw :: Operator -> String -> IO (Either OpenDALError Lister)
+listOpRaw (Operator op) path = withForeignPtr op $ \opptr ->
+  withCString path $ \cPath ->
+    alloca $ \ffiResultPtr -> do
+      c_blocking_list opptr cPath ffiResultPtr
+      ffiResult <- peek ffiResultPtr
+      if ffiCode ffiResult == 0
+        then do
+          ffilister <- peek $ dataPtr ffiResult
+          lister <- Lister <$> (newForeignPtr c_free_lister ffilister)
+          return $ Right lister
+        else do
+          let code = parseErrorCode $ fromIntegral $ ffiCode ffiResult
+          errMsg <- peekCString (errorMessage ffiResult)
+          return $ Left $ OpenDALError code errMsg
+
+scanOpRaw :: Operator -> String -> IO (Either OpenDALError Lister)
+scanOpRaw (Operator op) path = withForeignPtr op $ \opptr ->
+  withCString path $ \cPath ->
+    alloca $ \ffiResultPtr -> do
+      c_blocking_scan opptr cPath ffiResultPtr
+      ffiResult <- peek ffiResultPtr
+      if ffiCode ffiResult == 0
+        then do
+          ffilister <- peek $ dataPtr ffiResult
+          lister <- Lister <$> (newForeignPtr c_free_lister ffilister)
+          return $ Right lister
+        else do
+          let code = parseErrorCode $ fromIntegral $ ffiCode ffiResult
+          errMsg <- peekCString (errorMessage ffiResult)
+          return $ Left $ OpenDALError code errMsg
+
+nextLister :: Lister -> IO (Either OpenDALError (Maybe String))
+nextLister (Lister lister) = withForeignPtr lister $ \listerptr ->
+  alloca $ \ffiResultPtr -> do
+    c_lister_next listerptr ffiResultPtr
+    ffiResult <- peek ffiResultPtr
+    if ffiCode ffiResult == 0
+      then do
+        val <- peek $ dataPtr ffiResult
+        Right <$> parseCString val
+      else do
+        let code = parseErrorCode $ fromIntegral $ ffiCode ffiResult
+        errMsg <- peekCString (errorMessage ffiResult)
+        return $ Left $ OpenDALError code errMsg
+
+allLister :: Lister -> IO (Either OpenDALError [String])
+allLister = flip loop []
+ where
+  loop :: Lister -> [String] -> IO (Either OpenDALError [String])
+  loop lister acc = do
+    next <- nextLister lister
+    case next of
+      Left err -> return $ Left err
+      Right Nothing -> return $ Right acc
+      Right (Just path) -> loop lister (path : acc)

--- a/bindings/haskell/haskell-src/OpenDAL/FFI.hs
+++ b/bindings/haskell/haskell-src/OpenDAL/FFI.hs
@@ -15,7 +15,6 @@
 -- specific language governing permissions and limitations
 -- under the License.
 {-# LANGUAGE ForeignFunctionInterface #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module OpenDAL.FFI where
 
@@ -24,6 +23,8 @@ import Foreign.C.String
 import Foreign.C.Types
 
 data RawOperator
+
+data RawLister
 
 data FFIResult a = FFIResult
   { ffiCode :: CUInt
@@ -141,3 +142,7 @@ foreign import ccall "blocking_copy" c_blocking_copy :: Ptr RawOperator -> CStri
 foreign import ccall "blocking_rename" c_blocking_rename :: Ptr RawOperator -> CString -> CString -> Ptr (FFIResult ()) -> IO ()
 foreign import ccall "blocking_delete" c_blocking_delete :: Ptr RawOperator -> CString -> Ptr (FFIResult ()) -> IO ()
 foreign import ccall "blocking_stat" c_blocking_stat :: Ptr RawOperator -> CString -> Ptr (FFIResult FFIMetadata) -> IO ()
+foreign import ccall "blocking_list" c_blocking_list :: Ptr RawOperator -> CString -> Ptr (FFIResult (Ptr RawLister)) -> IO ()
+foreign import ccall "blocking_scan" c_blocking_scan :: Ptr RawOperator -> CString -> Ptr (FFIResult (Ptr RawLister)) -> IO ()
+foreign import ccall "lister_next" c_lister_next :: Ptr RawLister -> Ptr (FFIResult CString) -> IO ()
+foreign import ccall "&free_lister" c_free_lister :: FunPtr (Ptr RawLister -> IO ())

--- a/bindings/haskell/opendal-hs.cabal
+++ b/bindings/haskell/opendal-hs.cabal
@@ -59,6 +59,7 @@ test-suite opendal-hs-test
         base,
         unordered-containers,
         mtl,
+        containers,
         opendal-hs,
         tasty,
         tasty-hunit

--- a/bindings/haskell/src/lib.rs
+++ b/bindings/haskell/src/lib.rs
@@ -444,6 +444,16 @@ pub unsafe extern "C" fn blocking_stat(
     *result = res;
 }
 
+/// # Safety
+///
+/// * `op` is a valid pointer to a `BlockingOperator`.
+/// * `path` is a valid pointer to a nul terminated string.
+/// * `result` is a valid pointer, and has available memory to write to
+///
+/// # Panics
+///
+/// * If `op` is not a valid pointer.
+/// * If `result` is not a valid pointer, or does not have available memory to write to.
 #[no_mangle]
 pub unsafe extern "C" fn blocking_list(
     op: *mut od::BlockingOperator,
@@ -473,6 +483,16 @@ pub unsafe extern "C" fn blocking_list(
     *result = res;
 }
 
+/// # Safety
+///
+/// * `op` is a valid pointer to a `BlockingOperator`.
+/// * `path` is a valid pointer to a nul terminated string.
+/// * `result` is a valid pointer, and has available memory to write to
+///
+/// # Panics
+///
+/// * If `op` is not a valid pointer.
+/// * If `result` is not a valid pointer, or does not have available memory to write to.
 #[no_mangle]
 pub unsafe extern "C" fn blocking_scan(
     op: *mut od::BlockingOperator,
@@ -502,6 +522,15 @@ pub unsafe extern "C" fn blocking_scan(
     *result = res;
 }
 
+/// # Safety
+///
+/// * `lister` is a valid pointer to a `BlockingLister`.
+/// * `result` is a valid pointer, and has available memory to write to
+///
+/// # Panics
+///
+/// * If `lister` is not a valid pointer.
+/// * If `result` is not a valid pointer, or does not have available memory to write to.
 #[no_mangle]
 pub unsafe extern "C" fn lister_next(
     lister: *mut BlockingLister,
@@ -526,6 +555,13 @@ pub unsafe extern "C" fn lister_next(
     *result = res;
 }
 
+/// # Safety
+///
+/// * `lister` is a valid pointer to a `BlockingLister`.
+///
+/// # Panics
+///
+/// * If `lister` is not a valid pointer.
 #[no_mangle]
 pub unsafe extern "C" fn free_lister(lister: *mut BlockingLister) {
     if !lister.is_null() {

--- a/bindings/haskell/src/lib.rs
+++ b/bindings/haskell/src/lib.rs
@@ -25,6 +25,7 @@ use std::os::raw::c_char;
 use std::str::FromStr;
 
 use ::opendal as od;
+use od::BlockingLister;
 use result::FFIResult;
 use types::ByteSlice;
 use types::Metadata;
@@ -437,8 +438,97 @@ pub unsafe extern "C" fn blocking_stat(
 
     let res = match op.stat(path_str) {
         Ok(meta) => FFIResult::ok(meta.into()),
-        Err(e) => FFIResult::err_with_source("Failed to delete", e),
+        Err(e) => FFIResult::err_with_source("Failed to stat", e),
     };
 
     *result = res;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn blocking_list(
+    op: *mut od::BlockingOperator,
+    path: *const c_char,
+    result: *mut FFIResult<*mut BlockingLister>,
+) {
+    let op = if op.is_null() {
+        *result = FFIResult::err("Operator is null");
+        return;
+    } else {
+        &mut *op
+    };
+
+    let path_str = match CStr::from_ptr(path).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            *result = FFIResult::err("Failed to convert scheme to string");
+            return;
+        }
+    };
+
+    let res = match op.list(path_str) {
+        Ok(lister) => FFIResult::ok(Box::into_raw(Box::new(lister))),
+        Err(e) => FFIResult::err_with_source("Failed to list", e),
+    };
+
+    *result = res;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn blocking_scan(
+    op: *mut od::BlockingOperator,
+    path: *const c_char,
+    result: *mut FFIResult<*mut BlockingLister>,
+) {
+    let op = if op.is_null() {
+        *result = FFIResult::err("Operator is null");
+        return;
+    } else {
+        &mut *op
+    };
+
+    let path_str = match CStr::from_ptr(path).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            *result = FFIResult::err("Failed to convert scheme to string");
+            return;
+        }
+    };
+
+    let res = match op.scan(path_str) {
+        Ok(lister) => FFIResult::ok(Box::into_raw(Box::new(lister))),
+        Err(e) => FFIResult::err_with_source("Failed to scan", e),
+    };
+
+    *result = res;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn lister_next(
+    lister: *mut BlockingLister,
+    result: *mut FFIResult<*const c_char>,
+) {
+    let lister = if lister.is_null() {
+        *result = FFIResult::err("Lister is null");
+        return;
+    } else {
+        &mut *lister
+    };
+
+    let res = match lister.next() {
+        Some(Ok(item)) => {
+            let res = types::leak_str(item.path());
+            FFIResult::ok(res)
+        }
+        Some(Err(e)) => FFIResult::err_with_source("Failed to get next item", e),
+        None => FFIResult::ok(std::ptr::null()),
+    };
+
+    *result = res;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn free_lister(lister: *mut BlockingLister) {
+    if !lister.is_null() {
+        drop(Box::from_raw(lister));
+    }
 }


### PR DESCRIPTION
Update:
- export `list` and `scan`
- add tests for `copy`, `rename`, `list`, `scan`
- fix error of trailling `\0` in `leak_str`
- refactor `OpMonad` from custom type to type synonym in order to provide more available ways

I imitate `DirStream` in `unix` library to design `Lister` API. However, it doesn't seem very native and useful. I havn't came up with other solutions about it yet. Maybe we can improve it in the future.