### PR TITLE
feat: Add clippy rule to avoid wrong usage of tempfile crate

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 disallowed-methods = [
     { path = "tempfile::TempDir::into_path", reason = "tempdir will no longer be deleted automatically" }
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    { path = "tempfile::TempDir::into_path", reason = "tempdir will no longer be deleted automatically" }
+]


### PR DESCRIPTION
Related issue: #2835 

I added tempfile crate in https://github.com/apache/incubator-opendal/pull/2823 .
One pitfall is the usage of TempDir::into_path.
According to the [API doc](https://docs.rs/tempfile/latest/tempfile/struct.TempDir.html#method.into_path), TempDir::into_path leads the corresponding temporary directory not deleted automatically.
To avoid resource leak I proposes to add a clippy rule.