### PR TITLE
fix(service/s3):fix DEFAULT_WRITE_MIN_SIZE in s3 service

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -56,7 +56,7 @@ static ENDPOINT_TEMPLATES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new
     m
 });
 
-const DEFAULT_WRITE_MIN_SIZE: usize = 8 * 1024 * 1024;
+const DEFAULT_WRITE_MIN_SIZE: usize = 5 * 1024 * 1024;
 const DEFAULT_BATCH_MAX_OPERATIONS: usize = 1000;
 
 /// Aws S3 and compatible services (including minio, digitalocean space, Tencent Cloud Object Storage(COS) and so on) support.


### PR DESCRIPTION
according to the code of s3 service
https://github.com/apache/incubator-opendal/blob/dceea19c22977d6876a5ffd712bf405b7bccf32b/core/src/services/s3/backend.rs#L857-L863
and reference of s3 docs(https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html)
<img width="820" alt="image" src="https://github.com/apache/incubator-opendal/assets/48410497/2963eb9b-cc1d-4949-a1c4-acf8738fdc60">
it seems should be fixed as 5MiB