### PR TITLE
refactor: Remove optimize in into_seekable_read_by_range

### DIFF
--- a/core/src/raw/oio/read/into_seekable_read_by_range.rs
+++ b/core/src/raw/oio/read/into_seekable_read_by_range.rs
@@ -196,46 +196,10 @@ impl<A: Accessor> oio::Read for ByRangeSeekableReader<A> {
                     return Poll::Ready(Ok(self.cur));
                 }
 
-                // If the next seek pos is close enough, we can just
-                // read the cnt instead of dropping the reader.
-                //
-                // TODO: make this value configurable
-                if seek_pos > self.cur && seek_pos - self.cur < 1024 * 1024 {
-                    // 212992 is the default read mem buffer of archlinux.
-                    // Ideally we should make this configurable.
-                    //
-                    // TODO: make this value configurable
-                    let consume = cmp::min((seek_pos - self.cur) as usize, 212992);
-                    self.sink.reserve(consume);
-
-                    let mut buf = ReadBuf::uninit(self.sink.spare_capacity_mut());
-                    unsafe { buf.assume_init(consume) };
-
-                    match ready!(Pin::new(r).poll_read(cx, buf.initialized_mut())) {
-                        Ok(n) => {
-                            assert!(n > 0, "consumed bytes must be valid");
-                            self.cur += n as u64;
-                            // Make sure the pos is absolute from start.
-                            self.poll_seek(cx, SeekFrom::Start(seek_pos))
-                        }
-                        Err(_) => {
-                            // If we are hitting errors while read ahead.
-                            // It's better to drop this reader and seek to
-                            // correct position directly.
-                            self.state = State::Idle;
-                            self.cur = seek_pos;
-                            self.last_seek_pos = None;
-                            Poll::Ready(Ok(self.cur))
-                        }
-                    }
-                } else {
-                    // If we are trying to seek to far more away.
-                    // Let's just drop the reader.
-                    self.state = State::Idle;
-                    self.cur = seek_pos;
-                    self.last_seek_pos = None;
-                    Poll::Ready(Ok(self.cur))
-                }
+                self.state = State::Idle;
+                self.cur = seek_pos;
+                self.last_seek_pos = None;
+                Poll::Ready(Ok(self.cur))
             }
         }
     }


### PR DESCRIPTION
We used to have an optimize that using `read` instead of `seek` in `into_seekable_read_by_range`. But it not works in most case, let's remove them.