### PR TITLE
fix: Bump openssh-sftp-client from 0.13.5 to 0.13.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,9 +3508,9 @@ dependencies = [
 
 [[package]]
 name = "openssh-sftp-client"
-version = "0.13.6"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a88d72ccea61738948673f736b3c7f0abef0c268e61622ef61f069c963aba46"
+checksum = "9dbeb70e5692453993fc95efbf537ebcff84bf9b302398ccd68dada9a53202c5"
 dependencies = [
  "bytes",
  "derive_destructure2",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -223,7 +223,7 @@ minitrace = { version = "0.5", optional = true }
 moka = { version = "0.10", optional = true, features = ["future"] }
 once_cell = "1"
 openssh = { version = "0.9.9", optional = true }
-openssh-sftp-client = { version = "0.13.5", optional = true, features = [
+openssh-sftp-client = { version = "0.13.7", optional = true, features = [
   "openssh",
   "tracing",
 ] }


### PR DESCRIPTION
We found a problem with the older version while adding the blocking layer, bump this to fix it.

See details at #2780 