### PR TITLE
chore: fix cargo warning for resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
   "bin/oli",
   "bin/oay",
 ]
+resolver = "2"
 
 [workspace.package]
 authors = ["OpenDAL Contributors <dev@opendal.apache.org>"]


### PR DESCRIPTION
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest

As a library, this isn't important as end-user application decides the resolver finally. Just remove the warning.

ref:
- https://github.com/rust-lang/cargo/issues/10112
- https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions