### PR TITLE
test(oli): add oli related tests

### DIFF
--- a/bin/oli/tests/cat.rs
+++ b/bin/oli/tests/cat.rs
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::Result;
+use assert_cmd::prelude::*;
+
+#[tokio::test]
+async fn test_basic_cat() -> Result<()> {
+    let dir = env::temp_dir();
+    fs::create_dir_all(dir.clone())?;
+    let dst_path = Path::new(&dir).join("dst.txt");
+    let expect = "hello";
+    fs::write(&dst_path, expect)?;
+
+    let mut cmd = Command::cargo_bin("oli")?;
+
+    cmd.arg("cat").arg(dst_path.as_os_str());
+    let actual = fs::read_to_string(&dst_path)?;
+    let res = cmd.assert().success();
+    let output = res.get_output().stdout.clone();
+
+    let output_stdout = String::from_utf8(output)?;
+
+    assert_eq!(output_stdout, actual);
+    Ok(())
+}

--- a/bin/oli/tests/ls.rs
+++ b/bin/oli/tests/ls.rs
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::Result;
+use assert_cmd::prelude::*;
+
+#[tokio::test]
+async fn test_basic_cat() -> Result<()> {
+    let dir = env::temp_dir();
+    fs::create_dir_all(dir.clone())?;
+    let dst_path_1 = Path::new(&dir).join("dst_1.txt");
+    let dst_path_2 = Path::new(&dir).join("dst_2.txt");
+    let dst_path_3 = Path::new(&dir).join("dst_3.txt");
+
+    let expect = "hello";
+    fs::write(&dst_path_1, expect)?;
+    fs::write(&dst_path_2, expect)?;
+    fs::write(&dst_path_3, expect)?;
+
+    let mut cmd = Command::cargo_bin("oli")?;
+
+    let current_dir = dir.to_str().unwrap().to_string() + "/";
+
+    cmd.arg("ls").arg( current_dir );
+    let res = cmd.assert().success();
+    let output = res.get_output().stdout.clone();
+
+    let output_stdout = String::from_utf8(output)?;
+
+    assert!(output_stdout.contains("dst_1.txt"));
+    assert!(output_stdout.contains("dst_2.txt"));
+    assert!(output_stdout.contains("dst_3.txt"));
+
+    Ok(())
+}

--- a/bin/oli/tests/ls.rs
+++ b/bin/oli/tests/ls.rs
@@ -32,9 +32,9 @@ async fn test_basic_cat() -> Result<()> {
     let dst_path_3 = Path::new(&dir).join("dst_3.txt");
 
     let expect = "hello";
-    fs::write(&dst_path_1, expect)?;
-    fs::write(&dst_path_2, expect)?;
-    fs::write(&dst_path_3, expect)?;
+    fs::write(dst_path_1, expect)?;
+    fs::write(dst_path_2, expect)?;
+    fs::write(dst_path_3, expect)?;
 
     let mut cmd = Command::cargo_bin("oli")?;
 

--- a/bin/oli/tests/ls.rs
+++ b/bin/oli/tests/ls.rs
@@ -40,7 +40,7 @@ async fn test_basic_cat() -> Result<()> {
 
     let current_dir = dir.to_str().unwrap().to_string() + "/";
 
-    cmd.arg("ls").arg( current_dir );
+    cmd.arg("ls").arg(current_dir);
     let res = cmd.assert().success();
     let output = res.get_output().stdout.clone();
 

--- a/bin/oli/tests/rm.rs
+++ b/bin/oli/tests/rm.rs
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::Result;
+use assert_cmd::prelude::*;
+
+#[tokio::test]
+async fn test_basic_rm() -> Result<()> {
+    let dir = env::temp_dir();
+    fs::create_dir_all(dir.clone())?;
+    let dst_path = Path::new(&dir).join("dst.txt");
+    let expect = "hello";
+    fs::write(&dst_path, expect)?;
+
+    let mut cmd = Command::cargo_bin("oli")?;
+
+    cmd.arg("rm")
+        .arg(dst_path.as_os_str());
+    cmd.assert().success();
+
+    assert_eq!(fs::read_to_string(&dst_path).is_err(), true);
+    Ok(())
+}

--- a/bin/oli/tests/rm.rs
+++ b/bin/oli/tests/rm.rs
@@ -33,8 +33,7 @@ async fn test_basic_rm() -> Result<()> {
 
     let mut cmd = Command::cargo_bin("oli")?;
 
-    cmd.arg("rm")
-        .arg(dst_path.as_os_str());
+    cmd.arg("rm").arg(dst_path.as_os_str());
     cmd.assert().success();
 
     assert_eq!(fs::read_to_string(&dst_path).is_err(), true);

--- a/bin/oli/tests/rm.rs
+++ b/bin/oli/tests/rm.rs
@@ -36,6 +36,6 @@ async fn test_basic_rm() -> Result<()> {
     cmd.arg("rm").arg(dst_path.as_os_str());
     cmd.assert().success();
 
-    assert_eq!(fs::read_to_string(&dst_path).is_err(), true);
+    assert!(fs::read_to_string(&dst_path).is_err());
     Ok(())
 }

--- a/bin/oli/tests/stat.rs
+++ b/bin/oli/tests/stat.rs
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::Result;
+use assert_cmd::prelude::*;
+
+#[tokio::test]
+async fn test_basic_stat() -> Result<()> {
+    let dir = env::temp_dir();
+    fs::create_dir_all(dir.clone())?;
+    let dst_path = Path::new(&dir).join("dst.txt");
+    let expect = "hello";
+    fs::write(&dst_path, expect)?;
+
+    let mut cmd = Command::cargo_bin("oli")?;
+
+    cmd.arg("stat").arg(dst_path.as_os_str());
+    let res = cmd.assert().success();
+    let output = res.get_output().stdout.clone();
+
+    let output_stdout = String::from_utf8(output)?;
+    assert!(output_stdout.contains("path: tmp/dst.txt"));
+    assert!(output_stdout.contains("size: 5"));
+    assert!(output_stdout.contains("type: file"));
+    assert!(output_stdout.contains("last-modified: "));
+
+    Ok(())
+}


### PR DESCRIPTION
add `cat` `stat` `ls` `rm` sub command test.