### PR TITLE
fix: Cleanup temporary files generated in tests automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
  "async-lock",
  "async-task",
  "concurrent-queue",
- "fastrand",
+ "fastrand 1.9.0",
  "futures-lite",
  "slab",
 ]
@@ -502,7 +502,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a6197b2120bb2185a267f6515038558b019e92b832bb0320e96d66268dcf9"
 dependencies = [
- "fastrand",
+ "fastrand 1.9.0",
  "futures-core",
  "pin-project",
  "tokio",
@@ -637,7 +637,7 @@ dependencies = [
  "async-lock",
  "async-task",
  "atomic-waker",
- "fastrand",
+ "fastrand 1.9.0",
  "futures-lite",
  "log",
 ]
@@ -1648,6 +1648,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,7 +1838,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
- "fastrand",
+ "fastrand 1.9.0",
  "futures-core",
  "futures-io",
  "memchr",
@@ -3389,6 +3395,7 @@ dependencies = [
  "opendal",
  "predicates",
  "serde",
+ "tempfile",
  "tokio",
  "toml 0.7.5",
  "url",
@@ -5546,15 +5553,14 @@ checksum = "1b1c7f239eb94671427157bd93b3694320f3668d4e1eff08c7285366fd777fac"
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
 dependencies = [
- "autocfg",
  "cfg-if",
- "fastrand",
+ "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.37.22",
+ "rustix 0.38.2",
  "windows-sys 0.48.0",
 ]
 

--- a/bin/oli/Cargo.toml
+++ b/bin/oli/Cargo.toml
@@ -74,3 +74,4 @@ url = "2.3.1"
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+tempfile = "3.7.1"

--- a/bin/oli/src/config/mod.rs
+++ b/bin/oli/src/config/mod.rs
@@ -302,8 +302,8 @@ mod tests {
 
     #[test]
     fn test_load_from_toml() -> Result<()> {
-        let dir = env::temp_dir();
-        let tmpfile = dir.join("oli1.toml");
+        let dir = tempfile::tempdir()?;
+        let tmpfile = dir.path().join("oli1.toml");
         fs::write(
             &tmpfile,
             r#"
@@ -324,8 +324,8 @@ enable_virtual_host_style = "on"
 
     #[test]
     fn test_load_config_from_file_and_env() -> Result<()> {
-        let dir = env::temp_dir();
-        let tmpfile = dir.join("oli2.toml");
+        let dir = tempfile::tempdir()?;
+        let tmpfile = dir.path().join("oli2.toml");
         fs::write(
             &tmpfile,
             r#"

--- a/bin/oli/tests/cat.rs
+++ b/bin/oli/tests/cat.rs
@@ -15,9 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::env;
 use std::fs;
-use std::path::Path;
 use std::process::Command;
 
 use anyhow::Result;
@@ -25,9 +23,8 @@ use assert_cmd::prelude::*;
 
 #[tokio::test]
 async fn test_basic_cat() -> Result<()> {
-    let dir = env::temp_dir();
-    fs::create_dir_all(dir.clone())?;
-    let dst_path = Path::new(&dir).join("dst.txt");
+    let dir = tempfile::tempdir()?;
+    let dst_path = dir.path().join("dst.txt");
     let expect = "hello";
     fs::write(&dst_path, expect)?;
 

--- a/bin/oli/tests/cp.rs
+++ b/bin/oli/tests/cp.rs
@@ -15,9 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::env;
 use std::fs;
-use std::path::Path;
 use std::process::Command;
 
 use anyhow::Result;
@@ -25,10 +23,9 @@ use assert_cmd::prelude::*;
 
 #[tokio::test]
 async fn test_basic_cp() -> Result<()> {
-    let dir = env::temp_dir();
-    fs::create_dir_all(dir.clone())?;
-    let src_path = Path::new(&dir).join("src.txt");
-    let dst_path = Path::new(&dir).join("dst.txt");
+    let dir = tempfile::tempdir()?;
+    let src_path = dir.path().join("src.txt");
+    let dst_path = dir.path().join("dst.txt");
     let expect = "hello";
     fs::write(&src_path, expect)?;
 

--- a/bin/oli/tests/ls.rs
+++ b/bin/oli/tests/ls.rs
@@ -15,9 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::env;
 use std::fs;
-use std::path::Path;
 use std::process::Command;
 
 use anyhow::Result;
@@ -25,11 +23,10 @@ use assert_cmd::prelude::*;
 
 #[tokio::test]
 async fn test_basic_ls() -> Result<()> {
-    let dir = env::temp_dir();
-    fs::create_dir_all(dir.clone())?;
-    let dst_path_1 = Path::new(&dir).join("dst_1.txt");
-    let dst_path_2 = Path::new(&dir).join("dst_2.txt");
-    let dst_path_3 = Path::new(&dir).join("dst_3.txt");
+    let dir = tempfile::tempdir()?;
+    let dst_path_1 = dir.path().join("dst_1.txt");
+    let dst_path_2 = dir.path().join("dst_2.txt");
+    let dst_path_3 = dir.path().join("dst_3.txt");
 
     let expect = "hello";
     fs::write(dst_path_1, expect)?;
@@ -38,7 +35,7 @@ async fn test_basic_ls() -> Result<()> {
 
     let mut cmd = Command::cargo_bin("oli")?;
 
-    let current_dir = dir.to_str().unwrap().to_string() + "/";
+    let current_dir = dir.path().to_string_lossy().to_string() + "/";
 
     cmd.arg("ls").arg(current_dir);
     let res = cmd.assert().success();

--- a/bin/oli/tests/rm.rs
+++ b/bin/oli/tests/rm.rs
@@ -15,9 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::env;
 use std::fs;
-use std::path::Path;
 use std::process::Command;
 
 use anyhow::Result;
@@ -25,9 +23,8 @@ use assert_cmd::prelude::*;
 
 #[tokio::test]
 async fn test_basic_rm() -> Result<()> {
-    let dir = env::temp_dir();
-    fs::create_dir_all(dir.clone())?;
-    let dst_path = Path::new(&dir).join("dst.txt");
+    let dir = tempfile::tempdir()?;
+    let dst_path = dir.path().join("dst.txt");
     let expect = "hello";
     fs::write(&dst_path, expect)?;
 

--- a/bin/oli/tests/stat.rs
+++ b/bin/oli/tests/stat.rs
@@ -15,9 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::env;
 use std::fs;
-use std::path::Path;
 use std::process::Command;
 
 use anyhow::Result;
@@ -25,9 +23,8 @@ use assert_cmd::prelude::*;
 
 #[tokio::test]
 async fn test_basic_stat() -> Result<()> {
-    let dir = env::temp_dir();
-    fs::create_dir_all(dir.clone())?;
-    let dst_path = Path::new(&dir).join("dst.txt");
+    let dir = tempfile::tempdir()?;
+    let dst_path = dir.path().join("dst.txt");
     let expect = "hello";
     fs::write(&dst_path, expect)?;
 
@@ -38,7 +35,9 @@ async fn test_basic_stat() -> Result<()> {
     let output = res.get_output().stdout.clone();
 
     let output_stdout = String::from_utf8(output)?;
-    assert!(output_stdout.contains("path: tmp/dst.txt"));
+    let mut expected_path = "path: ".to_string();
+    expected_path.push_str(&dst_path.to_string_lossy()[1..]);
+    assert!(output_stdout.contains(&expected_path));
     assert!(output_stdout.contains("size: 5"));
     assert!(output_stdout.contains("type: file"));
     assert!(output_stdout.contains("last-modified: "));


### PR DESCRIPTION
As I mentioned at  #2822,  temporary files generated in tests are not deleted automatically.
To fix this issue, this PR introduces `tempfile` crate.
https://docs.rs/tempfile/latest/tempfile/index.html

A temporary directory created using `tempfile` crate and files in the temporary directory will be automatically deleted when the corresponding `TempDir` object is dropped.

This PR affects the tests in `bin/oli` and  confirmed all the tests passed with `cargo test --tests --package oli`