### PR TITLE
docs: add service doc for gcs

### DIFF
--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -42,65 +42,8 @@ const DEFAULT_GCS_ENDPOINT: &str = "https://storage.googleapis.com";
 const DEFAULT_GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.read_write";
 /// It's recommended that you use at least 8 MiB for the chunk size.
 const DEFAULT_WRITE_FIXED_SIZE: usize = 8 * 1024 * 1024;
-/// Google Cloud Storage service.
-///
-/// # Capabilities
-///
-/// This service can be used to:
-///
-/// - [x] stat
-/// - [x] read
-/// - [x] write
-/// - [x] create_dir
-/// - [x] delete
-/// - [x] copy
-/// - [ ] rename
-/// - [x] list
-/// - [x] scan
-/// - [x] presign
-/// - [ ] blocking
-///
-/// # Configuration
-///
-/// - `root`: Set the work directory for backend
-/// - `bucket`: Set the container name for backend
-/// - `endpoint`: Customizable endpoint setting
-/// - `credentials`: Credential string for GCS OAuth2
-/// - `predefined_acl`: Predefined ACL for GCS
-/// - `default_storage_class`: Default storage class for GCS
-///
-/// You can refer to [`GcsBuilder`]'s docs for more information
-///
-/// # Example
-///
-/// ## Via Builder
-///
-/// ```no_run
-/// use anyhow::Result;
-/// use opendal::services::Gcs;
-/// use opendal::Operator;
-///
-/// #[tokio::main]
-/// async fn main() -> Result<()> {
-///     // create backend builder
-///     let mut builder = Gcs::default();
-///
-///     // set the storage bucket for OpenDAL
-///     builder.bucket("test");
-///     // set the working directory root for GCS
-///     // all operations will happen within it
-///     builder.root("/path/to/dir");
-///     // set the credentials for GCS OAUTH2 authentication
-///     builder.credential("authentication token");
-///     // set the predefined ACL for GCS
-///     builder.predefined_acl("publicRead");
-///     // set the default storage class for GCS
-///     builder.default_storage_class("STANDARD");
-///
-///     let op: Operator = Operator::new(builder)?.finish();
-///     Ok(())
-/// }
-/// ```
+
+/// [Google Cloud Storage](https://cloud.google.com/storage) services support.
 #[derive(Default)]
 pub struct GcsBuilder {
     /// root URI, all operations happens under `root`

--- a/core/src/services/gcs/docs.md
+++ b/core/src/services/gcs/docs.md
@@ -1,0 +1,57 @@
+## Capabilities
+
+This service can be used to:
+
+- [x] stat
+- [x] read
+- [x] write
+- [x] create_dir
+- [x] delete
+- [x] copy
+- [ ] rename
+- [x] list
+- [x] scan
+- [x] presign
+- [ ] blocking
+
+## Configuration
+
+- `root`: Set the work directory for backend
+- `bucket`: Set the container name for backend
+- `endpoint`: Customizable endpoint setting
+- `credentials`: Credential string for GCS OAuth2
+- `predefined_acl`: Predefined ACL for GCS
+- `default_storage_class`: Default storage class for GCS
+
+Refer to public API docs for more information.
+
+## Example
+
+### Via Builder
+
+```rust
+use anyhow::Result;
+use opendal::services::Gcs;
+use opendal::Operator;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // create backend builder
+    let mut builder = Gcs::default();
+
+    // set the storage bucket for OpenDAL
+    builder.bucket("test");
+    // set the working directory root for GCS
+    // all operations will happen within it
+    builder.root("/path/to/dir");
+    // set the credentials for GCS OAUTH2 authentication
+    builder.credential("authentication token");
+    // set the predefined ACL for GCS
+    builder.predefined_acl("publicRead");
+    // set the default storage class for GCS
+    builder.default_storage_class("STANDARD");
+
+    let op: Operator = Operator::new(builder)?.finish();
+    Ok(())
+}
+```

--- a/website/docs/services/azblob.mdx
+++ b/website/docs/services/azblob.mdx
@@ -17,11 +17,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/azdfs.mdx
+++ b/website/docs/services/azdfs.mdx
@@ -18,11 +18,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/cos.mdx
+++ b/website/docs/services/cos.mdx
@@ -17,11 +17,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/fs.mdx
+++ b/website/docs/services/fs.mdx
@@ -17,11 +17,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/ftp.mdx
+++ b/website/docs/services/ftp.mdx
@@ -17,11 +17,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/gcs.mdx
+++ b/website/docs/services/gcs.mdx
@@ -1,0 +1,69 @@
+---
+title: Gcs
+---
+
+Google Cloud Storage Support
+
+import Docs from '../../../core/src/services/gcs/docs.md'
+
+<Docs components={props.components} />
+
+### Via Config
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+  <TabItem value="rust" label="Rust" default>
+
+```rust
+use anyhow::Result;
+use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut map = HashMap::new();
+    map.insert("bucket".to_string(), "test".to_string());
+    map.insert("root".to_string(), "/path/to/dir".to_string());
+    map.insert("credential".to_string(), "authentication token".to_string());
+    map.insert("predefined_acl".to_string(), "publicRead".to_string());
+    map.insert("default_storage_class".to_string(), "STANDARD".to_string());
+    let op: Operator = Operator::via_map(Scheme::Gcs, map)?;
+    Ok(())
+}
+```
+
+  </TabItem>
+  <TabItem value="node.js" label="Node.js">
+
+```javascript
+import { Operator } from "opendal";
+async function main() {
+  const op = new Operator("gcs", {
+    bucket: "test",
+    root: "/path/to/dir",
+    credential: "authentication token",
+    predefined_acl: "publicRead",
+    default_storage_class: "STANDARD",
+  });
+}
+```
+
+  </TabItem>
+  <TabItem value="python" label="Python">
+
+```python
+import opendal
+op = opendal.Operator("gcs",
+    bucket="test",
+    root="/path/to/dir",
+    credential="authentication token",
+    predefined_acl="publicRead",
+    default_storage_class="STANDARD",
+)
+```
+
+  </TabItem>
+</Tabs>

--- a/website/docs/services/hdfs.mdx
+++ b/website/docs/services/hdfs.mdx
@@ -17,11 +17,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/ipfs.mdx
+++ b/website/docs/services/ipfs.mdx
@@ -18,11 +18,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/memory.mdx
+++ b/website/docs/services/memory.mdx
@@ -18,11 +18,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/oss.mdx
+++ b/website/docs/services/oss.mdx
@@ -18,11 +18,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/redis.mdx
+++ b/website/docs/services/redis.mdx
@@ -18,11 +18,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/rocksdb.mdx
+++ b/website/docs/services/rocksdb.mdx
@@ -17,11 +17,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/s3.mdx
+++ b/website/docs/services/s3.mdx
@@ -19,11 +19,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/sftp.mdx
+++ b/website/docs/services/sftp.mdx
@@ -26,11 +26,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/sled.mdx
+++ b/website/docs/services/sled.mdx
@@ -18,11 +18,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/website/docs/services/webhdfs.mdx
+++ b/website/docs/services/webhdfs.mdx
@@ -18,11 +18,10 @@ import TabItem from '@theme/TabItem';
   <TabItem value="rust" label="Rust" default>
 
 ```rust
-use std::sync::Arc;
-
 use anyhow::Result;
-use opendal::Scheme;
 use opendal::Operator;
+use opendal::Scheme;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
Update #2304

All examples of Via Config written in Rust have unused import `Arc` and missing import `HashMap`. I update it for all service docs and format them with `cargo fmt`.