### PR TITLE
feat(oli): oli stat should show path as specified by users

### DIFF
--- a/bin/oli/src/commands/stat.rs
+++ b/bin/oli/src/commands/stat.rs
@@ -37,7 +37,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
     let (op, path) = cfg.parse_location(target)?;
 
     let meta = op.stat(&path).await?;
-    println!("path: {path}");
+    println!("path: {target}");
     let size = meta.content_length();
     println!("size: {size}");
     if let Some(etag) = meta.etag() {

--- a/bin/oli/tests/stat.rs
+++ b/bin/oli/tests/stat.rs
@@ -36,7 +36,7 @@ async fn test_basic_stat() -> Result<()> {
 
     let output_stdout = String::from_utf8(output)?;
     let mut expected_path = "path: ".to_string();
-    expected_path.push_str(&dst_path.to_string_lossy()[1..]);
+    expected_path.push_str(&dst_path.to_string_lossy());
     assert!(output_stdout.contains(&expected_path));
     assert!(output_stdout.contains("size: 5"));
     assert!(output_stdout.contains("type: file"));


### PR DESCRIPTION
Related issue: #2841 

This PR proposes to change `oli stat` to show the result of `path` field like as Linux's `stat`.
Before this change, when we run `oli stat` for a path, the root is omitted.
```
$ oli stat /path/to/file
path: path/to/file
size: 6307
type: file
last-modified: 2023-08-07 22:31:52.987908713 UTC
```

After this change, the root is prepended.
```
$ oli stat /path/to/file
path: path/to/file
size: 6307
type: file
last-modified: 2023-08-07 22:31:52.987908713 UTC
```

Also, a path are shown as specified by users like Linux's `stat` does.
```
$ stat ./myfile
  File: ./myfile
  Size: 6307      	Blocks: 16         IO Block: 4096   regular file
Device: 10304h/66308d	Inode: 1328196138  Links: 1
Access: (0664/-rw-rw-r--)  Uid: ( 1000/     kou)   Gid: ( 1000/     kou)
Access: 2023-08-10 04:48:01.320407752 +0900
Modify: 2023-08-08 07:31:52.987908713 +0900
Change: 2023-08-08 07:31:52.987908713 +0900
 Birth: -
```