### PR TITLE
docs(services/gcs): fix rust core doc include

### DIFF
--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -44,6 +44,7 @@ const DEFAULT_GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.read
 const DEFAULT_WRITE_FIXED_SIZE: usize = 8 * 1024 * 1024;
 
 /// [Google Cloud Storage](https://cloud.google.com/storage) services support.
+#[doc = include_str!("docs.md")]
 #[derive(Default)]
 pub struct GcsBuilder {
     /// root URI, all operations happens under `root`


### PR DESCRIPTION
https://opendal.apache.org/docs/rust/opendal/services/struct.Gcs.html

Currently, the doc of gcs in the rust core's docs is missing.