### PR TITLE
fix(oay): pass litmus copymove test

### DIFF
--- a/bin/oay/src/services/webdav/webdavfs.rs
+++ b/bin/oay/src/services/webdav/webdavfs.rs
@@ -167,18 +167,13 @@ impl DavFileSystem for WebdavFs {
                 .to_str()
                 .ok_or(FsError::GeneralFailure)?;
             let to_path = to.as_rel_ospath().to_str().ok_or(FsError::GeneralFailure)?;
-            let res = self.op.rename(from_path, to_path).await;
-            match res {
-                Ok(_) => Ok(()),
-                Err(e) => {
-                    if from.is_collection() {
-                        let _ = self.remove_file(to).await;
-                        self.rename(from, to).await
-                    } else {
-                        Err(convert_error(e))
-                    }
-                }
+            if from.is_collection() {
+                let _ = self.remove_file(to).await;
             }
+            self.op
+                .rename(from_path, to_path)
+                .await
+                .map_err(convert_error)
         }
         .boxed()
     }

--- a/bin/oay/src/services/webdav/webdavfs.rs
+++ b/bin/oay/src/services/webdav/webdavfs.rs
@@ -25,6 +25,7 @@ use dav_server::fs::DavDirEntry;
 use dav_server::fs::DavFile;
 use dav_server::fs::DavFileSystem;
 use dav_server::fs::DavMetaData;
+use dav_server::fs::FsError;
 use futures::FutureExt;
 use futures_util::Stream;
 use futures_util::StreamExt;
@@ -146,11 +147,13 @@ impl DavFileSystem for WebdavFs {
 
     fn copy<'a>(&'a self, from: &'a DavPath, to: &'a DavPath) -> dav_server::fs::FsFuture<()> {
         async move {
+            let from_path = from
+                .as_rel_ospath()
+                .to_str()
+                .ok_or(FsError::GeneralFailure)?;
+            let to_path = to.as_rel_ospath().to_str().ok_or(FsError::GeneralFailure)?;
             self.op
-                .copy(
-                    from.as_rel_ospath().to_str().unwrap(),
-                    to.as_rel_ospath().to_str().unwrap(),
-                )
+                .copy(from_path, to_path)
                 .await
                 .map_err(convert_error)
         }
@@ -159,17 +162,16 @@ impl DavFileSystem for WebdavFs {
 
     fn rename<'a>(&'a self, from: &'a DavPath, to: &'a DavPath) -> dav_server::fs::FsFuture<()> {
         async move {
-            let res = self
-                .op
-                .rename(
-                    from.as_rel_ospath().to_str().unwrap(),
-                    to.as_rel_ospath().to_str().unwrap(),
-                )
-                .await;
+            let from_path = from
+                .as_rel_ospath()
+                .to_str()
+                .ok_or(FsError::GeneralFailure)?;
+            let to_path = to.as_rel_ospath().to_str().ok_or(FsError::GeneralFailure)?;
+            let res = self.op.rename(from_path, to_path).await;
             match res {
                 Ok(_) => Ok(()),
                 Err(e) => {
-                    if e.kind() == opendal::ErrorKind::Unexpected && from.is_collection() {
+                    if from.is_collection() {
                         let _ = self.remove_file(to).await;
                         self.rename(from, to).await
                     } else {


### PR DESCRIPTION
This PR fix litmus copymove test `copy_overwrite`, `move` and `move_coll`. Refer to [`dav-server-rs::LocalFs::rename`](https://github.com/messense/dav-server-rs/blob/1346f52007aab7c701288b4c3e99b5e4d44369c3/src/localfs.rs#L414-L425)
```txt
-> running `copymove':
 0. init.................. pass
 1. begin................. pass
 2. copy_init............. pass
 3. copy_simple........... pass
 4. copy_overwrite........ pass
 5. copy_nodestcoll....... pass
 6. copy_cleanup.......... pass
 7. copy_coll............. pass
 8. copy_shallow.......... pass
 9. move.................. pass
10. move_coll............. pass
11. move_cleanup.......... pass
12. finish................ pass
<- summary for `copymove': of 13 tests run: 13 passed, 0 failed. 100.0%
```

https://github.com/apache/incubator-opendal/issues/2586