### PR TITLE
chore: disable oldtime feature of chrono

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -200,7 +200,7 @@ cacache = { version = "11.6", default-features = false, features = [
   "tokio-runtime",
   "mmap",
 ], optional = true }
-chrono = "0.4.26"
+chrono = { version = "0.4.26", default-features = false, features = ["clock", "std"] }
 dashmap = { version = "5.4", optional = true }
 dirs = { version = "5.0.1", optional = true }
 etcd-client = { version = "0.11", optional = true, features = ["tls"] }


### PR DESCRIPTION
`chrono` enables the `oldtime` feature for backwards compatibility but this project doesn't make use of it. Disabling it avoids the dependency on `time` v0.1