### PR TITLE
fix(binding/java): Overwrite default NOTICE file with correct years

### DIFF
--- a/bindings/java/src/main/resources/META-INF/NOTICE
+++ b/bindings/java/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,5 @@
+opendal-java
+Copyright 2023 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
This closes https://github.com/apache/incubator-opendal/issues/2916.

Verified locally. And yes, opendal-java contains built without any compile dependency on Maven Central.

FYI @markt-asf this should address the issue you spot :D