### PR TITLE
fix: add redis for nextcloud to solve file locking problem

### DIFF
--- a/.github/workflows/service_test_webdav.yml
+++ b/.github/workflows/service_test_webdav.yml
@@ -168,7 +168,20 @@ jobs:
           SQLITE_DATABASE: nextcloud
           NEXTCLOUD_ADMIN_USER: admin
           NEXTCLOUD_ADMIN_PASSWORD: admin
-        options: --health-cmd="curl -f http://localhost" --health-interval=10s --health-timeout=5s --health-retries=5
+          REDIS_HOST: redis
+        options: >-
+          --health-cmd="curl -f http://localhost" 
+          --health-interval=10s 
+          --health-timeout=5s 
+          --health-retries=5
+      
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5   
 
     steps:
       - uses: actions/checkout@v3
@@ -210,7 +223,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-      
       redis:
         image: redis
         options: >-


### PR DESCRIPTION
close: https://github.com/apache/incubator-opendal/issues/2804

Reference:
https://hub.docker.com/_/nextcloud/
> If you want to use Redis you have to create a separate [Redis](https://hub.docker.com/_/redis/) container in your setup / in your docker-compose file. To inform Nextcloud about the Redis container, pass in the following parameters:
REDIS_HOST (not set by default) Name of Redis container
The use of Redis is recommended to prevent file locking problems. See the examples for further instructions.