### PR TITLE
refactor(core): Add ErrorKind InvalidInput to indicate users input error

### DIFF
--- a/core/src/raw/oio/cursor.rs
+++ b/core/src/raw/oio/cursor.rs
@@ -84,7 +84,7 @@ impl oio::Read for Cursor {
             Some(n) if n >= 0 => n as u64,
             _ => {
                 return Poll::Ready(Err(Error::new(
-                    ErrorKind::Unexpected,
+                    ErrorKind::InvalidInput,
                     "invalid seek to a negative or overflowing position",
                 )))
             }
@@ -127,7 +127,7 @@ impl oio::BlockingRead for Cursor {
             Some(n) if n >= 0 => n as u64,
             _ => {
                 return Err(Error::new(
-                    ErrorKind::Unexpected,
+                    ErrorKind::InvalidInput,
                     "invalid seek to a negative or overflowing position",
                 ))
             }

--- a/core/src/raw/oio/into_blocking_reader/from_fd.rs
+++ b/core/src/raw/oio/into_blocking_reader/from_fd.rs
@@ -90,7 +90,7 @@ where
 
         match base.checked_add(offset) {
             Some(n) if n < 0 => Err(Error::new(
-                ErrorKind::Unexpected,
+                ErrorKind::InvalidInput,
                 "invalid seek to a negative or overflowing position",
             )),
             Some(n) => {
@@ -104,7 +104,7 @@ where
                 Ok(self.offset - self.start)
             }
             None => Err(Error::new(
-                ErrorKind::Unexpected,
+                ErrorKind::InvalidInput,
                 "invalid seek to a negative or overflowing position",
             )),
         }

--- a/core/src/raw/oio/into_reader/by_range.rs
+++ b/core/src/raw/oio/into_reader/by_range.rs
@@ -114,7 +114,7 @@ impl<A: Accessor> RangeReader<A> {
             Some(n) if n >= 0 => n as u64,
             _ => {
                 return Err(Error::new(
-                    ErrorKind::Unexpected,
+                    ErrorKind::InvalidInput,
                     "invalid seek to a negative or overflowing position",
                 ))
             }

--- a/core/src/raw/oio/into_reader/from_fd.rs
+++ b/core/src/raw/oio/into_reader/from_fd.rs
@@ -93,7 +93,7 @@ where
 
         match base.checked_add(offset) {
             Some(n) if n < 0 => Poll::Ready(Err(Error::new(
-                ErrorKind::Unexpected,
+                ErrorKind::InvalidInput,
                 "invalid seek to a negative or overflowing position",
             ))),
             Some(n) => {
@@ -109,7 +109,7 @@ where
                 Poll::Ready(Ok(self.offset - self.start))
             }
             None => Poll::Ready(Err(Error::new(
-                ErrorKind::Unexpected,
+                ErrorKind::InvalidInput,
                 "invalid seek to a negative or overflowing position",
             ))),
         }

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -99,6 +99,10 @@ pub enum ErrorKind {
     /// - Users expected to read 1024 bytes, but service returned less bytes.
     /// - Service expected to write 1024 bytes, but users write less bytes.
     ContentIncomplete,
+    /// The input is invalid.
+    /// 
+    /// For example, user try to seek to a negative position
+    InvalidInput, 
 }
 
 impl ErrorKind {
@@ -130,6 +134,7 @@ impl From<ErrorKind> for &'static str {
             ErrorKind::ConditionNotMatch => "ConditionNotMatch",
             ErrorKind::ContentTruncated => "ContentTruncated",
             ErrorKind::ContentIncomplete => "ContentIncomplete",
+            ErrorKind::InvalidInput => "InvalidInput",
         }
     }
 }

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -100,9 +100,9 @@ pub enum ErrorKind {
     /// - Service expected to write 1024 bytes, but users write less bytes.
     ContentIncomplete,
     /// The input is invalid.
-    /// 
+    ///
     /// For example, user try to seek to a negative position
-    InvalidInput, 
+    InvalidInput,
 }
 
 impl ErrorKind {


### PR DESCRIPTION
If user try to seek for a invalid position, we will give an `Unexpected` Error. `Unexpected` Error used to represent `OpenDAL don't know what happened here`. I think it may be better to use a new error kind `InvalidInput` to represent this situation.

```
    /// OpenDAL don't know what happened here, and no actions other than just
    /// returning it back. For example, s3 returns an internal service error.
    Unexpected,
```

before:
```
  2023-07-14T06:37:19.152933Z ERROR opendal::services: service=memory operation=Reader::seek path=bfae56eb-ae99-4ca6-b000-4bdad69c85e1 read=0 -> data read failed: Unexpected (permanent) at Reader::seek => invalid seek to a negative or overflowing position

Context:
    service: memory
    path: bfae56eb-ae99-4ca6-b000-4bdad69c85e1

    at core/src/layers/logging.rs:1108

```
after:
```
  2023-07-14T07:50:38.166551Z ERROR opendal::services: service=memory operation=Reader::seek path=0fca6ade-8d96-44fc-ac5b-86a370b26048 read=0 -> data read failed: InvalidInput (permanent) at Reader::seek => invalid seek to a negative or overflowing position

Context:
    service: memory
    path: 0fca6ade-8d96-44fc-ac5b-86a370b26048

    at core/src/layers/logging.rs:1108
    
```

related:https://github.com/apache/incubator-opendal/issues/2636#issuecomment-1635362220
fix: #2636 