### PR TITLE
fix: fix compile error by low version of backon in old project

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -192,7 +192,7 @@ async-compat = "0.2"
 async-tls = { version = "0.11", optional = true }
 async-trait = "0.1.68"
 await-tree = { version = "0.1.1", optional = true }
-backon = "0.4.0"
+backon = "0.4.1"
 base64 = "0.21"
 bb8 = { version = "0.8", optional = true }
 bytes = "1.2"


### PR DESCRIPTION
Update:
- bump backon to 0.4.1

https://github.com/Xuanwo/backon/pull/54 feature can only be used in 0.4.1. As result, if backon version is 0.4.0, it won't pass compile.

Compiler Output:
```
error[E0308]: mismatched types
   --> /Volumes/haha/code/project/incubator-opendal/core/src/layers/retry.rs:300:21
    |
300 |               .notify(|err, dur: Duration| {
    |  ______________------_^
    | |              |
    | |              arguments to this method are incorrect
301 | |                 self.notify.intercept(
302 | |                     err,
303 | |                     dur,
...   |
308 | |                 )
309 | |             })
    | |_____________^ expected fn pointer, found closure
    |
    = note: expected fn pointer `for<'a> fn(&'a types::error::Error, std::time::Duration)`
                  found closure `[closure@/Volumes/haha/code/project/incubator-opendal/core/src/layers/retry.rs:300:21: 300:41]`
note: closures can only be coerced to `fn` types if they do not capture any variables
   --> /Volumes/haha/code/project/incubator-opendal/core/src/layers/retry.rs:301:17
    |
301 |                 self.notify.intercept(
    |                 ^^^^ `__self` captured here
...
306 |                         ("path", path),
    |                                  ^^^^ `path` captured here
note: method defined here
   --> /Users/silver/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backon-0.4.0/src/retry.rs:182:12
    |
182 |     pub fn notify(mut self, notify: fn(&E, Duration)) -> Self {
    |            ^^^^^^
```

For old project without `cargo update`, this will happen.