### PR TITLE
test(bindings/c): Implement valgrind check in test and ci

### DIFF
--- a/.github/workflows/bindings_c.yml
+++ b/.github/workflows/bindings_c.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install gtest manually
         run: |
-          sudo apt-get install libgtest-dev
+          sudo apt-get install libgtest-dev valgrind
           cd /usr/src/gtest
           sudo cmake CMakeLists.txt
           sudo make

--- a/bindings/c/Makefile
+++ b/bindings/c/Makefile
@@ -25,6 +25,8 @@ LDFLAGS=-L$(RPATH) -Wl,-rpath,$(RPATH)
 
 LIBS=-lopendal_c -lgtest -lpthread
 
+VALGRIND=valgrind --error-exitcode=1 -- 
+
 .PHONY: all
 all: build test examples
 
@@ -42,8 +44,8 @@ build:
 test:
 	$(CXX) tests/bdd.cpp -o $(OBJ_DIR)/bdd $(CXXFLAGS) $(LDFLAGS) $(LIBS)
 	$(CXX) tests/list.cpp -o $(OBJ_DIR)/list $(CXXFLAGS) $(LDFLAGS) $(LIBS)
-	$(OBJ_DIR)/bdd
-	$(OBJ_DIR)/list
+	$(VALGRIND) $(OBJ_DIR)/bdd
+	$(VALGRIND) $(OBJ_DIR)/list
 
 .PHONY: doc
 doc:

--- a/bindings/c/Makefile
+++ b/bindings/c/Makefile
@@ -25,7 +25,7 @@ LDFLAGS=-L$(RPATH) -Wl,-rpath,$(RPATH)
 
 LIBS=-lopendal_c -lgtest -lpthread
 
-VALGRIND=valgrind --error-exitcode=1 -- 
+VALGRIND=valgrind --error-exitcode=1 --leak-check=full -- 
 
 .PHONY: all
 all: build test examples


### PR DESCRIPTION
This is for issue #2495 
Note that it currently breaks the ci testing because it has found memory leaks