### PR TITLE
fix(oli): oli commands don't work properly for files in CWD

### DIFF
--- a/bin/oli/src/config/mod.rs
+++ b/bin/oli/src/config/mod.rs
@@ -135,7 +135,10 @@ impl Config {
                     fs_builder.root(if base.is_empty() { "/" } else { base });
                     filename
                 }
-                _ => s,
+                _ => {
+                    fs_builder.root(".");
+                    s
+                }
             };
 
             return Ok((Operator::new(fs_builder)?.finish(), filename.into()));

--- a/bin/oli/tests/cat.rs
+++ b/bin/oli/tests/cat.rs
@@ -40,3 +40,25 @@ async fn test_basic_cat() -> Result<()> {
     assert_eq!(output_stdout, actual);
     Ok(())
 }
+
+#[tokio::test]
+async fn test_cat_for_path_in_current_dir() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let dst_path = dir.path().join("dst.txt");
+    let expect = "hello";
+    fs::write(&dst_path, expect)?;
+
+    let mut cmd = Command::cargo_bin("oli")?;
+
+    cmd.arg("cat")
+        .arg("dst.txt")
+        .current_dir(dir.path().clone());
+    let actual = fs::read_to_string(&dst_path)?;
+    let res = cmd.assert().success();
+    let output = res.get_output().stdout.clone();
+
+    let output_stdout = String::from_utf8(output)?;
+
+    assert_eq!(output_stdout, actual);
+    Ok(())
+}

--- a/bin/oli/tests/cp.rs
+++ b/bin/oli/tests/cp.rs
@@ -40,3 +40,24 @@ async fn test_basic_cp() -> Result<()> {
     assert_eq!(expect, actual);
     Ok(())
 }
+
+#[tokio::test]
+async fn test_cp_for_path_in_current_dir() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let src_path = dir.path().join("src.txt");
+    let dst_path = dir.path().join("dst.txt");
+    let expect = "hello";
+    fs::write(&src_path, expect)?;
+
+    let mut cmd = Command::cargo_bin("oli")?;
+
+    cmd.arg("cp")
+        .arg("src.txt")
+        .arg("dst.txt")
+        .current_dir(dir.path().clone());
+    cmd.assert().success();
+
+    let actual = fs::read_to_string(&dst_path)?;
+    assert_eq!(expect, actual);
+    Ok(())
+}

--- a/bin/oli/tests/cp.rs
+++ b/bin/oli/tests/cp.rs
@@ -47,7 +47,7 @@ async fn test_cp_for_path_in_current_dir() -> Result<()> {
     let src_path = dir.path().join("src.txt");
     let dst_path = dir.path().join("dst.txt");
     let expect = "hello";
-    fs::write(&src_path, expect)?;
+    fs::write(src_path, expect)?;
 
     let mut cmd = Command::cargo_bin("oli")?;
 
@@ -57,7 +57,7 @@ async fn test_cp_for_path_in_current_dir() -> Result<()> {
         .current_dir(dir.path().clone());
     cmd.assert().success();
 
-    let actual = fs::read_to_string(&dst_path)?;
+    let actual = fs::read_to_string(dst_path)?;
     assert_eq!(expect, actual);
     Ok(())
 }

--- a/bin/oli/tests/rm.rs
+++ b/bin/oli/tests/rm.rs
@@ -36,3 +36,19 @@ async fn test_basic_rm() -> Result<()> {
     assert!(fs::read_to_string(&dst_path).is_err());
     Ok(())
 }
+
+#[tokio::test]
+async fn test_rm_for_path_in_current_dir() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let dst_path = dir.path().join("dst.txt");
+    let expect = "hello";
+    fs::write(&dst_path, expect)?;
+
+    let mut cmd = Command::cargo_bin("oli")?;
+
+    cmd.arg("rm").arg("dst.txt").current_dir(dir.path().clone());
+    cmd.assert().success();
+
+    assert!(fs::read_to_string(&dst_path).is_err());
+    Ok(())
+}

--- a/bin/oli/tests/stat.rs
+++ b/bin/oli/tests/stat.rs
@@ -44,3 +44,27 @@ async fn test_basic_stat() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_stat_for_path_in_current_dir() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let dst_path = dir.path().join("dst.txt");
+    let expect = "hello";
+    fs::write(&dst_path, expect)?;
+
+    let mut cmd = Command::cargo_bin("oli")?;
+
+    cmd.arg("stat")
+        .arg("dst.txt")
+        .current_dir(dir.path().clone());
+    let res = cmd.assert().success();
+    let output = res.get_output().stdout.clone();
+
+    let output_stdout = String::from_utf8(output)?;
+    assert!(output_stdout.contains("path: dst.txt"));
+    assert!(output_stdout.contains("size: 5"));
+    assert!(output_stdout.contains("type: file"));
+    assert!(output_stdout.contains("last-modified: "));
+
+    Ok(())
+}

--- a/bin/oli/tests/stat.rs
+++ b/bin/oli/tests/stat.rs
@@ -50,7 +50,7 @@ async fn test_stat_for_path_in_current_dir() -> Result<()> {
     let dir = tempfile::tempdir()?;
     let dst_path = dir.path().join("dst.txt");
     let expect = "hello";
-    fs::write(&dst_path, expect)?;
+    fs::write(dst_path, expect)?;
 
     let mut cmd = Command::cargo_bin("oli")?;
 


### PR DESCRIPTION
Related issue: #2834 

Given we have a directory `d` and a file `d/f`, and the current working directory is `d`.
If we run `oli stat` for `f` like as follows, it works.
```
$ oli stat ./f
```

But if we omit `./`, it doesn't work.
```
$ oli stat f
Error: ConfigInvalid (permanent) at  => root is not specified
```

The cause is that root directory is not set to `fs_builder` as the error message says.