### PR TITLE
fix: Seek before the start of file should be invalid

### DIFF
--- a/core/src/raw/oio/read/into_read_from_file.rs
+++ b/core/src/raw/oio/read/into_read_from_file.rs
@@ -89,10 +89,16 @@ where
         };
 
         match base.checked_add(offset) {
+            // Seek to position like `-123` is invalid.
             Some(n) if n < 0 => Poll::Ready(Err(Error::new(
                 ErrorKind::InvalidInput,
-                "invalid seek to a negative or overflowing position",
-            ))),
+                "seek to a negative or overflowing position is invalid",
+            ).with_context("position", n.to_string()))),
+            // Seek to position before the start of current file is invalid.
+            Some(n) if n < self.start as i64 => Poll::Ready(Err(Error::new(
+                ErrorKind::InvalidInput,
+                "seek to a position before start of file is invalid",
+            ).with_context("position", n.to_string()).with_context("start", self.start.to_string()))),
             Some(n) => {
                 let cur =
                     ready!(Pin::new(&mut self.inner).poll_seek(cx, SeekFrom::Start(n as u64)))

--- a/core/src/raw/oio/read/into_read_from_file.rs
+++ b/core/src/raw/oio/read/into_read_from_file.rs
@@ -93,12 +93,15 @@ where
             Some(n) if n < 0 => Poll::Ready(Err(Error::new(
                 ErrorKind::InvalidInput,
                 "seek to a negative or overflowing position is invalid",
-            ).with_context("position", n.to_string()))),
+            )
+            .with_context("position", n.to_string()))),
             // Seek to position before the start of current file is invalid.
             Some(n) if n < self.start as i64 => Poll::Ready(Err(Error::new(
                 ErrorKind::InvalidInput,
                 "seek to a position before start of file is invalid",
-            ).with_context("position", n.to_string()).with_context("start", self.start.to_string()))),
+            )
+            .with_context("position", n.to_string())
+            .with_context("start", self.start.to_string()))),
             Some(n) => {
                 let cur =
                     ready!(Pin::new(&mut self.inner).poll_seek(cx, SeekFrom::Start(n as u64)))


### PR DESCRIPTION
Fix https://github.com/apache/incubator-opendal/issues/2717

The crash case has been fixed.

```shell
:) RUST_LOG=debug cargo +nightly fuzz run fuzz_range_reader /tmp/crash-4526ccffa285c58ef8c7731d4a5dfef69d38cfff
   Compiling opendal v0.38.1 (/home/xuanwo/Code/apache/incubator-opendal/core)
   Compiling opendal-fuzz v0.0.0 (/home/xuanwo/Code/apache/incubator-opendal/core/fuzz)
    Finished release [optimized] target(s) in 2m 06s
    Finished release [optimized] target(s) in 0.09s
     Running `/home/xuanwo/Code/apache/incubator-opendal/target/x86_64-unknown-linux-gnu/release/fuzz_range_reader -artifact_prefix=/home/xuanwo/Code/apache/incubator-opendal/core/fuzz/artifacts/fuzz_range_reader/ /tmp/crash-4526ccffa285c58ef8c7731d4a5dfef69d38cfff`
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 3882736719
INFO: Loaded 1 modules   (1722493 inline 8-bit counters): 1722493 [0x5621e8ab8590, 0x5621e8c5ce0d), 
INFO: Loaded 1 PC tables (1722493 PCs): 1722493 [0x5621e8c5ce10,0x5621ea6a55e0), 
/home/xuanwo/Code/apache/incubator-opendal/target/x86_64-unknown-linux-gnu/release/fuzz_range_reader: Running 1 inputs 1 time(s) each.
Running: /tmp/crash-4526ccffa285c58ef8c7731d4a5dfef69d38cfff
Executed /tmp/crash-4526ccffa285c58ef8c7731d4a5dfef69d38cfff in 62 ms
***
*** NOTE: fuzzing was not performed, you have only
***       executed the target code on a fixed set of inputs.
***
RUST_LOG=debug cargo +nightly fuzz run fuzz_range_reader   124.20s user 2.24s system 99% cpu 2:06.52 total
```