### PR TITLE
add detect_region code for S3Builder

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -517,6 +517,17 @@ impl S3Builder {
 
         self
     }
+
+    /// a helper function to make it easier to find region
+    fn detect_region(&self) -> Result<Option<String>> {
+        match &self.region {
+            Some(region) => Ok(Some(region.to_string())),
+            None => Err(Error::new(
+                ErrorKind::ConfigInvalid,
+                "region is None in S3Builder",
+            )),
+        }
+    }
 }
 
 impl Builder for S3Builder {


### PR DESCRIPTION
close #2632

I am newer for `OpenDAL` and this is my first PR for `OpenDAL`.

Now the test case for `detect_region` is not added. 

I am confusing how to build a `S3Builder` with custom `region`, default is None, and use `region(str)` function needs the `S3Builder` has a custom `region`.

BTW, how check `Error` in test case, I try use `assert_eq!()` for check `Error`, it failed.

Thanks for helping.