### PR TITLE
docs: Fix missing link for rust example

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -150,7 +150,7 @@ async fn main() -> Result<()> {
 
 ## Examples
 
-The examples are available at [here](./examples/rust).
+The examples are available at [here](../examples/rust).
 
 ## Contributing
 


### PR DESCRIPTION
Related issue: #2865 

This PR fixes an issue that the link to the Rust example is missing.