### PR TITLE
fix(types/operator): fix operation limit error default size

### DIFF
--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -83,7 +83,7 @@ impl Operator {
             .info()
             .capability()
             .batch_max_operations
-            .unwrap_or(100);
+            .unwrap_or(1000);
         Self { accessor, limit }
     }
 


### PR DESCRIPTION
base on comment https://github.com/apache/incubator-opendal/blob/main/core/src/types/operator/operator.rs#L102, default limit size must be 1000.