### PR TITLE
ci: Setup protoc in rust builder

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -39,6 +39,9 @@ runs:
         # Enable sparse index
         echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $GITHUB_ENV
 
+    - name: Setup protoc
+      uses: arduino/setup-protoc@v2
+
     - name: Cache nextest on linux
       id: cache-nextest
       uses: actions/cache@v3

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -22,6 +22,8 @@ inputs:
     description: "This setup needs rocksdb or not"
   need-nextest:
     description: "This setup needs nextest or not"
+  need-protoc:
+    description: "This setup needs protoc or not"
 
 runs:
   using: "composite"

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -39,8 +39,10 @@ runs:
         # Enable sparse index
         echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $GITHUB_ENV
 
-    - name: Setup protoc
-      uses: arduino/setup-protoc@v2
+    - name: Setup protoc on linux
+      if: inputs.need-protoc == 'true' && runner.os == 'Linux'
+      shell: bash
+      run: sudo apt install -y protobuf-compiler
 
     - name: Cache nextest on linux
       id: cache-nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           need-rocksdb: true
+          need-protoc: true
 
       - name: Checkout python env
         uses: actions/setup-python@v4
@@ -83,6 +84,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           need-rocksdb: true
+          need-protoc: true
 
       - name: Checkout python env
         uses: actions/setup-python@v4
@@ -145,6 +147,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           need-rocksdb: true
+          need-protoc: true
 
       - name: Build
         run: cargo build --all-features

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           need-rocksdb: true
+          need-protoc: true
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,8 +36,12 @@ jobs:
         with:
           distribution: temurin
           java-version: "11"
+
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
+        with:
+          need-rocksdb: true
+          need-protoc: true
 
       - name: Publish opendal
         working-directory: "core"

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -40,6 +40,7 @@ use crate::*;
 
 const DEFAULT_WRITE_MIN_SIZE: usize = 8 * 1024 * 1024;
 const DEFAULT_BATCH_MAX_OPERATIONS: usize = 1000;
+
 /// Aliyun Object Storage Service (OSS) support
 #[doc = include_str!("docs.md")]
 #[derive(Default)]


### PR DESCRIPTION
Add a step in the rust environment setup action to set up the protoc compiler. Currently used by tikv and etcd services.