### PR TITLE
chore: add haskell binding link to website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -133,6 +133,10 @@ const config = {
                 label: 'Lua Binding',
                 to: 'pathname:///docs/lua/'
               },
+              {
+                label: 'Haskell Binding',
+                to: 'pathname:///docs/haskell/'
+              }
             ]
           },
           {


### PR DESCRIPTION
I forgot to update `docusaurus.config.js` to add a link for haskell binding in #2569 