### PR TITLE
fix(test): profile setting warning

### DIFF
--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -35,9 +35,6 @@ sha2 = { version = "0.10.6" }
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1.3.0", features = ["v4"] }
 
-[profile.release]
-debug = 1
-
 [[bin]]
 doc = false
 name = "fuzz_reader"


### PR DESCRIPTION
I found that https://github.com/apache/incubator-opendal/actions/runs/5573356275/jobs/10180524092  made cargo give our a warning 
```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /githubProjects/incubator-opendal/core/fuzz/Cargo.toml
workspace: /githubProjects/incubator-opendal/Cargo.toml
```
**This pr remove the profile setting to fix this warning.**