### PR TITLE
chore: add tests path to make publish workflow work

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -141,6 +141,7 @@ services-oss = [
   "reqsign?/services-aliyun",
   "reqsign?/reqwest_request",
 ]
+services-redb = ["dep:redb"]
 services-redis = ["dep:redis"]
 services-rocksdb = ["dep:rocksdb"]
 services-s3 = [
@@ -159,7 +160,6 @@ services-wasabi = [
 ]
 services-webdav = []
 services-webhdfs = []
-services-redb = ["dep:redb"]
 
 [lib]
 bench = false
@@ -171,6 +171,7 @@ name = "ops"
 [[test]]
 harness = false
 name = "behavior"
+path = "tests/behavior/main.rs"
 
 [dependencies]
 anyhow = { version = "1.0.30", features = ["std"] }
@@ -181,7 +182,10 @@ backon = "0.4.0"
 base64 = "0.21"
 bb8 = { version = "0.8", optional = true }
 bytes = "1.2"
-cacache =  { version = "11.6", default-features = false, features = ["tokio-runtime", "mmap"], optional = true }
+cacache = { version = "11.6", default-features = false, features = [
+  "tokio-runtime",
+  "mmap",
+], optional = true }
 chrono = "0.4.24"
 dashmap = { version = "5.4", optional = true }
 dirs = { version = "5.0.1", optional = true }
@@ -196,8 +200,8 @@ log = "0.4"
 madsim = { version = "0.2.21", optional = true }
 md-5 = "0.10"
 metrics = { version = "0.20", optional = true }
-minitrace = { version = "0.4.0", optional = true }
 mini-moka = { version = "0.10", optional = true }
+minitrace = { version = "0.4.0", optional = true }
 moka = { version = "0.10", optional = true, features = ["future"] }
 once_cell = "1"
 openssh = { version = "0.9.9", optional = true }
@@ -213,6 +217,7 @@ prometheus = { version = "0.13", features = ["process"], optional = true }
 prost = { version = "0.11", optional = true }
 quick-xml = { version = "0.27", features = ["serialize", "overlapped-lists"] }
 rand = { version = "0.8", optional = true }
+redb = { version = "1.0.0", optional = true }
 redis = { version = "0.22", features = [
   "tokio-comp",
   "connection-manager",
@@ -226,7 +231,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = { version = "0.10", optional = true }
 sled = { version = "0.34.7", optional = true }
-redb = { version = "1.0.0", optional = true }
 suppaftp = { version = "4.5", default-features = false, features = [
   "async-secure",
   "async-rustls",


### PR DESCRIPTION
I'm not sure what happened, but configuring `tests.path` should at least ensure that opendal core enters the publish workflow.

Other changes are caused by `taplo fmt` and can be ignored.

fix https://github.com/apache/incubator-opendal/actions/runs/5391859099/jobs/9789526157