### PR TITLE
feat: Add benchmark for buf write

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -181,6 +181,10 @@ bench = false
 harness = false
 name = "ops"
 
+[[bench]]
+harness = false
+name = "oio"
+
 [[test]]
 harness = false
 name = "behavior"

--- a/core/benches/oio/main.rs
+++ b/core/benches/oio/main.rs
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+mod utils;
+mod write;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+
+criterion_group!(
+    benches,
+    write::bench_at_least_buf_write,
+    write::bench_exact_buf_write,
+);
+criterion_main!(benches);

--- a/core/benches/oio/utils.rs
+++ b/core/benches/oio/utils.rs
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use opendal::raw::oio;
+use opendal::raw::oio::Streamer;
+use rand::prelude::ThreadRng;
+use rand::RngCore;
+
+/// BlackHoleWriter will discard all data written to it so we can measure the buffer's cost.
+pub struct BlackHoleWriter;
+
+#[async_trait]
+impl oio::Write for BlackHoleWriter {
+    async fn write(&mut self, _: Bytes) -> opendal::Result<()> {
+        Ok(())
+    }
+
+    async fn sink(&mut self, _: u64, _: Streamer) -> opendal::Result<()> {
+        Ok(())
+    }
+
+    async fn abort(&mut self) -> opendal::Result<()> {
+        Ok(())
+    }
+
+    async fn close(&mut self) -> opendal::Result<()> {
+        Ok(())
+    }
+}
+
+pub fn gen_bytes(rng: &mut ThreadRng, size: usize) -> Bytes {
+    let mut content = vec![0; size];
+    rng.fill_bytes(&mut content);
+
+    content.into()
+}

--- a/core/benches/oio/write.rs
+++ b/core/benches/oio/write.rs
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use criterion::Criterion;
+use once_cell::sync::Lazy;
+use opendal::raw::oio::{AtLeastBufWriter, ExactBufWriter, Write};
+use rand::thread_rng;
+use size::Size;
+
+use super::utils::*;
+
+pub static TOKIO: Lazy<tokio::runtime::Runtime> =
+    Lazy::new(|| tokio::runtime::Runtime::new().expect("build tokio runtime"));
+
+pub fn bench_at_least_buf_write(c: &mut Criterion) {
+    let mut group = c.benchmark_group("at_least_buf_write");
+
+    let mut rng = thread_rng();
+
+    for size in [
+        Size::from_kibibytes(4),
+        Size::from_kibibytes(256),
+        Size::from_mebibytes(4),
+        Size::from_mebibytes(16),
+    ] {
+        let content = gen_bytes(&mut rng, size.bytes() as usize);
+
+        group.throughput(criterion::Throughput::Bytes(size.bytes() as u64));
+        group.bench_with_input(size.to_string(), &content, |b, content| {
+            b.to_async(&*TOKIO).iter(|| async {
+                let mut w = AtLeastBufWriter::new(BlackHoleWriter, 256 * 1024);
+                w.write(content.clone()).await.unwrap();
+                w.close().await.unwrap();
+            })
+        });
+    }
+
+    group.finish()
+}
+
+pub fn bench_exact_buf_write(c: &mut Criterion) {
+    let mut group = c.benchmark_group("exact_buf_write");
+
+    let mut rng = thread_rng();
+
+    for size in [
+        Size::from_kibibytes(4),
+        Size::from_kibibytes(256),
+        Size::from_mebibytes(4),
+        Size::from_mebibytes(16),
+    ] {
+        let content = gen_bytes(&mut rng, size.bytes() as usize);
+
+        group.throughput(criterion::Throughput::Bytes(size.bytes() as u64));
+        group.bench_with_input(size.to_string(), &content, |b, content| {
+            b.to_async(&*TOKIO).iter(|| async {
+                let mut w = ExactBufWriter::new(BlackHoleWriter, 256 * 1024);
+                w.write(content.clone()).await.unwrap();
+                w.close().await.unwrap();
+            })
+        });
+    }
+
+    group.finish()
+}

--- a/core/src/raw/oio/cursor.rs
+++ b/core/src/raw/oio/cursor.rs
@@ -313,7 +313,7 @@ impl ChunkedCursor {
     #[cfg(test)]
     fn concat(&self) -> Bytes {
         let mut bs = BytesMut::new();
-        for v in &self.inner {
+        for v in self.inner.iter().skip(self.idx) {
             bs.extend_from_slice(v);
         }
         bs.freeze()

--- a/core/src/raw/oio/write/exact_buf_write.rs
+++ b/core/src/raw/oio/write/exact_buf_write.rs
@@ -92,7 +92,7 @@ impl<W: oio::Write> oio::Write for ExactBufWriter<W> {
     /// # TODO
     ///
     /// We know every stream size, we can collect them into a buffer without chain them every time.
-    async fn sink(&mut self, size: u64, mut s: Streamer) -> Result<()> {
+    async fn sink(&mut self, _: u64, mut s: Streamer) -> Result<()> {
         if self.buffer.len() >= self.buffer_size {
             let mut buf = self.buffer.clone();
             let to_write = buf.split_to(self.buffer_size);

--- a/core/src/raw/oio/write/exact_buf_write.rs
+++ b/core/src/raw/oio/write/exact_buf_write.rs
@@ -93,14 +93,6 @@ impl<W: oio::Write> oio::Write for ExactBufWriter<W> {
     ///
     /// We know every stream size, we can collect them into a buffer without chain them every time.
     async fn sink(&mut self, size: u64, mut s: Streamer) -> Result<()> {
-        // Collect the stream into buffer directly if the buffet is not full.
-        if self.buffer_stream.is_none()
-            && self.buffer.len() as u64 + size <= self.buffer_size as u64
-        {
-            self.buffer.push(s.collect().await?);
-            return Ok(());
-        }
-
         if self.buffer.len() >= self.buffer_size {
             let mut buf = self.buffer.clone();
             let to_write = buf.split_to(self.buffer_size);


### PR DESCRIPTION
```rust
at_least_buf_write/4.00 KiB
                        time:   [149.96 ns 150.10 ns 150.25 ns]
                        thrpt:  [25.388 GiB/s 25.415 GiB/s 25.438 GiB/s]
at_least_buf_write/256 KiB
                        time:   [127.08 ns 127.17 ns 127.28 ns]
                        thrpt:  [1918.2 GiB/s 1919.8 GiB/s 1921.2 GiB/s]
at_least_buf_write/4.00 MiB
                        time:   [124.63 ns 125.06 ns 125.72 ns]
                        thrpt:  [ 31072 GiB/s  31234 GiB/s  31342 GiB/s]
at_least_buf_write/16.0 MiB
                        time:   [125.82 ns 126.05 ns 126.34 ns]
                        thrpt:  [123677 GiB/s 123955 GiB/s 124186 GiB/s]

exact_buf_write/4.00 KiB
                        time:   [245.48 ns 245.68 ns 245.88 ns]
                        thrpt:  [15.515 GiB/s 15.527 GiB/s 15.540 GiB/s]
exact_buf_write/256 KiB time:   [215.33 ns 215.43 ns 215.53 ns]
                        thrpt:  [1132.7 GiB/s 1133.3 GiB/s 1133.8 GiB/s]
exact_buf_write/4.00 MiB
                        time:   [1.6147 µs 1.6155 µs 1.6163 µs]
                        thrpt:  [2416.8 GiB/s 2418.0 GiB/s 2419.2 GiB/s]
exact_buf_write/16.0 MiB
                        time:   [5.9971 µs 6.0011 µs 6.0048 µs]
                        thrpt:  [2602.1 GiB/s 2603.7 GiB/s 2605.4 GiB/s]
```

exact_buf_write is slower than at_least_buf_write which is expected since we need to make sure all write operation has been aligned with buffer size. Although I'm sure that there are many areas for improvement.