### PR TITLE
s3 head with no X-Amz-Bucket-Region , using us-east-1 region as default

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -619,13 +619,16 @@ impl S3Builder {
         );
 
         match res.status() {
-            StatusCode::OK | StatusCode::FORBIDDEN | StatusCode::MOVED_PERMANENTLY => {
+            StatusCode::OK |  StatusCode::MOVED_PERMANENTLY => {
                 let region = res.headers().get("x-amz-bucket-region")?;
                 if let Ok(regin) = region.to_str() {
                     Some(regin.to_string())
                 } else {
                     None
                 }
+            },
+            StatusCode::FORBIDDEN => {
+                Some("us-east-1".to_string())
             }
             // Unexpected status code
             _ => None,


### PR DESCRIPTION
#2654  

If head bucket returns 403 but no X-Amz-Bucket-Region is given, we can use us-east-1 as region.