### PR TITLE
feat: setup the integrate with PHP binding

### DIFF
--- a/bindings/php/.cargo/config.toml
+++ b/bindings/php/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.'cfg(not(target_os = "windows"))']
+rustflags = ["-C", "link-arg=-Wl,-undefined,dynamic_lookup"]
+
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld"
+
+[target.i686-pc-windows-msvc]
+linker = "rust-lld"

--- a/bindings/php/.cargo/config.toml
+++ b/bindings/php/.cargo/config.toml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [target.'cfg(not(target_os = "windows"))']
 rustflags = ["-C", "link-arg=-Wl,-undefined,dynamic_lookup"]
 

--- a/bindings/php/.gitignore
+++ b/bindings/php/.gitignore
@@ -1,0 +1,3 @@
+/vendor
+composer.lock
+.phpunit.result.cache

--- a/bindings/php/Cargo.toml
+++ b/bindings/php/Cargo.toml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [package]
 name = "opendal-php"
 version = "0.1.0"

--- a/bindings/php/Cargo.toml
+++ b/bindings/php/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "opendal-php"
+version = "0.1.0"
+
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+ext-php-rs = "0.10.1"
+opendal = {version = "0.38.1", path = "../../core" }

--- a/bindings/php/README.md
+++ b/bindings/php/README.md
@@ -1,0 +1,32 @@
+# OpenDAL PHP Binding (WIP)
+
+## Requirements
+
+* PHP 8.1+
+
+## Development
+
+### Install Cargo PHP
+
+we use [cargo-php](https://davidcole1340.github.io/ext-php-rs/getting-started/hello_world.html) to build the PHP extension.
+
+```bash
+cargo install cargo-php
+```
+
+### Build
+
+Move to the `bindings/php` directory and run the following command, the extension will be built in `target/debug` directory and enable the extension in `php.ini` file.
+
+```bash
+cargo build
+cargo php install
+```
+
+### Test
+
+```bash
+composer install
+composer test
+```
+

--- a/bindings/php/composer.json
+++ b/bindings/php/composer.json
@@ -1,0 +1,21 @@
+{
+    "authors": [
+        {
+            "name": "Godruoyi",
+            "email": "godruoyi@gmail.com"
+        }
+    ],
+    "require-dev": {
+        "php": ">=8.1",
+        "pestphp/pest": "^2.9"
+    },
+    "license": "Apache-2.0",
+    "scripts": {
+        "test": "vendor/bin/pest"
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": false
+        }
+    }
+}

--- a/bindings/php/composer.json
+++ b/bindings/php/composer.json
@@ -1,8 +1,8 @@
 {
     "authors": [
         {
-            "name": "Godruoyi",
-            "email": "godruoyi@gmail.com"
+            "name": "OpenDAL Contributors",
+            "email": "dev@opendal.apache.org"
         }
     ],
     "require-dev": {

--- a/bindings/php/opendal-php.stubs.php
+++ b/bindings/php/opendal-php.stubs.php
@@ -1,4 +1,22 @@
 <?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 // Stubs for opendal-php
 

--- a/bindings/php/opendal-php.stubs.php
+++ b/bindings/php/opendal-php.stubs.php
@@ -1,0 +1,7 @@
+<?php
+
+// Stubs for opendal-php
+
+namespace {
+    function debug(): string {}
+}

--- a/bindings/php/phpunit.xml
+++ b/bindings/php/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/bindings/php/phpunit.xml
+++ b/bindings/php/phpunit.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"

--- a/bindings/php/src/lib.rs
+++ b/bindings/php/src/lib.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use ext_php_rs::prelude::*;
 use opendal::{EntryMode, Metadata};
 

--- a/bindings/php/src/lib.rs
+++ b/bindings/php/src/lib.rs
@@ -1,0 +1,14 @@
+use ext_php_rs::prelude::*;
+use opendal::{EntryMode, Metadata};
+
+#[php_function]
+pub fn debug() -> String {
+    let metadata = Metadata::new(EntryMode::FILE);
+
+    format!("{:?}", metadata)
+}
+
+#[php_module]
+pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
+    module
+}

--- a/bindings/php/tests/Unit/BasicTest.php
+++ b/bindings/php/tests/Unit/BasicTest.php
@@ -1,4 +1,22 @@
 <?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 it('opendal-php extension loaded', function () {
     expect(extension_loaded('opendal-php'))->toBeTrue();

--- a/bindings/php/tests/Unit/BasicTest.php
+++ b/bindings/php/tests/Unit/BasicTest.php
@@ -1,0 +1,9 @@
+<?php
+
+it('opendal-php extension loaded', function () {
+    expect(extension_loaded('opendal-php'))->toBeTrue();
+});
+
+it('debug function works', function () {
+    expect(debug())->toStartWith('Metadata');
+});


### PR DESCRIPTION
## Description

see https://github.com/apache/incubator-opendal/issues/2716

A new subdirectory `bindings/php` has been created in order to have PHP bindings for the OpenDAL library. This includes new PHP tests, stdlib stubs for the PHP interface, and addition of composer configuration for dependency management. as well as the initial source code written in Rust to provide PHP bindings. The 'debug' function is used as a test to check the binding. The README has been added to guide users and developers in building and testing the PHP bindings.