### PR TITLE
fix(services/gcs): migrate to new multipart impl for gcs_insert_object_request

### DIFF
--- a/.github/workflows/service_test_gcs.yml
+++ b/.github/workflows/service_test_gcs.yml
@@ -55,3 +55,23 @@ jobs:
           OPENDAL_GCS_ROOT: ${{ secrets.OPENDAL_GCS_ROOT }}
           OPENDAL_GCS_BUCKET: ${{ secrets.OPENDAL_GCS_BUCKET }}
           OPENDAL_GCS_CREDENTIAL: ${{ secrets.OPENDAL_GCS_CREDENTIAL }}
+
+  gcs-with-default-storage-class:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup
+        with:
+          need-nextest: true
+      - name: Test
+        shell: bash
+        working-directory: core
+        run: cargo nextest run gcs
+        env:
+          OPENDAL_GCS_TEST: ${{ secrets.OPENDAL_GCS_TEST }}
+          OPENDAL_GCS_ROOT: ${{ secrets.OPENDAL_GCS_ROOT }}
+          OPENDAL_GCS_BUCKET: ${{ secrets.OPENDAL_GCS_BUCKET }}
+          OPENDAL_GCS_CREDENTIAL: ${{ secrets.OPENDAL_GCS_CREDENTIAL }}
+          OPENDAL_GCS_DEFAULT_STORAGE_CLASS: STANDARD

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -257,11 +257,8 @@ impl GcsCore {
                 AsyncBody::Bytes(bytes) => {
                     media_part = media_part.content(bytes);
                 }
-                AsyncBody::Stream(_) => {
-                    return Err(Error::new(
-                        ErrorKind::Unsupported,
-                        "stream body is not supported",
-                    ));
+                AsyncBody::Stream(stream) => {
+                    media_part = media_part.stream(size.unwrap(), stream);
                 }
             }
 

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -23,7 +23,6 @@ use std::time::Duration;
 use backon::ExponentialBuilder;
 use backon::Retryable;
 use bytes::Bytes;
-use bytes::BytesMut;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_RANGE;
 use http::header::CONTENT_TYPE;
@@ -234,28 +233,41 @@ impl GcsCore {
         req = req.header(CONTENT_LENGTH, size.unwrap_or_default());
 
         if let Some(storage_class) = &self.default_storage_class {
-            req = req.header(CONTENT_TYPE, "multipart/related; boundary=my-boundary");
+            let mut multipart = Multipart::new();
 
-            let mut req_body = BytesMut::with_capacity(100);
-            write!(
-                &mut req_body,
-                "--my-boundary\nContent-Type: application/json; charset=UTF-8\n\n{{\"storageClass\": \"{}\"}}\n\n--my-boundary\n",
-                storage_class
-            ).unwrap();
+            multipart = multipart.part(
+                FormDataPart::new("metadata")
+                    .header(
+                        CONTENT_TYPE,
+                        "application/json; charset=UTF-8".parse().unwrap(),
+                    )
+                    .content(format!("{{\"storageClass\": \"{}\"}}", storage_class)),
+            );
 
-            if let Some(mime) = content_type {
-                write!(&mut req_body, "Content-Type: {}\n\n", mime).unwrap();
-            } else {
-                write!(&mut req_body, "Content-Type: application/octet-stream\n\n").unwrap();
+            let mut media_part = FormDataPart::new("media").header(
+                CONTENT_TYPE,
+                content_type
+                    .unwrap_or("application/octet-stream")
+                    .parse()
+                    .unwrap(),
+            );
+
+            match body {
+                AsyncBody::Empty => {}
+                AsyncBody::Bytes(bytes) => {
+                    media_part = media_part.content(bytes);
+                }
+                AsyncBody::Stream(_) => {
+                    return Err(Error::new(
+                        ErrorKind::Unsupported,
+                        "stream body is not supported",
+                    ));
+                }
             }
 
-            if let AsyncBody::Bytes(bytes) = body {
-                req_body.extend_from_slice(&bytes);
-            }
-            write!(&mut req_body, "\n--my-boundary").unwrap();
+            multipart = multipart.part(media_part);
 
-            let req_body = AsyncBody::Bytes(req_body.freeze());
-            let req = req.body(req_body).map_err(new_request_build_error)?;
+            let req = multipart.apply(Request::post(url))?;
             Ok(req)
         } else {
             if let Some(content_type) = content_type {

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -36,6 +36,7 @@ use reqsign::GoogleCredentialLoader;
 use reqsign::GoogleSigner;
 use reqsign::GoogleToken;
 use reqsign::GoogleTokenLoader;
+use serde_json::json;
 
 use super::uri::percent_encode_path;
 use crate::raw::*;
@@ -241,7 +242,7 @@ impl GcsCore {
                         CONTENT_TYPE,
                         "application/json; charset=UTF-8".parse().unwrap(),
                     )
-                    .content(format!("{{\"storageClass\": \"{}\"}}", storage_class)),
+                    .content(json!({"storageClass": storage_class}).to_string()),
             );
 
             let mut media_part = FormDataPart::new("media").header(


### PR DESCRIPTION
Fix #2837 

`test_writer_sink` and `test_writer_copy` will be failed because we can't put stream body into multipart. Is there any way to solve it?