### PR TITLE
feat(services/persy): add a basic persy service impl

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,11 @@ OPENDAL_REDB_TABLE=redb-table
 # cacache
 OPENDAL_CACACHE_TEST=false
 OPENDAL_CACACHE_DATADIR=/tmp/opendal/cacache/
+# persy
+OPENDAL_PERSY_TEST=false
+OPENDAL_PERSY_DATAFILE=/tmp/opendal/test.persy
+OPENDAL_PERSY_SEGMENT=data
+OPENDAL_PERSY_INDEX=index
 #dropbox
 OPENDAL_DROPBOX_TEST=false
 OPENDAL_DROPBOX_ROOT=/tmp/opendal/

--- a/.github/workflows/service_test_persy.yml
+++ b/.github/workflows/service_test_persy.yml
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Service Test Persy
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "core/src/**"
+      - "core/tests/**"
+      - "!core/src/docs/**"
+      - "!core/src/services/**"
+      - "core/src/services/persy/**"
+      - ".github/workflows/service_test_persy.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  persy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup
+      - name: Test persy
+        shell: bash
+        working-directory: core
+        run: cargo test persy --features services-persy -j=1
+        env:
+          RUST_BACKTRACE: full
+          RUST_LOG: debug
+          OPENDAL_PERSY_TEST: on
+          OPENDAL_PERSY_DATAFILE: ./test.persy
+          OPENDAL_PERSY_SEGMENT: data
+          OPENDAL_PERSY_INDEX: index

--- a/.github/workflows/service_test_persy.yml
+++ b/.github/workflows/service_test_persy.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test persy
         shell: bash
         working-directory: core
-        run: cargo test persy --features services-persy -j=1
+        run: cargo test persy --features services-persy
         env:
           RUST_BACKTRACE: full
           RUST_LOG: debug

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,6 +927,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,6 +2877,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "paste",
  "percent-encoding",
+ "persy",
  "pin-project",
  "pretty_assertions",
  "prometheus",
@@ -3339,6 +3355,22 @@ name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "persy"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3712821f12453814409ec149071bd4832a8ec458e648579c104aee30ed70b300"
+dependencies = [
+ "crc",
+ "data-encoding",
+ "fs2",
+ "linked-hash-map",
+ "rand 0.8.5",
+ "thiserror",
+ "unsigned-varint",
+ "zigzag",
+]
 
 [[package]]
 name = "pin-project"
@@ -5328,6 +5360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
 
 [[package]]
+name = "unsigned-varint"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5813,3 +5851,12 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[package]]
+name = "zigzag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b40401a28d86ce16a330b863b86fd7dbee4d7c940587ab09ab8c019f9e3fdf"
+dependencies = [
+ "num-traits",
+]

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Major components of the project include:
 - cacache: [cacache](https://crates.io/crates/cacache) backend
 - dashmap: [dashmap](https://github.com/xacrimon/dashmap) backend
 - memory: In memory backend
+- persy: [persy](https://crates.io/crates/persy) backend
 - redis: [Redis](https://redis.io/) services
 - rocksdb: [RocksDB](http://rocksdb.org/) services
 - sled: [sled](https://crates.io/crates/sled) backend

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -50,6 +50,7 @@ default = [
   "services-s3",
   "services-webdav",
   "services-webhdfs",
+  "services-persy"
 ]
 
 # Build docs or not.
@@ -141,6 +142,7 @@ services-oss = [
   "reqsign?/services-aliyun",
   "reqsign?/reqwest_request",
 ]
+services-persy = ["dep:persy"]
 services-redb = ["dep:redb"]
 services-redis = ["dep:redis"]
 services-rocksdb = ["dep:rocksdb"]
@@ -212,6 +214,7 @@ openssh-sftp-client = { version = "0.13.5", optional = true, features = [
 opentelemetry = { version = "0.19.0", optional = true }
 parking_lot = "0.12"
 percent-encoding = "2"
+persy = { version = "1.4.4", optional = true }
 pin-project = "1"
 prometheus = { version = "0.13", features = ["process"], optional = true }
 prost = { version = "0.11", optional = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -50,7 +50,6 @@ default = [
   "services-s3",
   "services-webdav",
   "services-webhdfs",
-  "services-persy"
 ]
 
 # Build docs or not.

--- a/core/README.md
+++ b/core/README.md
@@ -67,6 +67,7 @@
 - cacache: [cacache](https://crates.io/crates/cacache) backend
 - dashmap: [dashmap](https://github.com/xacrimon/dashmap) backend
 - memory: In memory backend
+- persy: [persy](https://crates.io/crates/persy) backend
 - redis: [Redis](https://redis.io/) services
 - rocksdb: [RocksDB](http://rocksdb.org/) services
 - sled: [sled](https://crates.io/crates/sled) backend

--- a/core/src/services/mod.rs
+++ b/core/src/services/mod.rs
@@ -114,6 +114,11 @@ mod cacache;
 #[cfg(feature = "services-cacache")]
 pub use self::cacache::Cacache;
 
+#[cfg(feature = "services-persy")]
+mod persy;
+#[cfg(feature = "services-persy")]
+pub use self::persy::Persy;
+
 #[cfg(feature = "services-redis")]
 mod redis;
 #[cfg(feature = "services-redis")]

--- a/core/src/services/persy/backend.rs
+++ b/core/src/services/persy/backend.rs
@@ -89,7 +89,7 @@ impl Builder for PersyBuilder {
 
         let segment = segment_name.clone();
 
-        let index_name  = self.index.take().ok_or_else(|| {
+        let index_name = self.index.take().ok_or_else(|| {
             Error::new(ErrorKind::ConfigInvalid, "index is required but not set")
                 .with_context("service", Scheme::Persy)
         })?;
@@ -108,7 +108,11 @@ impl Builder for PersyBuilder {
             })?;
 
         // This function will only be called on database creation
-        fn init(persy: &persy::Persy, segment_name: &str, index_name: &str) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        fn init(
+            persy: &persy::Persy,
+            segment_name: &str,
+            index_name: &str,
+        ) -> std::result::Result<(), Box<dyn std::error::Error>> {
             let mut tx = persy.begin()?;
 
             if !tx.exists_segment(segment_name)? {

--- a/core/src/services/persy/backend.rs
+++ b/core/src/services/persy/backend.rs
@@ -125,7 +125,6 @@ impl Builder for PersyBuilder {
             let prepared = tx.prepare()?;
             prepared.commit()?;
 
-            println!("Segment and Index successfully created");
             Ok(())
         }
 
@@ -218,14 +217,14 @@ impl kv::Adapter for Adapter {
             .get::<String, persy::PersyId>(&self.index, &path.to_string())
             .map_err(parse_error)?;
         if let Some(id) = delete_id.next() {
-            //Begin a transaction
+            // Begin a transaction.
             let mut tx = self.persy.begin().map_err(parse_error)?;
-            // delete the record
+            // Delete the record.
             tx.delete(&self.segment, &id).map_err(parse_error)?;
-            // remove the index
+            // Remove the index.
             tx.remove::<String, persy::PersyId>(&self.index, path.to_string(), Some(id))
                 .map_err(parse_error)?;
-            //Commit the tx.
+            // Commit the tx.
             let prepared = tx.prepare().map_err(parse_error)?;
             prepared.commit().map_err(parse_error)?;
         }

--- a/core/src/services/persy/backend.rs
+++ b/core/src/services/persy/backend.rs
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::str;
+
+use async_trait::async_trait;
+use persy;
+
+use crate::raw::adapters::kv;
+use crate::Builder;
+use crate::Error;
+use crate::ErrorKind;
+use crate::Scheme;
+use crate::*;
+
+/// persy service support.
+#[doc = include_str!("docs.md")]
+#[derive(Default)]
+pub struct PersyBuilder {
+    /// That path to the persy data file.
+    datafile: Option<String>,
+}
+
+impl PersyBuilder {
+    /// Set the path to the persy data directory. Will create if not exists.
+    pub fn datafile(&mut self, path: &str) -> &mut Self {
+        self.datafile = Some(path.into());
+        self
+    }
+}
+
+impl Builder for PersyBuilder {
+    const SCHEME: Scheme = Scheme::Persy;
+    type Accessor = PersyBackend;
+
+    fn from_map(map: HashMap<String, String>) -> Self {
+        let mut builder = PersyBuilder::default();
+
+        map.get("datafile").map(|v| builder.datafile(v));
+
+        builder
+    }
+
+    fn build(&mut self) -> Result<Self::Accessor> {
+        let datafile_path = self.datafile.take().ok_or_else(|| {
+            Error::new(ErrorKind::ConfigInvalid, "datafile is required but not set")
+                .with_context("service", Scheme::Persy)
+        })?;
+
+        let persy = persy::Persy::open(&datafile_path, persy::Config::new()).map_err(|e| {
+            Error::new(ErrorKind::ConfigInvalid, "open db")
+                .with_context("service", Scheme::Persy)
+                .with_context("datafile", datafile_path.clone())
+                .set_source(e)
+        })?;
+
+        Ok(PersyBackend::new(Adapter {
+            datafile: datafile_path,
+            persy,
+        }))
+    }
+}
+
+/// Backend for persy services.
+pub type PersyBackend = kv::Backend<Adapter>;
+
+#[derive(Clone)]
+pub struct Adapter {
+    datafile: String,
+    persy: persy::Persy,
+}
+
+impl Debug for Adapter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut ds = f.debug_struct("Adapter");
+        ds.field("path", &self.datafile);
+        ds.finish()
+    }
+}
+
+#[async_trait]
+impl kv::Adapter for Adapter {
+    fn metadata(&self) -> kv::Metadata {
+        kv::Metadata::new(
+            Scheme::Persy,
+            &self.datafile,
+            Capability {
+                read: true,
+                write: true,
+                delete: true,
+                blocking: true,
+                ..Default::default()
+            },
+        )
+    }
+
+    async fn get(&self, path: &str) -> Result<Option<Vec<u8>>> {
+        self.blocking_get(path)
+    }
+
+    fn blocking_get(&self, path: &str) -> Result<Option<Vec<u8>>> {
+        match self.persy.scan(path) {
+            Ok(bs) => {
+                let mut value = vec![];
+                for (_id, content) in bs {
+                    value = content;
+                }
+                Ok(Some(value))
+            }
+            Err(_) => Ok(None),
+        }
+    }
+
+    async fn set(&self, path: &str, value: &[u8]) -> Result<()> {
+        self.blocking_set(path, value)
+    }
+
+    fn blocking_set(&self, path: &str, value: &[u8]) -> Result<()> {
+        let mut tx = self
+            .persy
+            .begin()
+            .map_err(|e| parse_error(e.persy_error()))?;
+        tx.insert(path, value)
+            .map_err(|e| parse_error(e.persy_error()))?;
+        let prepared = tx.prepare().map_err(|e| parse_error(e.persy_error()))?;
+        prepared
+            .commit()
+            .map_err(|e| parse_error(e.persy_error()))?;
+
+        Ok(())
+    }
+
+    async fn delete(&self, path: &str) -> Result<()> {
+        self.blocking_delete(path)
+    }
+
+    fn blocking_delete(&self, path: &str) -> Result<()> {
+        let mut tx = self
+            .persy
+            .begin()
+            .map_err(|e| parse_error(e.persy_error()))?;
+        for (id, _content) in self
+            .persy
+            .scan(path)
+            .map_err(|e| parse_error(e.persy_error()))?
+        {
+            tx.delete(path, &id)
+                .map_err(|e| parse_error(e.persy_error()))?;
+        }
+        let prepared = tx.prepare().map_err(|e| parse_error(e.persy_error()))?;
+        prepared
+            .commit()
+            .map_err(|e| parse_error(e.persy_error()))?;
+
+        Ok(())
+    }
+}
+
+fn parse_error(err: persy::PersyError) -> Error {
+    let kind = match err {
+        persy::PersyError::RecordNotFound(_) => ErrorKind::NotFound,
+        _ => ErrorKind::Unexpected,
+    };
+
+    Error::new(kind, "error from persy").set_source(err)
+}

--- a/core/src/services/persy/docs.md
+++ b/core/src/services/persy/docs.md
@@ -1,0 +1,40 @@
+## Capabilities
+
+This service can be used to:
+
+- [x] stat
+- [x] read
+- [x] write
+- [x] create_dir
+- [x] delete
+- [ ] copy
+- [ ] rename
+- [ ] list
+- [ ] ~~scan~~
+- [ ] ~~presign~~
+- [x] blocking
+
+## Configuration
+
+- `datadir`: Set the path to the cacache data directory
+
+You can refer to [`CacacheBuilder`]'s docs for more information
+
+## Example
+
+### Via Builder
+
+```rust
+use anyhow::Result;
+use opendal::services::Cacache;
+use opendal::Operator;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut builder = Cacache::default();
+    builder.datadir("/tmp/opendal/cacache");
+
+    let op: Operator = Operator::new(builder)?.finish();
+    Ok(())
+}
+```

--- a/core/src/services/persy/docs.md
+++ b/core/src/services/persy/docs.md
@@ -16,9 +16,11 @@ This service can be used to:
 
 ## Configuration
 
-- `datadir`: Set the path to the cacache data directory
+- `datafile`: Set the path to the persy data file. The directory in the path must already exist.
+- `segment`: Set the name of the persy segment.
+- `index`: Set the name of the persy index.
 
-You can refer to [`CacacheBuilder`]'s docs for more information
+You can refer to [`PersyBuilder`]'s docs for more information
 
 ## Example
 
@@ -26,13 +28,15 @@ You can refer to [`CacacheBuilder`]'s docs for more information
 
 ```rust
 use anyhow::Result;
-use opendal::services::Cacache;
+use opendal::services::Persy;
 use opendal::Operator;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let mut builder = Cacache::default();
-    builder.datadir("/tmp/opendal/cacache");
+    let mut builder = Persy::default();
+    builder.datafile("./test.persy");
+    builder.segment("data");
+    builder.index("index");
 
     let op: Operator = Operator::new(builder)?.finish();
     Ok(())

--- a/core/src/services/persy/mod.rs
+++ b/core/src/services/persy/mod.rs
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+mod backend;
+
+pub use backend::PersyBuilder as Persy;

--- a/core/src/types/operator/builder.rs
+++ b/core/src/types/operator/builder.rs
@@ -195,6 +195,8 @@ impl Operator {
             Scheme::Gdrive => Self::from_map::<services::Gdrive>(map)?.finish(),
             #[cfg(feature = "services-oss")]
             Scheme::Oss => Self::from_map::<services::Oss>(map)?.finish(),
+            #[cfg(feature = "services-persy")]
+            Scheme::Persy => Self::from_map::<services::Persy>(map)?.finish(),
             #[cfg(feature = "services-redis")]
             Scheme::Redis => Self::from_map::<services::Redis>(map)?.finish(),
             #[cfg(feature = "services-rocksdb")]

--- a/core/src/types/scheme.rs
+++ b/core/src/types/scheme.rs
@@ -76,6 +76,8 @@ pub enum Scheme {
     Dropbox,
     /// [oss][crate::services::Oss]: Aliyun Object Storage Services
     Oss,
+    /// [persy][crate::services::Persy]: persy backend support.
+    Persy,
     /// [redis][crate::services::Redis]: Redis services
     Redis,
     /// [rocksdb][crate::services::Rocksdb]: RocksDB services
@@ -150,6 +152,7 @@ impl FromStr for Scheme {
             "mini_moka" => Ok(Scheme::MiniMoka),
             "moka" => Ok(Scheme::Moka),
             "obs" => Ok(Scheme::Obs),
+            "persy" => Ok(Scheme::Persy),
             "redis" => Ok(Scheme::Redis),
             "rocksdb" => Ok(Scheme::Rocksdb),
             "s3" => Ok(Scheme::S3),
@@ -187,6 +190,7 @@ impl From<Scheme> for &'static str {
             Scheme::Moka => "moka",
             Scheme::Obs => "obs",
             Scheme::Onedrive => "onedrive",
+            Scheme::Persy => "persy",
             Scheme::Gdrive => "gdrive",
             Scheme::Dropbox => "dropbox",
             Scheme::Redis => "redis",

--- a/core/tests/behavior/main.rs
+++ b/core/tests/behavior/main.rs
@@ -138,6 +138,8 @@ fn main() -> anyhow::Result<()> {
     tests.extend(behavior_test::<services::Dropbox>());
     #[cfg(feature = "services-oss")]
     tests.extend(behavior_test::<services::Oss>());
+    #[cfg(feature = "services-persy")]
+    tests.extend(behavior_test::<services::Persy>());
     #[cfg(feature = "services-redis")]
     tests.extend(behavior_test::<services::Redis>());
     #[cfg(feature = "services-rocksdb")]

--- a/website/src/components/HomepageFeatures/_feature_services.mdx
+++ b/website/src/components/HomepageFeatures/_feature_services.mdx
@@ -49,6 +49,7 @@ Apache OpenDAL provides native support for all kinds for storage systems.
 - cacache: [cacache](https://crates.io/crates/cacache) backend
 - dashmap: [dashmap](https://github.com/xacrimon/dashmap) backend
 - memory: In memory backend
+- persy: [persy](https://crates.io/crates/persy) backend
 - redis: [Redis](https://redis.io/) services
 - rocksdb: [RocksDB](http://rocksdb.org/) services
 - sled: [sled](https://crates.io/crates/sled) backend


### PR DESCRIPTION
This PR has initially implemented support for the persy backend, and added corresponding CI and documentation.

```
# persy
OPENDAL_PERSY_TEST=false
## That path to the persy data file. The directory in the path must already exist.
OPENDAL_PERSY_DATAFILE=/tmp/opendal/test.persy
OPENDAL_PERSY_SEGMENT=data
OPENDAL_PERSY_INDEX=index
```

Fixes: #2522 