### PR TITLE
fix: owncloud test sometimes fail

### DIFF
--- a/.github/workflows/service_test_webdav.yml
+++ b/.github/workflows/service_test_webdav.yml
@@ -202,6 +202,22 @@ jobs:
           OWNCLOUD_DOMAIN: localhost:8080
           OWNCLOUD_TRUSTED_DOMAINS: localhost
           HTTP_PORT: 8080
+          OWNCLOUD_REDIS_ENABLED: true
+          OWNCLOUD_REDIS_HOST: redis
+        options: >-
+          --health-cmd "/usr/bin/healthcheck"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5   
 
     steps:
       - uses: actions/checkout@v3
@@ -214,7 +230,7 @@ jobs:
         shell: bash
         working-directory: core
         run: |
-          cargo test webdav -j=1
+          cargo test webdav
         env:
           OPENDAL_WEBDAV_TEST: on
           OPENDAL_WEBDAV_ENDPOINT: http://127.0.0.1:8080/remote.php/webdav/


### PR DESCRIPTION
## Summary
Our integration test for owncloud has chance to fail

We try to solve this by reducing concurrency  https://github.com/apache/incubator-opendal/pull/2667

but it fail again, so this PR try to add redis to make owncloud happy

> I found a related discussion https://central.owncloud.org/t/file-is-locked-how-to-unlock/985.
Maybe we can try to use redis to reduce the unexpected lock happen?

https://github.com/apache/incubator-opendal/actions/runs/5606271748/jobs/10256268444