### PR TITLE
fix(services/sftp): bump openssh-sftp-client to 0.13.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,9 +3621,9 @@ dependencies = [
 
 [[package]]
 name = "openssh-sftp-client"
-version = "0.13.8"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d135b4ba6155660ac976170a720a135c4fe92c4ddb2763e44b279ee7b9eace"
+checksum = "bff0b8012752f6cdf35c0483c0bd0cc15f4b229284f1f5a7aaf2a66cd7e8fde9"
 dependencies = [
  "bytes",
  "derive_destructure2",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -227,7 +227,7 @@ minitrace = { version = "0.5", optional = true }
 moka = { version = "0.10", optional = true, features = ["future"] }
 once_cell = "1"
 openssh = { version = "0.9.9", optional = true }
-openssh-sftp-client = { version = "0.13.8", optional = true, features = [
+openssh-sftp-client = { version = "0.13.999999999", optional = true, features = [
   "openssh",
   "tracing",
 ] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -227,7 +227,7 @@ minitrace = { version = "0.5", optional = true }
 moka = { version = "0.10", optional = true, features = ["future"] }
 once_cell = "1"
 openssh = { version = "0.9.9", optional = true }
-openssh-sftp-client = { version = "0.13.999999999", optional = true, features = [
+openssh-sftp-client = { version = "0.13.9", optional = true, features = [
   "openssh",
   "tracing",
 ] }


### PR DESCRIPTION
Bump openssh-sftp-client to fix the failed test https://github.com/apache/incubator-opendal/actions/runs/5798363627/job/15715936917