### PR TITLE
ci: upgrade hawkeye to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Check license headers
-        uses: korandoru/hawkeye@v2.1.0
+        uses: korandoru/hawkeye@v3.0.1
 
       - name: Cargo format
         run: cargo fmt --all -- --check

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -36,10 +36,3 @@ excludes = [
   "**/*.md",
   "**/*.mdx",
 ]
-
-[properties]
-inceptionYear = 2023
-
-[mapping.SLASHSTAR_STYLE]
-# use SLASH_STAR_STYLE licence header for C/C++ and C# code
-extensions = ["c", "cc", "cpp", "h", "hpp", "cs"]

--- a/website/src/components/HomepageFeatures/styles.module.css
+++ b/website/src/components/HomepageFeatures/styles.module.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 .features {
   display: flex;
   align-items: center;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 /**
  * Any CSS included here will be global. The classic template
  * bundles Infima by default. Infima is a CSS framework designed to

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 /**
  * CSS files with the .module.css suffix will be treated as CSS modules
  * and scoped locally.


### PR DESCRIPTION
This closes https://github.com/apache/incubator-opendal/pull/2584.

It actually comes from the idea to follow the previous suggestion in C header style, lol.