### PR TITLE
refactor: Migrate Writer to stream based instead

### DIFF
--- a/core/benches/oio/utils.rs
+++ b/core/benches/oio/utils.rs
@@ -27,7 +27,7 @@ pub struct BlackHoleWriter;
 
 #[async_trait]
 impl oio::Write for BlackHoleWriter {
-    async fn sink(&mut self, _: u64, _: Streamer) -> opendal::Result<()> {
+    async fn write(&mut self, _: u64, _: Streamer) -> opendal::Result<()> {
         Ok(())
     }
 

--- a/core/benches/oio/utils.rs
+++ b/core/benches/oio/utils.rs
@@ -27,10 +27,6 @@ pub struct BlackHoleWriter;
 
 #[async_trait]
 impl oio::Write for BlackHoleWriter {
-    async fn write(&mut self, _: Bytes) -> opendal::Result<()> {
-        Ok(())
-    }
-
     async fn sink(&mut self, _: u64, _: Streamer) -> opendal::Result<()> {
         Ok(())
     }

--- a/core/benches/oio/utils.rs
+++ b/core/benches/oio/utils.rs
@@ -27,7 +27,7 @@ pub struct BlackHoleWriter;
 
 #[async_trait]
 impl oio::Write for BlackHoleWriter {
-    async fn write(&mut self, _: u64, _: Streamer) -> opendal::Result<()> {
+    async fn write(&mut self, _: Streamer) -> opendal::Result<()> {
         Ok(())
     }
 

--- a/core/benches/oio/write.rs
+++ b/core/benches/oio/write.rs
@@ -47,12 +47,9 @@ pub fn bench_at_least_buf_write(c: &mut Criterion) {
             b.to_async(&*TOKIO).iter(|| async {
                 let mut w = AtLeastBufWriter::new(BlackHoleWriter, 256 * 1024);
 
-                w.write(
-                    content.len() as u64,
-                    Box::new(oio::Cursor::from(content.clone())),
-                )
-                .await
-                .unwrap();
+                w.write(Box::new(oio::Cursor::from(content.clone())))
+                    .await
+                    .unwrap();
                 w.close().await.unwrap();
             })
         });
@@ -78,12 +75,9 @@ pub fn bench_exact_buf_write(c: &mut Criterion) {
         group.bench_with_input(size.to_string(), &content, |b, content| {
             b.to_async(&*TOKIO).iter(|| async {
                 let mut w = ExactBufWriter::new(BlackHoleWriter, 256 * 1024);
-                w.write(
-                    content.len() as u64,
-                    Box::new(oio::Cursor::from(content.clone())),
-                )
-                .await
-                .unwrap();
+                w.write(Box::new(oio::Cursor::from(content.clone())))
+                    .await
+                    .unwrap();
                 w.close().await.unwrap();
             })
         });

--- a/core/benches/oio/write.rs
+++ b/core/benches/oio/write.rs
@@ -47,7 +47,7 @@ pub fn bench_at_least_buf_write(c: &mut Criterion) {
             b.to_async(&*TOKIO).iter(|| async {
                 let mut w = AtLeastBufWriter::new(BlackHoleWriter, 256 * 1024);
 
-                w.sink(
+                w.write(
                     content.len() as u64,
                     Box::new(oio::Cursor::from(content.clone())),
                 )
@@ -78,7 +78,7 @@ pub fn bench_exact_buf_write(c: &mut Criterion) {
         group.bench_with_input(size.to_string(), &content, |b, content| {
             b.to_async(&*TOKIO).iter(|| async {
                 let mut w = ExactBufWriter::new(BlackHoleWriter, 256 * 1024);
-                w.sink(
+                w.write(
                     content.len() as u64,
                     Box::new(oio::Cursor::from(content.clone())),
                 )

--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -199,7 +199,7 @@ impl<I: oio::Write + 'static> oio::BlockingWrite for BlockingWrapper<I> {
     fn write(&mut self, bs: Bytes) -> Result<()> {
         self.handle.block_on(
             self.inner
-                .sink(bs.len() as u64, Box::new(oio::Cursor::from(bs))),
+                .write(bs.len() as u64, Box::new(oio::Cursor::from(bs))),
         )
     }
 

--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -197,7 +197,10 @@ impl<I: oio::Read + 'static> oio::BlockingRead for BlockingWrapper<I> {
 
 impl<I: oio::Write + 'static> oio::BlockingWrite for BlockingWrapper<I> {
     fn write(&mut self, bs: Bytes) -> Result<()> {
-        self.handle.block_on(self.inner.write(bs))
+        self.handle.block_on(
+            self.inner
+                .sink(bs.len() as u64, Box::new(oio::Cursor::from(bs))),
+        )
     }
 
     fn close(&mut self) -> Result<()> {

--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -197,10 +197,8 @@ impl<I: oio::Read + 'static> oio::BlockingRead for BlockingWrapper<I> {
 
 impl<I: oio::Write + 'static> oio::BlockingWrite for BlockingWrapper<I> {
     fn write(&mut self, bs: Bytes) -> Result<()> {
-        self.handle.block_on(
-            self.inner
-                .write(bs.len() as u64, Box::new(oio::Cursor::from(bs))),
-        )
+        self.handle
+            .block_on(self.inner.write(Box::new(oio::Cursor::from(bs))))
     }
 
     fn close(&mut self) -> Result<()> {

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -711,29 +711,6 @@ impl<W> oio::Write for CompleteWriter<W>
 where
     W: oio::Write,
 {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        let n = bs.len();
-
-        if let Some(size) = self.size {
-            if self.written + n as u64 > size {
-                return Err(Error::new(
-                    ErrorKind::ContentTruncated,
-                    &format!(
-                        "writer got too much data, expect: {size}, actual: {}",
-                        self.written + n as u64
-                    ),
-                ));
-            }
-        }
-
-        let w = self.inner.as_mut().ok_or_else(|| {
-            Error::new(ErrorKind::Unexpected, "writer has been closed or aborted")
-        })?;
-        w.write(bs).await?;
-        self.written += n as u64;
-        Ok(())
-    }
-
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         if let Some(total_size) = self.size {
             if self.written + size > total_size {

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -711,7 +711,7 @@ impl<W> oio::Write for CompleteWriter<W>
 where
     W: oio::Write,
 {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         if let Some(total_size) = self.size {
             if self.written + size > total_size {
                 return Err(Error::new(
@@ -727,7 +727,7 @@ where
         let w = self.inner.as_mut().ok_or_else(|| {
             Error::new(ErrorKind::Unexpected, "writer has been closed or aborted")
         })?;
-        w.sink(size, s).await?;
+        w.write(size, s).await?;
         self.written += size;
         Ok(())
     }

--- a/core/src/layers/concurrent_limit.rs
+++ b/core/src/layers/concurrent_limit.rs
@@ -285,16 +285,12 @@ impl<R: oio::BlockingRead> oio::BlockingRead for ConcurrentLimitWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for ConcurrentLimitWrapper<R> {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        self.inner.write(bs).await
+    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+        self.inner.sink(size, s).await
     }
 
     async fn abort(&mut self) -> Result<()> {
         self.inner.abort().await
-    }
-
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        self.inner.sink(size, s).await
     }
 
     async fn close(&mut self) -> Result<()> {

--- a/core/src/layers/concurrent_limit.rs
+++ b/core/src/layers/concurrent_limit.rs
@@ -285,8 +285,8 @@ impl<R: oio::BlockingRead> oio::BlockingRead for ConcurrentLimitWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for ConcurrentLimitWrapper<R> {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        self.inner.sink(size, s).await
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+        self.inner.write(size, s).await
     }
 
     async fn abort(&mut self) -> Result<()> {

--- a/core/src/layers/concurrent_limit.rs
+++ b/core/src/layers/concurrent_limit.rs
@@ -285,8 +285,8 @@ impl<R: oio::BlockingRead> oio::BlockingRead for ConcurrentLimitWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for ConcurrentLimitWrapper<R> {
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        self.inner.write(size, s).await
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
+        self.inner.write(s).await
     }
 
     async fn abort(&mut self) -> Result<()> {

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -411,8 +411,8 @@ impl<T: oio::Write> oio::Write for ErrorContextWrapper<T> {
         })
     }
 
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        self.inner.sink(size, s).await.map_err(|err| {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+        self.inner.write(size, s).await.map_err(|err| {
             err.with_operation(WriteOperation::Sink)
                 .with_context("service", self.scheme)
                 .with_context("path", &self.path)

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -411,8 +411,8 @@ impl<T: oio::Write> oio::Write for ErrorContextWrapper<T> {
         })
     }
 
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        self.inner.write(size, s).await.map_err(|err| {
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
+        self.inner.write(s).await.map_err(|err| {
             err.with_operation(WriteOperation::Sink)
                 .with_context("service", self.scheme)
                 .with_context("path", &self.path)

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -403,14 +403,6 @@ impl<T: oio::BlockingRead> oio::BlockingRead for ErrorContextWrapper<T> {
 
 #[async_trait::async_trait]
 impl<T: oio::Write> oio::Write for ErrorContextWrapper<T> {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        self.inner.write(bs).await.map_err(|err| {
-            err.with_operation(WriteOperation::Write)
-                .with_context("service", self.scheme)
-                .with_context("path", &self.path)
-        })
-    }
-
     async fn abort(&mut self) -> Result<()> {
         self.inner.abort().await.map_err(|err| {
             err.with_operation(WriteOperation::Abort)

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -1252,40 +1252,6 @@ impl<W> LoggingWriter<W> {
 
 #[async_trait]
 impl<W: oio::Write> oio::Write for LoggingWriter<W> {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        let size = bs.len();
-        match self.inner.write(bs).await {
-            Ok(_) => {
-                self.written += size as u64;
-                trace!(
-                    target: LOGGING_TARGET,
-                    "service={} operation={} path={} written={} -> data write {}B",
-                    self.ctx.scheme,
-                    WriteOperation::Write,
-                    self.path,
-                    self.written,
-                    size
-                );
-                Ok(())
-            }
-            Err(err) => {
-                if let Some(lvl) = self.ctx.error_level(&err) {
-                    log!(
-                        target: LOGGING_TARGET,
-                        lvl,
-                        "service={} operation={} path={} written={} -> data write failed: {}",
-                        self.ctx.scheme,
-                        WriteOperation::Write,
-                        self.path,
-                        self.written,
-                        self.ctx.error_print(&err),
-                    )
-                }
-                Err(err)
-            }
-        }
-    }
-
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         match self.inner.sink(size, s).await {
             Ok(_) => {

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -1252,7 +1252,7 @@ impl<W> LoggingWriter<W> {
 
 #[async_trait]
 impl<W: oio::Write> oio::Write for LoggingWriter<W> {
-    async fn write(&mut self, mut s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
         let size = s.size();
         match self.inner.write(s).await {
             Ok(_) => {

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -1252,8 +1252,8 @@ impl<W> LoggingWriter<W> {
 
 #[async_trait]
 impl<W: oio::Write> oio::Write for LoggingWriter<W> {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        match self.inner.sink(size, s).await {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+        match self.inner.write(size, s).await {
             Ok(_) => {
                 self.written += size;
                 trace!(

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -1252,8 +1252,9 @@ impl<W> LoggingWriter<W> {
 
 #[async_trait]
 impl<W: oio::Write> oio::Write for LoggingWriter<W> {
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        match self.inner.write(size, s).await {
+    async fn write(&mut self, mut s: oio::Streamer) -> Result<()> {
+        let size = s.size();
+        match self.inner.write(s).await {
             Ok(_) => {
                 self.written += size;
                 trace!(

--- a/core/src/layers/madsim.rs
+++ b/core/src/layers/madsim.rs
@@ -302,7 +302,7 @@ pub struct MadsimWriter {
 
 #[async_trait]
 impl oio::Write for MadsimWriter {
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> crate::Result<()> {
+    async fn write(&mut self, s: oio::Streamer) -> crate::Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "will be supported in the future",

--- a/core/src/layers/madsim.rs
+++ b/core/src/layers/madsim.rs
@@ -302,7 +302,7 @@ pub struct MadsimWriter {
 
 #[async_trait]
 impl oio::Write for MadsimWriter {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> crate::Result<()> {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> crate::Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "will be supported in the future",

--- a/core/src/layers/madsim.rs
+++ b/core/src/layers/madsim.rs
@@ -302,22 +302,6 @@ pub struct MadsimWriter {
 
 #[async_trait]
 impl oio::Write for MadsimWriter {
-    async fn write(&mut self, bs: Bytes) -> crate::Result<()> {
-        #[cfg(madsim)]
-        {
-            let req = Request::Write(self.path.to_string(), bs);
-            let ep = Endpoint::bind(self.addr).await?;
-            let (tx, mut rx) = ep.connect1(self.addr).await?;
-            tx.send(Box::new(req)).await?;
-            rx.recv().await?;
-            Ok(())
-        }
-        #[cfg(not(madsim))]
-        {
-            unreachable!("madsim is not enabled")
-        }
-    }
-
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> crate::Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -847,9 +847,10 @@ impl<R: oio::BlockingRead> oio::BlockingRead for MetricWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for MetricWrapper<R> {
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
+        let size = s.size();
         self.inner
-            .write(size, s)
+            .write(s)
             .await
             .map(|_| self.bytes += size)
             .map_err(|err| {

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -847,18 +847,6 @@ impl<R: oio::BlockingRead> oio::BlockingRead for MetricWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for MetricWrapper<R> {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        let size = bs.len();
-        self.inner
-            .write(bs)
-            .await
-            .map(|_| self.bytes += size as u64)
-            .map_err(|err| {
-                self.handle.increment_errors_total(self.op, err.kind());
-                err
-            })
-    }
-
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.inner
             .sink(size, s)

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -847,9 +847,9 @@ impl<R: oio::BlockingRead> oio::BlockingRead for MetricWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for MetricWrapper<R> {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.inner
-            .sink(size, s)
+            .write(size, s)
             .await
             .map(|_| self.bytes += size)
             .map_err(|err| {

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -337,9 +337,9 @@ impl<R: oio::BlockingRead> oio::BlockingRead for MinitraceWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for MinitraceWrapper<R> {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.inner
-            .sink(size, s)
+            .write(size, s)
             .in_span(Span::enter_with_parent(
                 WriteOperation::Sink.into_static(),
                 &self.span,

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -337,9 +337,9 @@ impl<R: oio::BlockingRead> oio::BlockingRead for MinitraceWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for MinitraceWrapper<R> {
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
         self.inner
-            .write(size, s)
+            .write(s)
             .in_span(Span::enter_with_parent(
                 WriteOperation::Sink.into_static(),
                 &self.span,

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -337,16 +337,6 @@ impl<R: oio::BlockingRead> oio::BlockingRead for MinitraceWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for MinitraceWrapper<R> {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        self.inner
-            .write(bs)
-            .in_span(Span::enter_with_parent(
-                WriteOperation::Write.into_static(),
-                &self.span,
-            ))
-            .await
-    }
-
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.inner
             .sink(size, s)

--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -313,8 +313,8 @@ impl<R: oio::BlockingRead> oio::BlockingRead for OtelTraceWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for OtelTraceWrapper<R> {
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        self.inner.write(size, s).await
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
+        self.inner.write(s).await
     }
 
     async fn abort(&mut self) -> Result<()> {

--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -313,10 +313,6 @@ impl<R: oio::BlockingRead> oio::BlockingRead for OtelTraceWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for OtelTraceWrapper<R> {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        self.inner.write(bs).await
-    }
-
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.inner.sink(size, s).await
     }

--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -313,8 +313,8 @@ impl<R: oio::BlockingRead> oio::BlockingRead for OtelTraceWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for OtelTraceWrapper<R> {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        self.inner.sink(size, s).await
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+        self.inner.write(size, s).await
     }
 
     async fn abort(&mut self) -> Result<()> {

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -662,9 +662,9 @@ impl<R: oio::BlockingRead> oio::BlockingRead for PrometheusMetricWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.inner
-            .sink(size, s)
+            .write(size, s)
             .await
             .map(|_| {
                 self.stats

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -662,23 +662,6 @@ impl<R: oio::BlockingRead> oio::BlockingRead for PrometheusMetricWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        let size = bs.len();
-        self.inner
-            .write(bs)
-            .await
-            .map(|_| {
-                self.stats
-                    .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::Write.into_static()])
-                    .observe(size as f64)
-            })
-            .map_err(|err| {
-                self.stats.increment_errors_total(self.op, err.kind());
-                err
-            })
-    }
-
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.inner
             .sink(size, s)

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -662,9 +662,10 @@ impl<R: oio::BlockingRead> oio::BlockingRead for PrometheusMetricWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
+        let size = s.size();
         self.inner
-            .write(size, s)
+            .write(s)
             .await
             .map(|_| {
                 self.stats

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -893,13 +893,13 @@ impl<R: oio::Write, I: RetryInterceptor> oio::Write for RetryWrapper<R, I> {
     /// The overhead is constant, which means the overhead will not increase with the size of
     /// stream. For example, if every `next` call cost 1ms, then the overhead will only take 0.005%
     /// which is acceptable.
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         let s = Arc::new(Mutex::new(s));
 
         let mut backoff = self.builder.build();
 
         loop {
-            match self.inner.sink(size, Box::new(s.clone())).await {
+            match self.inner.write(size, Box::new(s.clone())).await {
                 Ok(_) => return Ok(()),
                 Err(e) if !e.is_temporary() => return Err(e),
                 Err(e) => match backoff.next() {

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -893,13 +893,13 @@ impl<R: oio::Write, I: RetryInterceptor> oio::Write for RetryWrapper<R, I> {
     /// The overhead is constant, which means the overhead will not increase with the size of
     /// stream. For example, if every `next` call cost 1ms, then the overhead will only take 0.005%
     /// which is acceptable.
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
         let s = Arc::new(Mutex::new(s));
 
         let mut backoff = self.builder.build();
 
         loop {
-            match self.inner.write(size, Box::new(s.clone())).await {
+            match self.inner.write(Box::new(s.clone())).await {
                 Ok(_) => return Ok(()),
                 Err(e) if !e.is_temporary() => return Err(e),
                 Err(e) => match backoff.next() {

--- a/core/src/layers/throttle.rs
+++ b/core/src/layers/throttle.rs
@@ -217,8 +217,8 @@ impl<R: oio::BlockingRead> oio::BlockingRead for ThrottleWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for ThrottleWrapper<R> {
-    async fn write(&mut self, size: u64, s: Streamer) -> Result<()> {
-        self.inner.write(size, s).await
+    async fn write(&mut self, s: Streamer) -> Result<()> {
+        self.inner.write(s).await
     }
 
     async fn abort(&mut self) -> Result<()> {

--- a/core/src/layers/throttle.rs
+++ b/core/src/layers/throttle.rs
@@ -217,8 +217,8 @@ impl<R: oio::BlockingRead> oio::BlockingRead for ThrottleWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for ThrottleWrapper<R> {
-    async fn sink(&mut self, size: u64, s: Streamer) -> Result<()> {
-        self.inner.sink(size, s).await
+    async fn write(&mut self, size: u64, s: Streamer) -> Result<()> {
+        self.inner.write(size, s).await
     }
 
     async fn abort(&mut self) -> Result<()> {

--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -322,10 +322,10 @@ impl<R: oio::Read> oio::Read for TimeoutWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for TimeoutWrapper<R> {
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        let timeout = self.io_timeout(size);
+    async fn write(&mut self, mut s: oio::Streamer) -> Result<()> {
+        let timeout = self.io_timeout(s.size());
 
-        tokio::time::timeout(timeout, self.inner.write(size, s))
+        tokio::time::timeout(timeout, self.inner.write(s))
             .await
             .map_err(|_| {
                 Error::new(ErrorKind::Unexpected, "operation timeout")

--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -322,19 +322,6 @@ impl<R: oio::Read> oio::Read for TimeoutWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for TimeoutWrapper<R> {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        let timeout = self.io_timeout(bs.len() as u64);
-
-        tokio::time::timeout(timeout, self.inner.write(bs))
-            .await
-            .map_err(|_| {
-                Error::new(ErrorKind::Unexpected, "operation timeout")
-                    .with_operation(WriteOperation::Write)
-                    .with_context("timeout", timeout.as_secs_f64().to_string())
-                    .set_temporary()
-            })?
-    }
-
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         let timeout = self.io_timeout(size);
 

--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -322,7 +322,7 @@ impl<R: oio::Read> oio::Read for TimeoutWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for TimeoutWrapper<R> {
-    async fn write(&mut self, mut s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
         let timeout = self.io_timeout(s.size());
 
         tokio::time::timeout(timeout, self.inner.write(s))

--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -322,10 +322,10 @@ impl<R: oio::Read> oio::Read for TimeoutWrapper<R> {
 
 #[async_trait]
 impl<R: oio::Write> oio::Write for TimeoutWrapper<R> {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         let timeout = self.io_timeout(size);
 
-        tokio::time::timeout(timeout, self.inner.sink(size, s))
+        tokio::time::timeout(timeout, self.inner.write(size, s))
             .await
             .map_err(|_| {
                 Error::new(ErrorKind::Unexpected, "operation timeout")

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -324,14 +324,6 @@ impl<R: oio::Write> oio::Write for TracingWrapper<R> {
         parent = &self.span,
         level = "trace",
         skip_all)]
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        self.inner.write(bs).await
-    }
-
-    #[tracing::instrument(
-        parent = &self.span,
-        level = "trace",
-        skip_all)]
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.inner.sink(size, s).await
     }

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -324,8 +324,8 @@ impl<R: oio::Write> oio::Write for TracingWrapper<R> {
         parent = &self.span,
         level = "trace",
         skip_all)]
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        self.inner.sink(size, s).await
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+        self.inner.write(size, s).await
     }
 
     #[tracing::instrument(

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -324,8 +324,8 @@ impl<R: oio::Write> oio::Write for TracingWrapper<R> {
         parent = &self.span,
         level = "trace",
         skip_all)]
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        self.inner.write(size, s).await
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
+        self.inner.write(s).await
     }
 
     #[tracing::instrument(

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -389,7 +389,7 @@ impl<S> KvWriter<S> {
 
 #[async_trait]
 impl<S: Adapter> oio::Write for KvWriter<S> {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -389,13 +389,6 @@ impl<S> KvWriter<S> {
 
 #[async_trait]
 impl<S: Adapter> oio::Write for KvWriter<S> {
-    // TODO: we need to support append in the future.
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        self.buf = Some(bs.into());
-
-        Ok(())
-    }
-
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -389,7 +389,7 @@ impl<S> KvWriter<S> {
 
 #[async_trait]
 impl<S: Adapter> oio::Write for KvWriter<S> {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/raw/adapters/typed_kv/backend.rs
+++ b/core/src/raw/adapters/typed_kv/backend.rs
@@ -402,7 +402,7 @@ impl<S> KvWriter<S> {
 
 #[async_trait]
 impl<S: Adapter> oio::Write for KvWriter<S> {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/raw/adapters/typed_kv/backend.rs
+++ b/core/src/raw/adapters/typed_kv/backend.rs
@@ -402,13 +402,6 @@ impl<S> KvWriter<S> {
 
 #[async_trait]
 impl<S: Adapter> oio::Write for KvWriter<S> {
-    // TODO: we need to support append in the future.
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        self.buf.push(bs);
-
-        Ok(())
-    }
-
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/raw/adapters/typed_kv/backend.rs
+++ b/core/src/raw/adapters/typed_kv/backend.rs
@@ -402,7 +402,7 @@ impl<S> KvWriter<S> {
 
 #[async_trait]
 impl<S: Adapter> oio::Write for KvWriter<S> {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -155,7 +155,10 @@ impl HttpClient {
                 .set_source(err)
         });
 
-        let body = IncomingAsyncBody::new(Box::new(oio::into_stream(stream)), content_length);
+        let body = IncomingAsyncBody::new(
+            Box::new(oio::into_stream(content_length.unwrap_or_default(), stream)),
+            content_length,
+        );
 
         let resp = hr.body(body).expect("response must build succeed");
 

--- a/core/src/raw/http_util/multipart.rs
+++ b/core/src/raw/http_util/multipart.rs
@@ -182,7 +182,7 @@ pub struct MultipartStream<T: Part> {
 }
 
 impl<T: Part> Stream for MultipartStream<T> {
-    fn size(&mut self) -> u64 {
+    fn size(&self) -> u64 {
         self.size
     }
 
@@ -338,7 +338,7 @@ pub struct FormDataPartStream {
 
 #[async_trait]
 impl Stream for FormDataPartStream {
-    fn size(&mut self) -> u64 {
+    fn size(&self) -> u64 {
         self.size
     }
 
@@ -701,7 +701,7 @@ pub struct MixedPartStream {
 }
 
 impl Stream for MixedPartStream {
-    fn size(&mut self) -> u64 {
+    fn size(&self) -> u64 {
         self.size
     }
 

--- a/core/src/raw/http_util/multipart.rs
+++ b/core/src/raw/http_util/multipart.rs
@@ -125,7 +125,7 @@ impl<T: Part> Multipart<T> {
         let mut parts = VecDeque::new();
         // Write headers.
         for v in self.parts.into_iter() {
-            let mut stream = v.format();
+            let stream = v.format();
             total_size += stream.size();
             parts.push_back(stream);
         }
@@ -154,7 +154,7 @@ impl<T: Part> Multipart<T> {
     /// This function will make sure content_type and content_length set correctly.
     pub fn apply(self, mut builder: http::request::Builder) -> Result<Request<AsyncBody>> {
         let boundary = self.boundary.clone();
-        let mut stream = self.build();
+        let stream = self.build();
 
         // Insert content type with correct boundary.
         builder = builder.header(
@@ -755,7 +755,7 @@ mod tests {
             .part(FormDataPart::new("foo").content(Bytes::from("bar")))
             .part(FormDataPart::new("hello").content(Bytes::from("world")));
 
-        let mut body = multipart.build();
+        let body = multipart.build();
         let size = body.size();
         let bs = body.collect().await.unwrap();
         assert_eq!(size, bs.len() as u64);
@@ -917,7 +917,7 @@ Upload to Amazon S3
                     .content(r#"{"metadata": {"type": "calico"}}"#),
             );
 
-        let mut body = multipart.build();
+        let body = multipart.build();
         let size = body.size();
         let bs = body.collect().await?;
         assert_eq!(size, bs.len() as u64);
@@ -1024,7 +1024,7 @@ content-length: 32
                     .header("content-length".parse().unwrap(), "0".parse().unwrap()),
             );
 
-        let mut body = multipart.build();
+        let body = multipart.build();
         let size = body.size();
         let bs = body.collect().await?;
         assert_eq!(size, bs.len() as u64);

--- a/core/src/raw/http_util/multipart.rs
+++ b/core/src/raw/http_util/multipart.rs
@@ -126,7 +126,7 @@ impl<T: Part> Multipart<T> {
         // Write headers.
         for v in self.parts.into_iter() {
             let stream = v.format();
-            total_size += stream.size();
+            total_size += pre_part.len() as u64 + stream.size();
             parts.push_back(stream);
         }
 

--- a/core/src/raw/oio/cursor.rs
+++ b/core/src/raw/oio/cursor.rs
@@ -161,6 +161,10 @@ impl oio::BlockingRead for Cursor {
 }
 
 impl oio::Stream for Cursor {
+    fn size(&mut self) -> u64 {
+        self.inner.len() as u64 - self.pos
+    }
+
     fn poll_next(&mut self, _: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
         if self.is_empty() {
             return Poll::Ready(None);
@@ -327,6 +331,10 @@ impl ChunkedCursor {
 }
 
 impl oio::Stream for ChunkedCursor {
+    fn size(&mut self) -> u64 {
+        self.len() as u64
+    }
+
     fn poll_next(&mut self, _: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
         if self.is_empty() {
             return Poll::Ready(None);

--- a/core/src/raw/oio/cursor.rs
+++ b/core/src/raw/oio/cursor.rs
@@ -180,7 +180,7 @@ impl oio::Stream for Cursor {
 /// ChunkedCursor is used represents a non-contiguous bytes in memory.
 ///
 /// This is useful when we buffer users' random writes without copy. ChunkedCursor implements
-/// [`oio::Stream`] so it can be used in [`oio::Write::sink`] directly.
+/// [`oio::Stream`] so it can be used in [`oio::Write::write`] directly.
 ///
 /// # TODO
 ///

--- a/core/src/raw/oio/cursor.rs
+++ b/core/src/raw/oio/cursor.rs
@@ -161,7 +161,7 @@ impl oio::BlockingRead for Cursor {
 }
 
 impl oio::Stream for Cursor {
-    fn size(&mut self) -> u64 {
+    fn size(&self) -> u64 {
         self.inner.len() as u64 - self.pos
     }
 
@@ -331,7 +331,7 @@ impl ChunkedCursor {
 }
 
 impl oio::Stream for ChunkedCursor {
-    fn size(&mut self) -> u64 {
+    fn size(&self) -> u64 {
         self.len() as u64
     }
 

--- a/core/src/raw/oio/stream/api.rs
+++ b/core/src/raw/oio/stream/api.rs
@@ -83,7 +83,7 @@ impl<T: Stream + ?Sized> Stream for Box<T> {
 impl<T: Stream + ?Sized> Stream for Arc<std::sync::Mutex<T>> {
     fn size(&self) -> u64 {
         match self.try_lock() {
-            Ok(mut this) => this.size(),
+            Ok(this) => this.size(),
             Err(_) => panic!("the stream is expected to have only one consumer, but it's not"),
         }
     }
@@ -112,7 +112,7 @@ impl<T: Stream + ?Sized> Stream for Arc<std::sync::Mutex<T>> {
 impl<T: Stream + ?Sized> Stream for Arc<tokio::sync::Mutex<T>> {
     fn size(&self) -> u64 {
         match self.try_lock() {
-            Ok(mut this) => this.size(),
+            Ok(this) => this.size(),
             Err(_) => panic!("the stream is expected to have only one consumer, but it's not"),
         }
     }

--- a/core/src/raw/oio/stream/into_stream.rs
+++ b/core/src/raw/oio/stream/into_stream.rs
@@ -44,7 +44,7 @@ impl<S> oio::Stream for IntoStream<S>
 where
     S: futures::Stream<Item = Result<Bytes>> + Send + Sync + Unpin,
 {
-    fn size(&mut self) -> u64 {
+    fn size(&self) -> u64 {
         self.size
     }
 

--- a/core/src/raw/oio/stream/into_stream_from_reader.rs
+++ b/core/src/raw/oio/stream/into_stream_from_reader.rs
@@ -54,7 +54,7 @@ impl<S> oio::Stream for FromReaderStream<S>
 where
     S: AsyncRead + Send + Sync + Unpin,
 {
-    fn size(&mut self) -> u64 {
+    fn size(&self) -> u64 {
         self.size
     }
 

--- a/core/src/raw/oio/write/api.rs
+++ b/core/src/raw/oio/write/api.rs
@@ -30,7 +30,7 @@ use crate::*;
 pub enum WriteOperation {
     /// Operation for [`Write::write`]
     Write,
-    /// Operation for [`Write::sink`]
+    /// Operation for [`Write::write`]
     Sink,
     /// Operation for [`Write::abort`]
     Abort,
@@ -95,7 +95,7 @@ pub trait Write: Unpin + Send + Sync {
     /// content length. And users will call write multiple times.
     ///
     /// Please make sure `write` is safe to re-enter.
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()>;
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()>;
 
     /// Abort the pending writer.
     async fn abort(&mut self) -> Result<()>;
@@ -106,7 +106,7 @@ pub trait Write: Unpin + Send + Sync {
 
 #[async_trait]
 impl Write for () {
-    async fn sink(&mut self, _: u64, _: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _: u64, _: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "output writer doesn't support sink",
@@ -133,8 +133,8 @@ impl Write for () {
 /// To make Writer work as expected, we must add this impl.
 #[async_trait]
 impl<T: Write + ?Sized> Write for Box<T> {
-    async fn sink(&mut self, n: u64, s: oio::Streamer) -> Result<()> {
-        (**self).sink(n, s).await
+    async fn write(&mut self, n: u64, s: oio::Streamer) -> Result<()> {
+        (**self).write(n, s).await
     }
 
     async fn abort(&mut self) -> Result<()> {

--- a/core/src/raw/oio/write/append_object_write.rs
+++ b/core/src/raw/oio/write/append_object_write.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 
 use crate::raw::oio::Streamer;
 use crate::raw::*;
@@ -79,17 +78,6 @@ impl<W> oio::Write for AppendObjectWriter<W>
 where
     W: AppendObjectWrite,
 {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        let offset = self.offset().await?;
-
-        let size = bs.len() as u64;
-
-        self.inner
-            .append(offset, size, AsyncBody::Bytes(bs))
-            .await
-            .map(|_| self.offset = Some(offset + size))
-    }
-
     async fn sink(&mut self, size: u64, s: Streamer) -> Result<()> {
         let offset = self.offset().await?;
 

--- a/core/src/raw/oio/write/append_object_write.rs
+++ b/core/src/raw/oio/write/append_object_write.rs
@@ -78,7 +78,7 @@ impl<W> oio::Write for AppendObjectWriter<W>
 where
     W: AppendObjectWrite,
 {
-    async fn sink(&mut self, size: u64, s: Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: Streamer) -> Result<()> {
         let offset = self.offset().await?;
 
         self.inner

--- a/core/src/raw/oio/write/append_object_write.rs
+++ b/core/src/raw/oio/write/append_object_write.rs
@@ -17,7 +17,7 @@
 
 use async_trait::async_trait;
 
-use crate::raw::oio::Streamer;
+use crate::raw::oio::{Stream, Streamer};
 use crate::raw::*;
 use crate::*;
 
@@ -78,11 +78,12 @@ impl<W> oio::Write for AppendObjectWriter<W>
 where
     W: AppendObjectWrite,
 {
-    async fn write(&mut self, size: u64, s: Streamer) -> Result<()> {
+    async fn write(&mut self, s: Streamer) -> Result<()> {
         let offset = self.offset().await?;
 
+        let size = s.size();
         self.inner
-            .append(offset, size, AsyncBody::Stream(s))
+            .append(offset, s.size(), AsyncBody::Stream(s))
             .await
             .map(|_| self.offset = Some(offset + size))
     }

--- a/core/src/raw/oio/write/append_object_write.rs
+++ b/core/src/raw/oio/write/append_object_write.rs
@@ -38,7 +38,7 @@ pub trait AppendObjectWrite: Send + Sync + Unpin {
     async fn offset(&self) -> Result<u64>;
 
     /// Append the data to the end of this object.
-    async fn append(&self, offset: u64, size: u64, body: AsyncBody) -> Result<()>;
+    async fn append(&self, offset: u64, stream: Streamer) -> Result<()>;
 }
 
 /// AppendObjectWriter will implements [`Write`] based on append object.
@@ -83,7 +83,7 @@ where
 
         let size = s.size();
         self.inner
-            .append(offset, s.size(), AsyncBody::Stream(s))
+            .append(offset, s)
             .await
             .map(|_| self.offset = Some(offset + size))
     }

--- a/core/src/raw/oio/write/at_least_buf_write.rs
+++ b/core/src/raw/oio/write/at_least_buf_write.rs
@@ -78,7 +78,6 @@ impl<W: oio::Write> oio::Write for AtLeastBufWriter<W> {
         }
 
         let buf = self.buffer.clone();
-        let buffer_size = buf.len() as u64;
         let stream = buf.chain(s);
 
         self.inner

--- a/core/src/raw/oio/write/compose_write.rs
+++ b/core/src/raw/oio/write/compose_write.rs
@@ -39,7 +39,6 @@
 //! type_alias_impl_trait has been stabilized.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 
 use crate::raw::oio::Streamer;
 use crate::raw::*;
@@ -57,13 +56,6 @@ pub enum TwoWaysWriter<ONE: oio::Write, TWO: oio::Write> {
 
 #[async_trait]
 impl<ONE: oio::Write, TWO: oio::Write> oio::Write for TwoWaysWriter<ONE, TWO> {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        match self {
-            Self::One(one) => one.write(bs).await,
-            Self::Two(two) => two.write(bs).await,
-        }
-    }
-
     async fn sink(&mut self, size: u64, s: Streamer) -> Result<()> {
         match self {
             Self::One(one) => one.sink(size, s).await,
@@ -102,14 +94,6 @@ pub enum ThreeWaysWriter<ONE: oio::Write, TWO: oio::Write, THREE: oio::Write> {
 impl<ONE: oio::Write, TWO: oio::Write, THREE: oio::Write> oio::Write
     for ThreeWaysWriter<ONE, TWO, THREE>
 {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        match self {
-            Self::One(one) => one.write(bs).await,
-            Self::Two(two) => two.write(bs).await,
-            Self::Three(three) => three.write(bs).await,
-        }
-    }
-
     async fn sink(&mut self, size: u64, s: Streamer) -> Result<()> {
         match self {
             Self::One(one) => one.sink(size, s).await,

--- a/core/src/raw/oio/write/compose_write.rs
+++ b/core/src/raw/oio/write/compose_write.rs
@@ -56,10 +56,10 @@ pub enum TwoWaysWriter<ONE: oio::Write, TWO: oio::Write> {
 
 #[async_trait]
 impl<ONE: oio::Write, TWO: oio::Write> oio::Write for TwoWaysWriter<ONE, TWO> {
-    async fn write(&mut self, size: u64, s: Streamer) -> Result<()> {
+    async fn write(&mut self, s: Streamer) -> Result<()> {
         match self {
-            Self::One(one) => one.write(size, s).await,
-            Self::Two(two) => two.write(size, s).await,
+            Self::One(one) => one.write(s).await,
+            Self::Two(two) => two.write(s).await,
         }
     }
 
@@ -94,11 +94,11 @@ pub enum ThreeWaysWriter<ONE: oio::Write, TWO: oio::Write, THREE: oio::Write> {
 impl<ONE: oio::Write, TWO: oio::Write, THREE: oio::Write> oio::Write
     for ThreeWaysWriter<ONE, TWO, THREE>
 {
-    async fn write(&mut self, size: u64, s: Streamer) -> Result<()> {
+    async fn write(&mut self, s: Streamer) -> Result<()> {
         match self {
-            Self::One(one) => one.write(size, s).await,
-            Self::Two(two) => two.write(size, s).await,
-            Self::Three(three) => three.write(size, s).await,
+            Self::One(one) => one.write(s).await,
+            Self::Two(two) => two.write(s).await,
+            Self::Three(three) => three.write(s).await,
         }
     }
 

--- a/core/src/raw/oio/write/compose_write.rs
+++ b/core/src/raw/oio/write/compose_write.rs
@@ -56,10 +56,10 @@ pub enum TwoWaysWriter<ONE: oio::Write, TWO: oio::Write> {
 
 #[async_trait]
 impl<ONE: oio::Write, TWO: oio::Write> oio::Write for TwoWaysWriter<ONE, TWO> {
-    async fn sink(&mut self, size: u64, s: Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: Streamer) -> Result<()> {
         match self {
-            Self::One(one) => one.sink(size, s).await,
-            Self::Two(two) => two.sink(size, s).await,
+            Self::One(one) => one.write(size, s).await,
+            Self::Two(two) => two.write(size, s).await,
         }
     }
 
@@ -94,11 +94,11 @@ pub enum ThreeWaysWriter<ONE: oio::Write, TWO: oio::Write, THREE: oio::Write> {
 impl<ONE: oio::Write, TWO: oio::Write, THREE: oio::Write> oio::Write
     for ThreeWaysWriter<ONE, TWO, THREE>
 {
-    async fn sink(&mut self, size: u64, s: Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: Streamer) -> Result<()> {
         match self {
-            Self::One(one) => one.sink(size, s).await,
-            Self::Two(two) => two.sink(size, s).await,
-            Self::Three(three) => three.sink(size, s).await,
+            Self::One(one) => one.write(size, s).await,
+            Self::Two(two) => two.write(size, s).await,
+            Self::Three(three) => three.write(size, s).await,
         }
     }
 

--- a/core/src/raw/oio/write/exact_buf_write.rs
+++ b/core/src/raw/oio/write/exact_buf_write.rs
@@ -87,13 +87,13 @@ impl<W: oio::Write> oio::Write for ExactBufWriter<W> {
     /// # TODO
     ///
     /// We know every stream size, we can collect them into a buffer without chain them every time.
-    async fn write(&mut self, _: u64, mut s: Streamer) -> Result<()> {
+    async fn write(&mut self, mut s: Streamer) -> Result<()> {
         if self.buffer.len() >= self.buffer_size {
             let mut buf = self.buffer.clone();
             let to_write = buf.split_to(self.buffer_size);
             return self
                 .inner
-                .write(to_write.len() as u64, Box::new(to_write))
+                .write(Box::new(to_write))
                 .await
                 // Replace buffer with remaining if the write is successful.
                 .map(|_| {
@@ -121,7 +121,7 @@ impl<W: oio::Write> oio::Write for ExactBufWriter<W> {
 
         let to_write = buf.split_to(self.buffer_size);
         self.inner
-            .write(to_write.len() as u64, Box::new(to_write))
+            .write(Box::new(to_write))
             .await
             // Replace buffer with remaining if the write is successful.
             .map(|_| {
@@ -153,7 +153,7 @@ impl<W: oio::Write> oio::Write for ExactBufWriter<W> {
                 let mut buf = self.buffer.clone();
                 let to_write = buf.split_to(self.buffer_size);
                 self.inner
-                    .write(to_write.len() as u64, Box::new(to_write))
+                    .write(Box::new(to_write))
                     .await
                     // Replace buffer with remaining if the write is successful.
                     .map(|_| {
@@ -167,7 +167,7 @@ impl<W: oio::Write> oio::Write for ExactBufWriter<W> {
             let to_write = buf.split_to(min(self.buffer_size, buf.len()));
 
             self.inner
-                .write(to_write.len() as u64, Box::new(to_write))
+                .write(Box::new(to_write))
                 .await
                 // Replace buffer with remaining if the write is successful.
                 .map(|_| self.buffer = buf)?;
@@ -197,9 +197,8 @@ mod tests {
 
     #[async_trait]
     impl Write for MockWriter {
-        async fn write(&mut self, size: u64, s: Streamer) -> Result<()> {
+        async fn write(&mut self, s: Streamer) -> Result<()> {
             let bs = s.collect().await?;
-            assert_eq!(bs.len() as u64, size);
             self.buf.extend_from_slice(&bs);
 
             Ok(())
@@ -228,11 +227,8 @@ mod tests {
 
         let mut w = ExactBufWriter::new(MockWriter { buf: vec![] }, 10);
 
-        w.write(
-            expected.len() as u64,
-            Box::new(oio::Cursor::from(Bytes::from(expected.clone()))),
-        )
-        .await?;
+        w.write(Box::new(oio::Cursor::from(Bytes::from(expected.clone()))))
+            .await?;
         w.close().await?;
 
         assert_eq!(w.inner.buf.len(), expected.len());
@@ -266,10 +262,7 @@ mod tests {
 
             expected.extend_from_slice(&content);
             writer
-                .write(
-                    expected.len() as u64,
-                    Box::new(oio::Cursor::from(Bytes::from(expected.clone()))),
-                )
+                .write(Box::new(oio::Cursor::from(Bytes::from(expected.clone()))))
                 .await?;
         }
         writer.close().await?;

--- a/core/src/raw/oio/write/exact_buf_write.rs
+++ b/core/src/raw/oio/write/exact_buf_write.rs
@@ -262,7 +262,7 @@ mod tests {
 
             expected.extend_from_slice(&content);
             writer
-                .write(Box::new(oio::Cursor::from(Bytes::from(expected.clone()))))
+                .write(Box::new(oio::Cursor::from(Bytes::from(content.clone()))))
                 .await?;
         }
         writer.close().await?;

--- a/core/src/raw/oio/write/multipart_upload_write.rs
+++ b/core/src/raw/oio/write/multipart_upload_write.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 
 use crate::raw::*;
 use crate::*;
@@ -120,22 +119,6 @@ impl<W> oio::Write for MultipartUploadWriter<W>
 where
     W: MultipartUploadWrite,
 {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        let upload_id = self.upload_id().await?;
-
-        let size = bs.len();
-
-        self.inner
-            .write_part(
-                &upload_id,
-                self.parts.len(),
-                size as u64,
-                AsyncBody::Bytes(bs),
-            )
-            .await
-            .map(|v| self.parts.push(v))
-    }
-
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         let upload_id = self.upload_id().await?;
 

--- a/core/src/raw/oio/write/multipart_upload_write.rs
+++ b/core/src/raw/oio/write/multipart_upload_write.rs
@@ -119,7 +119,7 @@ impl<W> oio::Write for MultipartUploadWriter<W>
 where
     W: MultipartUploadWrite,
 {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         let upload_id = self.upload_id().await?;
 
         self.inner

--- a/core/src/raw/oio/write/multipart_upload_write.rs
+++ b/core/src/raw/oio/write/multipart_upload_write.rs
@@ -51,8 +51,7 @@ pub trait MultipartUploadWrite: Send + Sync + Unpin {
         &self,
         upload_id: &str,
         part_number: usize,
-        size: u64,
-        body: AsyncBody,
+        content: oio::Streamer,
     ) -> Result<MultipartUploadPart>;
 
     /// complete_part will complete the multipart upload to build the final
@@ -119,11 +118,11 @@ impl<W> oio::Write for MultipartUploadWriter<W>
 where
     W: MultipartUploadWrite,
 {
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
         let upload_id = self.upload_id().await?;
 
         self.inner
-            .write_part(&upload_id, self.parts.len(), size, AsyncBody::Stream(s))
+            .write_part(&upload_id, self.parts.len(), s)
             .await
             .map(|v| self.parts.push(v))
     }

--- a/core/src/raw/oio/write/one_shot_write.rs
+++ b/core/src/raw/oio/write/one_shot_write.rs
@@ -48,7 +48,7 @@ impl<W: OneShotWrite> OneShotWriter<W> {
 
 #[async_trait]
 impl<W: OneShotWrite> oio::Write for OneShotWriter<W> {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.inner.write_once(size, s).await
     }
 

--- a/core/src/raw/oio/write/one_shot_write.rs
+++ b/core/src/raw/oio/write/one_shot_write.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 
 use crate::raw::*;
 use crate::*;
@@ -49,13 +48,6 @@ impl<W: OneShotWrite> OneShotWriter<W> {
 
 #[async_trait]
 impl<W: OneShotWrite> oio::Write for OneShotWriter<W> {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        let cursor = oio::Cursor::from(bs);
-        self.inner
-            .write_once(cursor.len() as u64, Box::new(cursor))
-            .await
-    }
-
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.inner.write_once(size, s).await
     }

--- a/core/src/raw/oio/write/one_shot_write.rs
+++ b/core/src/raw/oio/write/one_shot_write.rs
@@ -31,7 +31,7 @@ pub trait OneShotWrite: Send + Sync + Unpin {
     /// write_once write all data at once.
     ///
     /// Implementations should make sure that the data is written correctly at once.
-    async fn write_once(&self, size: u64, stream: oio::Streamer) -> Result<()>;
+    async fn write_once(&self, stream: oio::Streamer) -> Result<()>;
 }
 
 /// OneShotWrite is used to implement [`Write`] based on one shot.
@@ -48,8 +48,8 @@ impl<W: OneShotWrite> OneShotWriter<W> {
 
 #[async_trait]
 impl<W: OneShotWrite> oio::Write for OneShotWriter<W> {
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        self.inner.write_once(size, s).await
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
+        self.inner.write_once(s).await
     }
 
     async fn abort(&mut self) -> Result<()> {

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -532,7 +532,6 @@ impl Accessor for AzblobBackend {
 
                 write: true,
                 write_can_append: true,
-                write_can_sink: true,
                 write_with_cache_control: true,
                 write_with_content_type: true,
 

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -613,7 +613,7 @@ impl Accessor for AzblobBackend {
         } else {
             return Err(Error::new(
                 ErrorKind::Unsupported,
-                "azblob write without neither content-length nor append is not supported yet",
+                "azblob write with block blobs is not supported yet, refer to https://github.com/apache/incubator-opendal/issues/2113 for more details",
             ));
         };
 

--- a/core/src/services/azblob/writer.rs
+++ b/core/src/services/azblob/writer.rs
@@ -18,7 +18,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::AzblobCore;
@@ -161,23 +160,6 @@ impl AzblobWriter {
 
 #[async_trait]
 impl oio::Write for AzblobWriter {
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        if self.op.append() {
-            self.append_oneshot(bs.len() as u64, AsyncBody::Bytes(bs))
-                .await
-        } else {
-            if self.op.content_length().is_none() {
-                return Err(Error::new(
-                    ErrorKind::Unsupported,
-                    "write without content length is not supported",
-                ));
-            }
-
-            self.write_oneshot(bs.len() as u64, AsyncBody::Bytes(bs))
-                .await
-        }
-    }
-
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         if self.op.append() {
             self.append_oneshot(size, AsyncBody::Stream(s)).await

--- a/core/src/services/azblob/writer.rs
+++ b/core/src/services/azblob/writer.rs
@@ -27,7 +27,6 @@ use crate::raw::*;
 use crate::*;
 
 const X_MS_BLOB_TYPE: &str = "x-ms-blob-type";
-const X_MS_BLOB_APPEND_OFFSET: &str = "x-ms-blob-append-offset";
 
 pub type AzblobWriters =
     oio::TwoWaysWriter<oio::OneShotWriter<AzblobWriter>, oio::AppendObjectWriter<AzblobWriter>>;

--- a/core/src/services/azblob/writer.rs
+++ b/core/src/services/azblob/writer.rs
@@ -22,6 +22,7 @@ use http::StatusCode;
 
 use super::core::AzblobCore;
 use super::error::parse_error;
+use crate::raw::oio::Stream;
 use crate::raw::*;
 use crate::*;
 
@@ -160,9 +161,9 @@ impl AzblobWriter {
 
 #[async_trait]
 impl oio::Write for AzblobWriter {
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
         if self.op.append() {
-            self.append_oneshot(size, AsyncBody::Stream(s)).await
+            self.append_oneshot(s.size(), AsyncBody::Stream(s)).await
         } else {
             if self.op.content_length().is_none() {
                 return Err(Error::new(
@@ -171,7 +172,7 @@ impl oio::Write for AzblobWriter {
                 ));
             }
 
-            self.write_oneshot(size, AsyncBody::Stream(s)).await
+            self.write_oneshot(s.size(), AsyncBody::Stream(s)).await
         }
     }
 

--- a/core/src/services/azblob/writer.rs
+++ b/core/src/services/azblob/writer.rs
@@ -160,7 +160,7 @@ impl AzblobWriter {
 
 #[async_trait]
 impl oio::Write for AzblobWriter {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         if self.op.append() {
             self.append_oneshot(size, AsyncBody::Stream(s)).await
         } else {

--- a/core/src/services/azdfs/core.rs
+++ b/core/src/services/azdfs/core.rs
@@ -204,7 +204,7 @@ impl AzdfsCore {
     pub fn azdfs_update_request(
         &self,
         path: &str,
-        size: Option<usize>,
+        size: Option<u64>,
         body: AsyncBody,
     ) -> Result<Request<AsyncBody>> {
         let p = build_abs_path(&self.root, path);

--- a/core/src/services/azdfs/writer.rs
+++ b/core/src/services/azdfs/writer.rs
@@ -86,7 +86,7 @@ impl AzdfsWriter {
 
 #[async_trait]
 impl oio::Write for AzdfsWriter {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/azdfs/writer.rs
+++ b/core/src/services/azdfs/writer.rs
@@ -37,10 +37,7 @@ impl AzdfsWriter {
     pub fn new(core: Arc<AzdfsCore>, op: OpWrite, path: String) -> Self {
         AzdfsWriter { core, op, path }
     }
-}
 
-#[async_trait]
-impl oio::Write for AzdfsWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         let mut req = self.core.azdfs_create_request(
             &self.path,
@@ -85,7 +82,10 @@ impl oio::Write for AzdfsWriter {
                 .with_operation("Backend::azdfs_update_request")),
         }
     }
+}
 
+#[async_trait]
+impl oio::Write for AzdfsWriter {
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/services/azdfs/writer.rs
+++ b/core/src/services/azdfs/writer.rs
@@ -86,7 +86,7 @@ impl AzdfsWriter {
 
 #[async_trait]
 impl oio::Write for AzdfsWriter {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -272,7 +272,6 @@ impl Accessor for CosBackend {
 
                 write: true,
                 write_can_append: true,
-                write_can_sink: true,
                 write_with_content_type: true,
                 write_with_cache_control: true,
                 write_with_content_disposition: true,

--- a/core/src/services/cos/writer.rs
+++ b/core/src/services/cos/writer.rs
@@ -215,10 +215,14 @@ impl oio::AppendObjectWrite for CosWriter {
         }
     }
 
-    async fn append(&self, offset: u64, size: u64, body: AsyncBody) -> Result<()> {
-        let mut req = self
-            .core
-            .cos_append_object_request(&self.path, offset, size, &self.op, body)?;
+    async fn append(&self, offset: u64, stream: Streamer) -> Result<()> {
+        let mut req = self.core.cos_append_object_request(
+            &self.path,
+            offset,
+            stream.size(),
+            &self.op,
+            AsyncBody::Stream(stream),
+        )?;
 
         self.core.sign(&mut req).await?;
 

--- a/core/src/services/dropbox/core.rs
+++ b/core/src/services/dropbox/core.rs
@@ -97,7 +97,7 @@ impl DropboxCore {
     pub async fn dropbox_update(
         &self,
         path: &str,
-        size: Option<usize>,
+        size: Option<u64>,
         content_type: Option<&str>,
         body: AsyncBody,
     ) -> Result<Response<IncomingAsyncBody>> {

--- a/core/src/services/dropbox/writer.rs
+++ b/core/src/services/dropbox/writer.rs
@@ -18,7 +18,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::DropboxCore;

--- a/core/src/services/dropbox/writer.rs
+++ b/core/src/services/dropbox/writer.rs
@@ -60,7 +60,7 @@ impl DropboxWriter {
 
 #[async_trait]
 impl oio::Write for DropboxWriter {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/dropbox/writer.rs
+++ b/core/src/services/dropbox/writer.rs
@@ -60,7 +60,7 @@ impl DropboxWriter {
 
 #[async_trait]
 impl oio::Write for DropboxWriter {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/dropbox/writer.rs
+++ b/core/src/services/dropbox/writer.rs
@@ -36,10 +36,7 @@ impl DropboxWriter {
     pub fn new(core: Arc<DropboxCore>, op: OpWrite, path: String) -> Self {
         DropboxWriter { core, op, path }
     }
-}
 
-#[async_trait]
-impl oio::Write for DropboxWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         let resp = self
             .core
@@ -59,7 +56,10 @@ impl oio::Write for DropboxWriter {
             _ => Err(parse_error(resp).await?),
         }
     }
+}
 
+#[async_trait]
+impl oio::Write for DropboxWriter {
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -266,7 +266,6 @@ impl Accessor for FsBackend {
 
                 write: true,
                 write_can_append: true,
-                write_can_sink: true,
                 write_without_content_length: true,
                 create_dir: true,
                 delete: true,

--- a/core/src/services/fs/writer.rs
+++ b/core/src/services/fs/writer.rs
@@ -65,10 +65,7 @@ impl oio::Write for FsWriter<tokio::fs::File> {
     }
 
     async fn abort(&mut self) -> Result<()> {
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "output writer doesn't support abort",
-        ))
+        Ok(())
     }
 
     async fn close(&mut self) -> Result<()> {

--- a/core/src/services/fs/writer.rs
+++ b/core/src/services/fs/writer.rs
@@ -50,7 +50,7 @@ impl<F> FsWriter<F> {
 
 #[async_trait]
 impl oio::Write for FsWriter<tokio::fs::File> {
-    async fn sink(&mut self, _size: u64, mut s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, mut s: oio::Streamer) -> Result<()> {
         while let Some(bs) = s.next().await {
             let bs = bs?;
             self.f

--- a/core/src/services/fs/writer.rs
+++ b/core/src/services/fs/writer.rs
@@ -50,21 +50,6 @@ impl<F> FsWriter<F> {
 
 #[async_trait]
 impl oio::Write for FsWriter<tokio::fs::File> {
-    /// # Notes
-    ///
-    /// File could be partial written, so we will seek to start to make sure
-    /// we write the same content.
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        self.f
-            .seek(SeekFrom::Start(self.pos))
-            .await
-            .map_err(parse_io_error)?;
-        self.f.write_all(&bs).await.map_err(parse_io_error)?;
-        self.pos += bs.len() as u64;
-
-        Ok(())
-    }
-
     async fn sink(&mut self, _size: u64, mut s: oio::Streamer) -> Result<()> {
         while let Some(bs) = s.next().await {
             let bs = bs?;

--- a/core/src/services/fs/writer.rs
+++ b/core/src/services/fs/writer.rs
@@ -50,7 +50,7 @@ impl<F> FsWriter<F> {
 
 #[async_trait]
 impl oio::Write for FsWriter<tokio::fs::File> {
-    async fn write(&mut self, _size: u64, mut s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, mut s: oio::Streamer) -> Result<()> {
         while let Some(bs) = s.next().await {
             let bs = bs?;
             self.f

--- a/core/src/services/ftp/writer.rs
+++ b/core/src/services/ftp/writer.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use futures::AsyncWriteExt;
 
 use super::backend::FtpBackend;

--- a/core/src/services/ftp/writer.rs
+++ b/core/src/services/ftp/writer.rs
@@ -37,10 +37,7 @@ impl FtpWriter {
     pub fn new(backend: FtpBackend, path: String) -> Self {
         FtpWriter { backend, path }
     }
-}
 
-#[async_trait]
-impl oio::Write for FtpWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         let mut ftp_stream = self.backend.ftp_connect(Operation::Write).await?;
         let mut data_stream = ftp_stream.append_with_stream(&self.path).await?;
@@ -52,7 +49,10 @@ impl oio::Write for FtpWriter {
 
         Ok(())
     }
+}
 
+#[async_trait]
+impl oio::Write for FtpWriter {
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/services/ftp/writer.rs
+++ b/core/src/services/ftp/writer.rs
@@ -53,7 +53,7 @@ impl FtpWriter {
 
 #[async_trait]
 impl oio::Write for FtpWriter {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/ftp/writer.rs
+++ b/core/src/services/ftp/writer.rs
@@ -53,7 +53,7 @@ impl FtpWriter {
 
 #[async_trait]
 impl oio::Write for FtpWriter {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -360,7 +360,6 @@ impl Accessor for GcsBackend {
                 read_with_if_none_match: true,
 
                 write: true,
-                write_can_sink: true,
                 write_with_content_type: true,
                 // TODO: we are working on refactor this.
                 // write_without_content_length: true,

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -362,7 +362,8 @@ impl Accessor for GcsBackend {
                 write: true,
                 write_can_sink: true,
                 write_with_content_type: true,
-                write_without_content_length: true,
+                // TODO: we are working on refactor this.
+                // write_without_content_length: true,
                 delete: true,
                 copy: true,
 

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -282,7 +282,7 @@ impl GcsCore {
                     media_part = media_part.content(bytes);
                 }
                 AsyncBody::Stream(stream) => {
-                    media_part = media_part.stream(size.unwrap(), stream);
+                    media_part = media_part.stream(stream);
                 }
             }
 

--- a/core/src/services/gcs/writer.rs
+++ b/core/src/services/gcs/writer.rs
@@ -114,10 +114,7 @@ impl GcsWriter {
             _ => Err(parse_error(resp).await?),
         }
     }
-}
 
-#[async_trait]
-impl oio::Write for GcsWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         let location = match &self.location {
             Some(location) => location,
@@ -163,7 +160,10 @@ impl oio::Write for GcsWriter {
             }
         }
     }
+}
 
+#[async_trait]
+impl oio::Write for GcsWriter {
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.write_oneshot(size, AsyncBody::Stream(s)).await
     }

--- a/core/src/services/gcs/writer.rs
+++ b/core/src/services/gcs/writer.rs
@@ -23,6 +23,7 @@ use http::StatusCode;
 
 use super::core::GcsCore;
 use super::error::parse_error;
+use crate::raw::oio::Stream;
 use crate::raw::*;
 use crate::*;
 
@@ -164,8 +165,8 @@ impl GcsWriter {
 
 #[async_trait]
 impl oio::Write for GcsWriter {
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        self.write_oneshot(size, AsyncBody::Stream(s)).await
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
+        self.write_oneshot(s.size(), AsyncBody::Stream(s)).await
     }
 
     async fn abort(&mut self) -> Result<()> {

--- a/core/src/services/gcs/writer.rs
+++ b/core/src/services/gcs/writer.rs
@@ -164,7 +164,7 @@ impl GcsWriter {
 
 #[async_trait]
 impl oio::Write for GcsWriter {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.write_oneshot(size, AsyncBody::Stream(s)).await
     }
 

--- a/core/src/services/gcs/writer.rs
+++ b/core/src/services/gcs/writer.rs
@@ -38,6 +38,7 @@ pub struct GcsWriter {
     write_fixed_size: usize,
 }
 
+/// TODO we need to add buffer support for gcs.
 impl GcsWriter {
     pub fn new(core: Arc<GcsCore>, path: &str, op: OpWrite) -> Self {
         let write_fixed_size = core.write_fixed_size;

--- a/core/src/services/gdrive/core.rs
+++ b/core/src/services/gdrive/core.rs
@@ -366,7 +366,7 @@ impl GdriveCore {
         &self,
         path: &str,
         size: u64,
-        body: bytes::Bytes,
+        stream: oio::Streamer,
     ) -> Result<Response<IncomingAsyncBody>> {
         let parent = self.ensure_parent_path(path).await?;
 
@@ -396,7 +396,7 @@ impl GdriveCore {
                         header::CONTENT_TYPE,
                         "application/octet-stream".parse().unwrap(),
                     )
-                    .content(body),
+                    .stream(stream),
             );
 
         let mut req = multipart.apply(req)?;
@@ -410,7 +410,7 @@ impl GdriveCore {
         &self,
         file_id: &str,
         size: u64,
-        body: bytes::Bytes,
+        stream: oio::Streamer,
     ) -> Result<Response<IncomingAsyncBody>> {
         let url = format!(
             "https://www.googleapis.com/upload/drive/v3/files/{}?uploadType=media",
@@ -421,7 +421,7 @@ impl GdriveCore {
             .header(header::CONTENT_TYPE, "application/octet-stream")
             .header(header::CONTENT_LENGTH, size)
             .header("X-Upload-Content-Length", size)
-            .body(AsyncBody::Bytes(body))
+            .body(AsyncBody::Stream(stream))
             .map_err(new_request_build_error)?;
 
         self.sign(&mut req).await?;

--- a/core/src/services/gdrive/writer.rs
+++ b/core/src/services/gdrive/writer.rs
@@ -103,7 +103,7 @@ impl GdriveWriter {
 
 #[async_trait]
 impl oio::Write for GdriveWriter {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(ErrorKind::Unsupported, "sink is not supported"))
     }
 

--- a/core/src/services/gdrive/writer.rs
+++ b/core/src/services/gdrive/writer.rs
@@ -103,7 +103,7 @@ impl GdriveWriter {
 
 #[async_trait]
 impl oio::Write for GdriveWriter {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(ErrorKind::Unsupported, "sink is not supported"))
     }
 

--- a/core/src/services/gdrive/writer.rs
+++ b/core/src/services/gdrive/writer.rs
@@ -91,10 +91,7 @@ impl GdriveWriter {
             _ => Err(parse_error(resp).await?),
         }
     }
-}
 
-#[async_trait]
-impl oio::Write for GdriveWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         if self.file_id.is_none() {
             self.write_create(bs.len() as u64, bs).await
@@ -102,7 +99,10 @@ impl oio::Write for GdriveWriter {
             self.write_overwrite(bs.len() as u64, bs).await
         }
     }
+}
 
+#[async_trait]
+impl oio::Write for GdriveWriter {
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(ErrorKind::Unsupported, "sink is not supported"))
     }

--- a/core/src/services/gdrive/writer.rs
+++ b/core/src/services/gdrive/writer.rs
@@ -18,7 +18,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::GdriveCore;

--- a/core/src/services/ghac/writer.rs
+++ b/core/src/services/ghac/writer.rs
@@ -62,7 +62,7 @@ impl GhacWriter {
 
 #[async_trait]
 impl oio::Write for GhacWriter {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/ghac/writer.rs
+++ b/core/src/services/ghac/writer.rs
@@ -62,7 +62,7 @@ impl GhacWriter {
 
 #[async_trait]
 impl oio::Write for GhacWriter {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/ghac/writer.rs
+++ b/core/src/services/ghac/writer.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 
 use super::backend::GhacBackend;
 use super::error::parse_error;

--- a/core/src/services/ghac/writer.rs
+++ b/core/src/services/ghac/writer.rs
@@ -38,10 +38,7 @@ impl GhacWriter {
             size: 0,
         }
     }
-}
 
-#[async_trait]
-impl oio::Write for GhacWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         let size = bs.len() as u64;
         let req = self
@@ -61,7 +58,10 @@ impl oio::Write for GhacWriter {
                 .map(|err| err.with_operation("Backend::ghac_upload"))?)
         }
     }
+}
 
+#[async_trait]
+impl oio::Write for GhacWriter {
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/services/hdfs/writer.rs
+++ b/core/src/services/hdfs/writer.rs
@@ -58,7 +58,7 @@ impl HdfsWriter<hdrs::AsyncFile> {
 
 #[async_trait]
 impl oio::Write for HdfsWriter<hdrs::AsyncFile> {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/hdfs/writer.rs
+++ b/core/src/services/hdfs/writer.rs
@@ -39,8 +39,7 @@ impl<F> HdfsWriter<F> {
     }
 }
 
-#[async_trait]
-impl oio::Write for HdfsWriter<hdrs::AsyncFile> {
+impl HdfsWriter<hdrs::AsyncFile> {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         while self.pos < bs.len() {
             let n = self
@@ -55,7 +54,10 @@ impl oio::Write for HdfsWriter<hdrs::AsyncFile> {
 
         Ok(())
     }
+}
 
+#[async_trait]
+impl oio::Write for HdfsWriter<hdrs::AsyncFile> {
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/services/hdfs/writer.rs
+++ b/core/src/services/hdfs/writer.rs
@@ -58,7 +58,7 @@ impl HdfsWriter<hdrs::AsyncFile> {
 
 #[async_trait]
 impl oio::Write for HdfsWriter<hdrs::AsyncFile> {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -290,7 +290,7 @@ impl IpmfsBackend {
     pub async fn ipmfs_write(
         &self,
         path: &str,
-        body: Bytes,
+        stream: oio::Streamer,
     ) -> Result<Response<IncomingAsyncBody>> {
         let p = build_rooted_abs_path(&self.root, path);
 
@@ -300,7 +300,7 @@ impl IpmfsBackend {
             percent_encode_path(&p)
         );
 
-        let multipart = Multipart::new().part(FormDataPart::new("data").content(body));
+        let multipart = Multipart::new().part(FormDataPart::new("data").stream(stream));
 
         let req: http::request::Builder = Request::post(url);
         let req = multipart.apply(req)?;

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -21,7 +21,6 @@ use std::str;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::Request;
 use http::Response;
 use http::StatusCode;

--- a/core/src/services/ipmfs/writer.rs
+++ b/core/src/services/ipmfs/writer.rs
@@ -52,7 +52,7 @@ impl IpmfsWriter {
 
 #[async_trait]
 impl oio::Write for IpmfsWriter {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/ipmfs/writer.rs
+++ b/core/src/services/ipmfs/writer.rs
@@ -52,7 +52,7 @@ impl IpmfsWriter {
 
 #[async_trait]
 impl oio::Write for IpmfsWriter {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/ipmfs/writer.rs
+++ b/core/src/services/ipmfs/writer.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::StatusCode;
 
 use super::backend::IpmfsBackend;

--- a/core/src/services/ipmfs/writer.rs
+++ b/core/src/services/ipmfs/writer.rs
@@ -34,9 +34,12 @@ impl IpmfsWriter {
     pub fn new(backend: IpmfsBackend, path: String) -> Self {
         IpmfsWriter { backend, path }
     }
+}
 
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        let resp = self.backend.ipmfs_write(&self.path, bs).await?;
+#[async_trait]
+impl oio::Write for IpmfsWriter {
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
+        let resp = self.backend.ipmfs_write(&self.path, s).await?;
 
         let status = resp.status();
 
@@ -47,16 +50,6 @@ impl IpmfsWriter {
             }
             _ => Err(parse_error(resp).await?),
         }
-    }
-}
-
-#[async_trait]
-impl oio::Write for IpmfsWriter {
-    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "Write::sink is not supported",
-        ))
     }
 
     async fn abort(&mut self) -> Result<()> {

--- a/core/src/services/ipmfs/writer.rs
+++ b/core/src/services/ipmfs/writer.rs
@@ -34,10 +34,7 @@ impl IpmfsWriter {
     pub fn new(backend: IpmfsBackend, path: String) -> Self {
         IpmfsWriter { backend, path }
     }
-}
 
-#[async_trait]
-impl oio::Write for IpmfsWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         let resp = self.backend.ipmfs_write(&self.path, bs).await?;
 
@@ -51,7 +48,10 @@ impl oio::Write for IpmfsWriter {
             _ => Err(parse_error(resp).await?),
         }
     }
+}
 
+#[async_trait]
+impl oio::Write for IpmfsWriter {
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -279,7 +279,6 @@ impl Accessor for ObsBackend {
 
                 write: true,
                 write_can_append: true,
-                write_can_sink: true,
                 write_with_content_type: true,
                 write_with_cache_control: true,
                 write_without_content_length: true,

--- a/core/src/services/obs/writer.rs
+++ b/core/src/services/obs/writer.rs
@@ -23,8 +23,8 @@ use http::StatusCode;
 
 use super::core::*;
 use super::error::parse_error;
-use crate::raw::oio::MultipartUploadPart;
 use crate::raw::oio::Streamer;
+use crate::raw::oio::{MultipartUploadPart, Stream};
 use crate::raw::*;
 use crate::*;
 
@@ -53,10 +53,10 @@ impl ObsWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for ObsWriter {
-    async fn write_once(&self, size: u64, stream: Streamer) -> Result<()> {
+    async fn write_once(&self, stream: Streamer) -> Result<()> {
         let mut req = self.core.obs_put_object_request(
             &self.path,
-            Some(size),
+            Some(stream.size()),
             self.op.content_type(),
             self.op.cache_control(),
             AsyncBody::Stream(stream),
@@ -105,15 +105,20 @@ impl oio::MultipartUploadWrite for ObsWriter {
         &self,
         upload_id: &str,
         part_number: usize,
-        size: u64,
-        body: AsyncBody,
+        stream: Streamer,
     ) -> Result<MultipartUploadPart> {
         // Obs service requires part number must between [1..=10000]
         let part_number = part_number + 1;
 
         let resp = self
             .core
-            .obs_upload_part_request(&self.path, upload_id, part_number, Some(size), body)
+            .obs_upload_part_request(
+                &self.path,
+                upload_id,
+                part_number,
+                Some(stream.size()),
+                AsyncBody::Stream(stream),
+            )
             .await?;
 
         let status = resp.status();

--- a/core/src/services/obs/writer.rs
+++ b/core/src/services/obs/writer.rs
@@ -206,10 +206,14 @@ impl oio::AppendObjectWrite for ObsWriter {
         }
     }
 
-    async fn append(&self, offset: u64, size: u64, body: AsyncBody) -> Result<()> {
-        let mut req = self
-            .core
-            .obs_append_object_request(&self.path, offset, size, &self.op, body)?;
+    async fn append(&self, offset: u64, stream: Streamer) -> Result<()> {
+        let mut req = self.core.obs_append_object_request(
+            &self.path,
+            offset,
+            stream.size(),
+            &self.op,
+            AsyncBody::Stream(stream),
+        )?;
 
         self.core.sign(&mut req).await?;
 

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -263,7 +263,7 @@ impl OnedriveBackend {
     pub async fn onedrive_upload_simple(
         &self,
         path: &str,
-        size: Option<usize>,
+        size: Option<u64>,
         content_type: Option<&str>,
         body: AsyncBody,
     ) -> Result<Response<IncomingAsyncBody>> {

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -18,7 +18,6 @@
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::header;
 use http::Request;
 use http::Response;
@@ -27,7 +26,6 @@ use http::StatusCode;
 use super::error::parse_error;
 use super::graph_model::CreateDirPayload;
 use super::graph_model::ItemType;
-use super::graph_model::OneDriveUploadSessionCreationRequestBody;
 use super::graph_model::OnedriveGetItemBody;
 use super::pager::OnedrivePager;
 use super::writer::OneDriveWriter;
@@ -202,7 +200,7 @@ impl Accessor for OnedriveBackend {
 }
 
 impl OnedriveBackend {
-    pub(crate) const BASE_URL: &'static str = "https://graph.microsoft.com/v1.0/me";
+    // pub(crate) const BASE_URL: &'static str = "https://graph.microsoft.com/v1.0/me";
 
     async fn onedrive_get_stat(&self, path: &str) -> Result<Response<IncomingAsyncBody>> {
         let path = build_rooted_abs_path(&self.root, path);
@@ -290,53 +288,53 @@ impl OnedriveBackend {
         self.client.send(req).await
     }
 
-    pub(crate) async fn onedrive_chunked_upload(
-        &self,
-        url: &str,
-        content_type: Option<&str>,
-        offset: usize,
-        chunk_end: usize,
-        total_len: usize,
-        body: AsyncBody,
-    ) -> Result<Response<IncomingAsyncBody>> {
-        let mut req = Request::put(url);
+    // pub(crate) async fn onedrive_chunked_upload(
+    //     &self,
+    //     url: &str,
+    //     content_type: Option<&str>,
+    //     offset: usize,
+    //     chunk_end: usize,
+    //     total_len: usize,
+    //     body: AsyncBody,
+    // ) -> Result<Response<IncomingAsyncBody>> {
+    //     let mut req = Request::put(url);
+    //
+    //     let auth_header_content = format!("Bearer {}", self.access_token);
+    //     req = req.header(header::AUTHORIZATION, auth_header_content);
+    //
+    //     let range = format!("bytes {}-{}/{}", offset, chunk_end, total_len);
+    //     req = req.header("Content-Range".to_string(), range);
+    //
+    //     let size = chunk_end - offset + 1;
+    //     req = req.header(header::CONTENT_LENGTH, size.to_string());
+    //
+    //     if let Some(mime) = content_type {
+    //         req = req.header(header::CONTENT_TYPE, mime)
+    //     }
+    //
+    //     let req = req.body(body).map_err(new_request_build_error)?;
+    //
+    //     self.client.send(req).await
+    // }
 
-        let auth_header_content = format!("Bearer {}", self.access_token);
-        req = req.header(header::AUTHORIZATION, auth_header_content);
-
-        let range = format!("bytes {}-{}/{}", offset, chunk_end, total_len);
-        req = req.header("Content-Range".to_string(), range);
-
-        let size = chunk_end - offset + 1;
-        req = req.header(header::CONTENT_LENGTH, size.to_string());
-
-        if let Some(mime) = content_type {
-            req = req.header(header::CONTENT_TYPE, mime)
-        }
-
-        let req = req.body(body).map_err(new_request_build_error)?;
-
-        self.client.send(req).await
-    }
-
-    pub(crate) async fn onedrive_create_upload_session(
-        &self,
-        url: &str,
-        body: OneDriveUploadSessionCreationRequestBody,
-    ) -> Result<Response<IncomingAsyncBody>> {
-        let mut req = Request::post(url);
-
-        let auth_header_content = format!("Bearer {}", self.access_token);
-        req = req.header(header::AUTHORIZATION, auth_header_content);
-
-        req = req.header(header::CONTENT_TYPE, "application/json");
-
-        let body_bytes = serde_json::to_vec(&body).map_err(new_json_serialize_error)?;
-        let asyn_body = AsyncBody::Bytes(Bytes::from(body_bytes));
-        let req = req.body(asyn_body).map_err(new_request_build_error)?;
-
-        self.client.send(req).await
-    }
+    // pub(crate) async fn onedrive_create_upload_session(
+    //     &self,
+    //     url: &str,
+    //     body: OneDriveUploadSessionCreationRequestBody,
+    // ) -> Result<Response<IncomingAsyncBody>> {
+    //     let mut req = Request::post(url);
+    //
+    //     let auth_header_content = format!("Bearer {}", self.access_token);
+    //     req = req.header(header::AUTHORIZATION, auth_header_content);
+    //
+    //     req = req.header(header::CONTENT_TYPE, "application/json");
+    //
+    //     let body_bytes = serde_json::to_vec(&body).map_err(new_json_serialize_error)?;
+    //     let asyn_body = AsyncBody::Bytes(Bytes::from(body_bytes));
+    //     let req = req.body(asyn_body).map_err(new_request_build_error)?;
+    //
+    //     self.client.send(req).await
+    // }
 
     async fn onedrive_create_dir(
         &self,

--- a/core/src/services/onedrive/graph_model.rs
+++ b/core/src/services/onedrive/graph_model.rs
@@ -132,17 +132,17 @@ pub struct OneDriveUploadSessionCreationRequestBody {
     item: FileUploadItem,
 }
 
-impl OneDriveUploadSessionCreationRequestBody {
-    pub fn new(path: String) -> Self {
-        OneDriveUploadSessionCreationRequestBody {
-            item: FileUploadItem {
-                odata_type: "microsoft.graph.driveItemUploadableProperties".to_string(),
-                microsoft_graph_conflict_behavior: "replace".to_string(),
-                name: path,
-            },
-        }
-    }
-}
+// impl OneDriveUploadSessionCreationRequestBody {
+//     pub fn new(path: String) -> Self {
+//         OneDriveUploadSessionCreationRequestBody {
+//             item: FileUploadItem {
+//                 odata_type: "microsoft.graph.driveItemUploadableProperties".to_string(),
+//                 microsoft_graph_conflict_behavior: "replace".to_string(),
+//                 name: path,
+//             },
+//         }
+//     }
+// }
 
 #[test]
 fn test_parse_one_drive_json() {

--- a/core/src/services/onedrive/writer.rs
+++ b/core/src/services/onedrive/writer.rs
@@ -32,10 +32,10 @@ pub struct OneDriveWriter {
 }
 
 impl OneDriveWriter {
-    const MAX_SIMPLE_SIZE: usize = 4 * 1024 * 1024;
+    // const MAX_SIMPLE_SIZE: usize = 4 * 1024 * 1024;
     // If your app splits a file into multiple byte ranges, the size of each byte range MUST be a multiple of 320 KiB (327,680 bytes). Using a fragment size that does not divide evenly by 320 KiB will result in errors committing some files.
     // https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online#upload-bytes-to-the-upload-session
-    const CHUNK_SIZE_FACTOR: usize = 327_680;
+    // const CHUNK_SIZE_FACTOR: usize = 327_680;
 
     pub fn new(backend: OnedriveBackend, op: OpWrite, path: String) -> Self {
         OneDriveWriter { backend, op, path }

--- a/core/src/services/onedrive/writer.rs
+++ b/core/src/services/onedrive/writer.rs
@@ -42,10 +42,7 @@ impl OneDriveWriter {
     pub fn new(backend: OnedriveBackend, op: OpWrite, path: String) -> Self {
         OneDriveWriter { backend, op, path }
     }
-}
 
-#[async_trait]
-impl oio::Write for OneDriveWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         let size = bs.len();
 
@@ -55,7 +52,10 @@ impl oio::Write for OneDriveWriter {
             self.write_chunked(bs).await
         }
     }
+}
 
+#[async_trait]
+impl oio::Write for OneDriveWriter {
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/services/onedrive/writer.rs
+++ b/core/src/services/onedrive/writer.rs
@@ -16,14 +16,10 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Buf;
-use bytes::Bytes;
 use http::StatusCode;
 
 use super::backend::OnedriveBackend;
 use super::error::parse_error;
-use super::graph_model::OneDriveUploadSessionCreationRequestBody;
-use super::graph_model::OneDriveUploadSessionCreationResponseBody;
 use crate::raw::oio::Stream;
 use crate::raw::*;
 use crate::*;

--- a/core/src/services/onedrive/writer.rs
+++ b/core/src/services/onedrive/writer.rs
@@ -56,7 +56,7 @@ impl OneDriveWriter {
 
 #[async_trait]
 impl oio::Write for OneDriveWriter {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/onedrive/writer.rs
+++ b/core/src/services/onedrive/writer.rs
@@ -56,7 +56,7 @@ impl OneDriveWriter {
 
 #[async_trait]
 impl oio::Write for OneDriveWriter {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/onedrive/writer.rs
+++ b/core/src/services/onedrive/writer.rs
@@ -24,6 +24,7 @@ use super::backend::OnedriveBackend;
 use super::error::parse_error;
 use super::graph_model::OneDriveUploadSessionCreationRequestBody;
 use super::graph_model::OneDriveUploadSessionCreationResponseBody;
+use crate::raw::oio::Stream;
 use crate::raw::*;
 use crate::*;
 
@@ -39,28 +40,16 @@ impl OneDriveWriter {
     // If your app splits a file into multiple byte ranges, the size of each byte range MUST be a multiple of 320 KiB (327,680 bytes). Using a fragment size that does not divide evenly by 320 KiB will result in errors committing some files.
     // https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online#upload-bytes-to-the-upload-session
     const CHUNK_SIZE_FACTOR: usize = 327_680;
+
     pub fn new(backend: OnedriveBackend, op: OpWrite, path: String) -> Self {
         OneDriveWriter { backend, op, path }
-    }
-
-    async fn write(&mut self, bs: Bytes) -> Result<()> {
-        let size = bs.len();
-
-        if size <= Self::MAX_SIMPLE_SIZE {
-            self.write_simple(bs).await
-        } else {
-            self.write_chunked(bs).await
-        }
     }
 }
 
 #[async_trait]
 impl oio::Write for OneDriveWriter {
-    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
-        Err(Error::new(
-            ErrorKind::Unsupported,
-            "Write::sink is not supported",
-        ))
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
+        self.write_simple(s).await
     }
 
     async fn abort(&mut self) -> Result<()> {
@@ -73,14 +62,14 @@ impl oio::Write for OneDriveWriter {
 }
 
 impl OneDriveWriter {
-    async fn write_simple(&mut self, bs: Bytes) -> Result<()> {
+    async fn write_simple(&mut self, s: oio::Streamer) -> Result<()> {
         let resp = self
             .backend
             .onedrive_upload_simple(
                 &self.path,
-                Some(bs.len()),
+                Some(s.size()),
                 self.op.content_type(),
-                AsyncBody::Bytes(bs),
+                AsyncBody::Stream(s),
             )
             .await?;
 
@@ -97,85 +86,87 @@ impl OneDriveWriter {
         }
     }
 
-    pub(crate) async fn write_chunked(&self, total_bytes: Bytes) -> Result<()> {
-        // Upload large files via sessions: https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online#upload-bytes-to-the-upload-session
-        // 1. Create an upload session
-        // 2. Upload the bytes of each chunk
-        // 3. Commit the session
-
-        let session_response = self.create_upload_session().await?;
-
-        let mut offset = 0;
-
-        let iter = total_bytes.chunks(OneDriveWriter::CHUNK_SIZE_FACTOR);
-
-        for chunk in iter {
-            let mut end = offset + OneDriveWriter::CHUNK_SIZE_FACTOR;
-            if end > total_bytes.len() {
-                end = total_bytes.len();
-            }
-            let total_len = total_bytes.len();
-            let chunk_end = end - 1;
-
-            let resp = self
-                .backend
-                .onedrive_chunked_upload(
-                    &session_response.upload_url,
-                    None,
-                    offset,
-                    chunk_end,
-                    total_len,
-                    AsyncBody::Bytes(Bytes::copy_from_slice(chunk)),
-                )
-                .await?;
-
-            let status = resp.status();
-
-            match status {
-                // Typical response code: 202 Accepted
-                // Reference: https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_put_content?view=odsp-graph-online#response
-                StatusCode::ACCEPTED | StatusCode::CREATED | StatusCode::OK => {
-                    resp.into_body().consume().await?;
-                }
-                _ => return Err(parse_error(resp).await?),
-            }
-
-            offset += OneDriveWriter::CHUNK_SIZE_FACTOR;
-        }
-
-        Ok(())
-    }
-
-    async fn create_upload_session(&self) -> Result<OneDriveUploadSessionCreationResponseBody> {
-        let file_name_from_path = self.path.split('/').last().ok_or_else(|| {
-            Error::new(
-                ErrorKind::Unexpected,
-                "connection string must have AccountName",
-            )
-        })?;
-        let url = format!(
-            "{}/drive/root:{}:/createUploadSession",
-            OnedriveBackend::BASE_URL,
-            percent_encode_path(&self.path)
-        );
-        let body = OneDriveUploadSessionCreationRequestBody::new(file_name_from_path.to_string());
-
-        let resp = self
-            .backend
-            .onedrive_create_upload_session(&url, body)
-            .await?;
-
-        let status = resp.status();
-
-        match status {
-            // Reference: https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online#response
-            StatusCode::OK => {
-                let bs = resp.into_body().bytes().await?;
-                let result: OneDriveUploadSessionCreationResponseBody =
-                    serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
-                Ok(result)
-            }
-            _ => Err(parse_error(resp).await?),
-        }
-    }
+    // TODO: We should migrate to opendal's framework of uploading large files.
+    //
+    // pub(crate) async fn write_chunked(&self, total_bytes: Bytes) -> Result<()> {
+    //     // Upload large files via sessions: https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online#upload-bytes-to-the-upload-session
+    //     // 1. Create an upload session
+    //     // 2. Upload the bytes of each chunk
+    //     // 3. Commit the session
+    //
+    //     let session_response = self.create_upload_session().await?;
+    //
+    //     let mut offset = 0;
+    //
+    //     let iter = total_bytes.chunks(OneDriveWriter::CHUNK_SIZE_FACTOR);
+    //
+    //     for chunk in iter {
+    //         let mut end = offset + OneDriveWriter::CHUNK_SIZE_FACTOR;
+    //         if end > total_bytes.len() {
+    //             end = total_bytes.len();
+    //         }
+    //         let total_len = total_bytes.len();
+    //         let chunk_end = end - 1;
+    //
+    //         let resp = self
+    //             .backend
+    //             .onedrive_chunked_upload(
+    //                 &session_response.upload_url,
+    //                 None,
+    //                 offset,
+    //                 chunk_end,
+    //                 total_len,
+    //                 AsyncBody::Bytes(Bytes::copy_from_slice(chunk)),
+    //             )
+    //             .await?;
+    //
+    //         let status = resp.status();
+    //
+    //         match status {
+    //             // Typical response code: 202 Accepted
+    //             // Reference: https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_put_content?view=odsp-graph-online#response
+    //             StatusCode::ACCEPTED | StatusCode::CREATED | StatusCode::OK => {
+    //                 resp.into_body().consume().await?;
+    //             }
+    //             _ => return Err(parse_error(resp).await?),
+    //         }
+    //
+    //         offset += OneDriveWriter::CHUNK_SIZE_FACTOR;
+    //     }
+    //
+    //     Ok(())
+    // }
+    //
+    // async fn create_upload_session(&self) -> Result<OneDriveUploadSessionCreationResponseBody> {
+    //     let file_name_from_path = self.path.split('/').last().ok_or_else(|| {
+    //         Error::new(
+    //             ErrorKind::Unexpected,
+    //             "connection string must have AccountName",
+    //         )
+    //     })?;
+    //     let url = format!(
+    //         "{}/drive/root:{}:/createUploadSession",
+    //         OnedriveBackend::BASE_URL,
+    //         percent_encode_path(&self.path)
+    //     );
+    //     let body = OneDriveUploadSessionCreationRequestBody::new(file_name_from_path.to_string());
+    //
+    //     let resp = self
+    //         .backend
+    //         .onedrive_create_upload_session(&url, body)
+    //         .await?;
+    //
+    //     let status = resp.status();
+    //
+    //     match status {
+    //         // Reference: https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online#response
+    //         StatusCode::OK => {
+    //             let bs = resp.into_body().bytes().await?;
+    //             let result: OneDriveUploadSessionCreationResponseBody =
+    //                 serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
+    //             Ok(result)
+    //         }
+    //         _ => Err(parse_error(resp).await?),
+    //     }
+    // }
 }

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -404,7 +404,6 @@ impl Accessor for OssBackend {
 
                 write: true,
                 write_can_append: true,
-                write_can_sink: true,
                 write_with_cache_control: true,
                 write_with_content_type: true,
                 write_with_content_disposition: true,

--- a/core/src/services/oss/writer.rs
+++ b/core/src/services/oss/writer.rs
@@ -217,10 +217,14 @@ impl oio::AppendObjectWrite for OssWriter {
         }
     }
 
-    async fn append(&self, offset: u64, size: u64, body: AsyncBody) -> Result<()> {
-        let mut req = self
-            .core
-            .oss_append_object_request(&self.path, offset, size, &self.op, body)?;
+    async fn append(&self, offset: u64, stream: Streamer) -> Result<()> {
+        let mut req = self.core.oss_append_object_request(
+            &self.path,
+            offset,
+            stream.size(),
+            &self.op,
+            AsyncBody::Stream(stream),
+        )?;
 
         self.core.sign(&mut req).await?;
 

--- a/core/src/services/oss/writer.rs
+++ b/core/src/services/oss/writer.rs
@@ -23,7 +23,7 @@ use http::StatusCode;
 
 use super::core::*;
 use super::error::parse_error;
-use crate::raw::oio::Streamer;
+use crate::raw::oio::{Stream, Streamer};
 use crate::raw::*;
 use crate::*;
 
@@ -52,10 +52,10 @@ impl OssWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for OssWriter {
-    async fn write_once(&self, size: u64, stream: Streamer) -> Result<()> {
+    async fn write_once(&self, stream: Streamer) -> Result<()> {
         let mut req = self.core.oss_put_object_request(
             &self.path,
-            Some(size),
+            Some(stream.size()),
             self.op.content_type(),
             self.op.content_disposition(),
             self.op.cache_control(),
@@ -112,15 +112,21 @@ impl oio::MultipartUploadWrite for OssWriter {
         &self,
         upload_id: &str,
         part_number: usize,
-        size: u64,
-        body: AsyncBody,
+        stream: Streamer,
     ) -> Result<oio::MultipartUploadPart> {
         // OSS requires part number must between [1..=10000]
         let part_number = part_number + 1;
 
         let resp = self
             .core
-            .oss_upload_part_request(&self.path, upload_id, part_number, false, size, body)
+            .oss_upload_part_request(
+                &self.path,
+                upload_id,
+                part_number,
+                false,
+                stream.size(),
+                AsyncBody::Stream(stream),
+            )
             .await?;
 
         let status = resp.status();

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -917,7 +917,6 @@ impl Accessor for S3Backend {
                 read_with_override_content_type: true,
 
                 write: true,
-                write_can_sink: true,
                 write_with_cache_control: true,
                 write_with_content_type: true,
                 write_without_content_length: true,

--- a/core/src/services/sftp/writer.rs
+++ b/core/src/services/sftp/writer.rs
@@ -32,16 +32,16 @@ impl SftpWriter {
     pub fn new(file: File) -> Self {
         SftpWriter { file }
     }
-}
 
-#[async_trait]
-impl oio::Write for SftpWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         self.file.write_all(&bs).await?;
 
         Ok(())
     }
+}
 
+#[async_trait]
+impl oio::Write for SftpWriter {
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/services/sftp/writer.rs
+++ b/core/src/services/sftp/writer.rs
@@ -42,7 +42,7 @@ impl SftpWriter {
 
 #[async_trait]
 impl oio::Write for SftpWriter {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/sftp/writer.rs
+++ b/core/src/services/sftp/writer.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use openssh_sftp_client::file::File;
 
 use crate::raw::oio;

--- a/core/src/services/sftp/writer.rs
+++ b/core/src/services/sftp/writer.rs
@@ -42,7 +42,7 @@ impl SftpWriter {
 
 #[async_trait]
 impl oio::Write for SftpWriter {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/supabase/core.rs
+++ b/core/src/services/supabase/core.rs
@@ -82,7 +82,7 @@ impl SupabaseCore {
     pub fn supabase_upload_object_request(
         &self,
         path: &str,
-        size: Option<usize>,
+        size: Option<u64>,
         content_type: Option<&str>,
         body: AsyncBody,
     ) -> Result<Request<AsyncBody>> {

--- a/core/src/services/supabase/writer.rs
+++ b/core/src/services/supabase/writer.rs
@@ -63,10 +63,7 @@ impl SupabaseWriter {
             _ => Err(parse_error(resp).await?),
         }
     }
-}
 
-#[async_trait]
-impl oio::Write for SupabaseWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         if bs.is_empty() {
             return Ok(());
@@ -74,7 +71,10 @@ impl oio::Write for SupabaseWriter {
 
         self.upload(bs).await
     }
+}
 
+#[async_trait]
+impl oio::Write for SupabaseWriter {
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/services/supabase/writer.rs
+++ b/core/src/services/supabase/writer.rs
@@ -18,7 +18,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::*;

--- a/core/src/services/supabase/writer.rs
+++ b/core/src/services/supabase/writer.rs
@@ -75,7 +75,7 @@ impl SupabaseWriter {
 
 #[async_trait]
 impl oio::Write for SupabaseWriter {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/supabase/writer.rs
+++ b/core/src/services/supabase/writer.rs
@@ -75,7 +75,7 @@ impl SupabaseWriter {
 
 #[async_trait]
 impl oio::Write for SupabaseWriter {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/vercel_artifacts/writer.rs
+++ b/core/src/services/vercel_artifacts/writer.rs
@@ -60,7 +60,7 @@ impl VercelArtifactsWriter {
 
 #[async_trait]
 impl oio::Write for VercelArtifactsWriter {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/vercel_artifacts/writer.rs
+++ b/core/src/services/vercel_artifacts/writer.rs
@@ -60,7 +60,7 @@ impl VercelArtifactsWriter {
 
 #[async_trait]
 impl oio::Write for VercelArtifactsWriter {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/vercel_artifacts/writer.rs
+++ b/core/src/services/vercel_artifacts/writer.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::StatusCode;
 
 use super::backend::VercelArtifactsBackend;

--- a/core/src/services/vercel_artifacts/writer.rs
+++ b/core/src/services/vercel_artifacts/writer.rs
@@ -35,10 +35,7 @@ impl VercelArtifactsWriter {
     pub fn new(backend: VercelArtifactsBackend, op: OpWrite, path: String) -> Self {
         VercelArtifactsWriter { backend, op, path }
     }
-}
 
-#[async_trait]
-impl oio::Write for VercelArtifactsWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         let resp = self
             .backend
@@ -59,7 +56,10 @@ impl oio::Write for VercelArtifactsWriter {
             _ => Err(parse_error(resp).await?),
         }
     }
+}
 
+#[async_trait]
+impl oio::Write for VercelArtifactsWriter {
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/services/wasabi/core.rs
+++ b/core/src/services/wasabi/core.rs
@@ -301,7 +301,7 @@ impl WasabiCore {
     pub fn put_object_request(
         &self,
         path: &str,
-        size: Option<usize>,
+        size: Option<u64>,
         content_type: Option<&str>,
         content_disposition: Option<&str>,
         cache_control: Option<&str>,
@@ -637,7 +637,7 @@ impl WasabiCore {
     pub async fn put_object(
         &self,
         path: &str,
-        size: Option<usize>,
+        size: Option<u64>,
         content_type: Option<&str>,
         content_disposition: Option<&str>,
         cache_control: Option<&str>,

--- a/core/src/services/wasabi/writer.rs
+++ b/core/src/services/wasabi/writer.rs
@@ -18,7 +18,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::*;

--- a/core/src/services/wasabi/writer.rs
+++ b/core/src/services/wasabi/writer.rs
@@ -37,10 +37,7 @@ impl WasabiWriter {
     pub fn new(core: Arc<WasabiCore>, op: OpWrite, path: String) -> Self {
         WasabiWriter { core, op, path }
     }
-}
 
-#[async_trait]
-impl oio::Write for WasabiWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         let resp = self
             .core
@@ -62,7 +59,10 @@ impl oio::Write for WasabiWriter {
             _ => Err(parse_error(resp).await?),
         }
     }
+}
 
+#[async_trait]
+impl oio::Write for WasabiWriter {
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/services/wasabi/writer.rs
+++ b/core/src/services/wasabi/writer.rs
@@ -63,7 +63,7 @@ impl WasabiWriter {
 
 #[async_trait]
 impl oio::Write for WasabiWriter {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/wasabi/writer.rs
+++ b/core/src/services/wasabi/writer.rs
@@ -63,7 +63,7 @@ impl WasabiWriter {
 
 #[async_trait]
 impl oio::Write for WasabiWriter {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -238,7 +238,6 @@ impl Accessor for WebdavBackend {
                 read_with_range: true,
 
                 write: true,
-                write_can_sink: true,
 
                 create_dir: true,
                 delete: true,

--- a/core/src/services/webdav/writer.rs
+++ b/core/src/services/webdav/writer.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::StatusCode;
 
 use super::backend::WebdavBackend;

--- a/core/src/services/webdav/writer.rs
+++ b/core/src/services/webdav/writer.rs
@@ -67,7 +67,7 @@ impl WebdavWriter {
 
 #[async_trait]
 impl oio::Write for WebdavWriter {
-    async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.write_oneshot(size, AsyncBody::Stream(s)).await
     }
 

--- a/core/src/services/webdav/writer.rs
+++ b/core/src/services/webdav/writer.rs
@@ -58,15 +58,15 @@ impl WebdavWriter {
             _ => Err(parse_error(resp).await?),
         }
     }
-}
 
-#[async_trait]
-impl oio::Write for WebdavWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         self.write_oneshot(bs.len() as u64, AsyncBody::Bytes(bs))
             .await
     }
+}
 
+#[async_trait]
+impl oio::Write for WebdavWriter {
     async fn sink(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
         self.write_oneshot(size, AsyncBody::Stream(s)).await
     }

--- a/core/src/services/webdav/writer.rs
+++ b/core/src/services/webdav/writer.rs
@@ -21,6 +21,7 @@ use http::StatusCode;
 
 use super::backend::WebdavBackend;
 use super::error::parse_error;
+use crate::raw::oio::Stream;
 use crate::raw::*;
 use crate::*;
 
@@ -67,8 +68,8 @@ impl WebdavWriter {
 
 #[async_trait]
 impl oio::Write for WebdavWriter {
-    async fn write(&mut self, size: u64, s: oio::Streamer) -> Result<()> {
-        self.write_oneshot(size, AsyncBody::Stream(s)).await
+    async fn write(&mut self, s: oio::Streamer) -> Result<()> {
+        self.write_oneshot(s.size(), AsyncBody::Stream(s)).await
     }
 
     async fn abort(&mut self) -> Result<()> {

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -200,7 +200,7 @@ impl WebhdfsBackend {
     pub async fn webhdfs_create_object_request(
         &self,
         path: &str,
-        size: Option<usize>,
+        size: Option<u64>,
         content_type: Option<&str>,
         body: AsyncBody,
     ) -> Result<Request<AsyncBody>> {

--- a/core/src/services/webhdfs/error.rs
+++ b/core/src/services/webhdfs/error.rs
@@ -100,7 +100,10 @@ mod tests {
     "#,
         );
         let body = IncomingAsyncBody::new(
-            Box::new(oio::into_stream(stream::iter(vec![Ok(ill_args.clone())]))),
+            Box::new(oio::into_stream(
+                ill_args.len() as u64,
+                stream::iter(vec![Ok(ill_args.clone())]),
+            )),
             None,
         );
         let resp = Response::builder()

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -62,7 +62,7 @@ impl WebhdfsWriter {
 
 #[async_trait]
 impl oio::Write for WebhdfsWriter {
-    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::StatusCode;
 
 use super::backend::WebhdfsBackend;

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -35,10 +35,7 @@ impl WebhdfsWriter {
     pub fn new(backend: WebhdfsBackend, op: OpWrite, path: String) -> Self {
         WebhdfsWriter { backend, op, path }
     }
-}
 
-#[async_trait]
-impl oio::Write for WebhdfsWriter {
     async fn write(&mut self, bs: Bytes) -> Result<()> {
         let req = self
             .backend
@@ -61,7 +58,10 @@ impl oio::Write for WebhdfsWriter {
             _ => Err(parse_error(resp).await?),
         }
     }
+}
 
+#[async_trait]
+impl oio::Write for WebhdfsWriter {
     async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -62,7 +62,7 @@ impl WebhdfsWriter {
 
 #[async_trait]
 impl oio::Write for WebhdfsWriter {
-    async fn sink(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
+    async fn write(&mut self, _size: u64, _s: oio::Streamer) -> Result<()> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "Write::sink is not supported",

--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -78,8 +78,6 @@ pub struct Capability {
     pub write: bool,
     /// If operator supports write by append, it will be true.
     pub write_can_append: bool,
-    /// If operator supports write by sink a stream into, it will be true.
-    pub write_can_sink: bool,
     /// If operator supports write with without content length, it will
     /// be true.
     ///

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -729,7 +729,9 @@ impl Operator {
                     }
 
                     let (_, mut w) = inner.write(&path, args).await?;
-                    w.write(bs).await?;
+                    // FIXME: we should bench here to measure the perf.
+                    w.sink(bs.len() as u64, Box::new(oio::Cursor::from(bs)))
+                        .await?;
                     w.close().await?;
 
                     Ok(())

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -730,7 +730,7 @@ impl Operator {
 
                     let (_, mut w) = inner.write(&path, args).await?;
                     // FIXME: we should bench here to measure the perf.
-                    w.sink(bs.len() as u64, Box::new(oio::Cursor::from(bs)))
+                    w.write(bs.len() as u64, Box::new(oio::Cursor::from(bs)))
                         .await?;
                     w.close().await?;
 

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -730,8 +730,7 @@ impl Operator {
 
                     let (_, mut w) = inner.write(&path, args).await?;
                     // FIXME: we should bench here to measure the perf.
-                    w.write(bs.len() as u64, Box::new(oio::Cursor::from(bs)))
-                        .await?;
+                    w.write(Box::new(oio::Cursor::from(bs))).await?;
                     w.close().await?;
 
                     Ok(())

--- a/core/src/types/writer.rs
+++ b/core/src/types/writer.rs
@@ -131,7 +131,7 @@ impl Writer {
         T: Into<Bytes>,
     {
         if let State::Idle(Some(w)) = &mut self.state {
-            let s = Box::new(oio::into_stream(sink_from.map_ok(|v| v.into())));
+            let s = Box::new(oio::into_stream(size, sink_from.map_ok(|v| v.into())));
             w.write(size, s).await
         } else {
             unreachable!(
@@ -176,7 +176,7 @@ impl Writer {
         R: futures::AsyncRead + Send + Sync + Unpin + 'static,
     {
         if let State::Idle(Some(w)) = &mut self.state {
-            let s = Box::new(oio::into_stream_from_reader(read_from));
+            let s = Box::new(oio::into_stream_from_reader(size, read_from));
             w.write(size, s).await
         } else {
             unreachable!(

--- a/core/src/types/writer.rs
+++ b/core/src/types/writer.rs
@@ -83,7 +83,7 @@ impl Writer {
     pub async fn write(&mut self, bs: impl Into<Bytes>) -> Result<()> {
         if let State::Idle(Some(w)) = &mut self.state {
             let bs = bs.into();
-            w.sink(bs.len() as u64, Box::new(oio::Cursor::from(bs)))
+            w.write(bs.len() as u64, Box::new(oio::Cursor::from(bs)))
                 .await
         } else {
             unreachable!(
@@ -132,7 +132,7 @@ impl Writer {
     {
         if let State::Idle(Some(w)) = &mut self.state {
             let s = Box::new(oio::into_stream(sink_from.map_ok(|v| v.into())));
-            w.sink(size, s).await
+            w.write(size, s).await
         } else {
             unreachable!(
                 "writer state invalid while sink, expect Idle, actual {}",
@@ -177,7 +177,7 @@ impl Writer {
     {
         if let State::Idle(Some(w)) = &mut self.state {
             let s = Box::new(oio::into_stream_from_reader(read_from));
-            w.sink(size, s).await
+            w.write(size, s).await
         } else {
             unreachable!(
                 "writer state invalid while copy, expect Idle, actual {}",
@@ -253,7 +253,8 @@ impl AsyncWrite for Writer {
                     let size = bs.len();
                     let fut = async move {
                         // FIXME: we should bench here to measure the perf.
-                        w.sink(size as u64, Box::new(oio::Cursor::from(bs))).await?;
+                        w.write(size as u64, Box::new(oio::Cursor::from(bs)))
+                            .await?;
                         Ok((size, w))
                     };
                     self.state = State::Write(Box::pin(fut));
@@ -321,7 +322,8 @@ impl tokio::io::AsyncWrite for Writer {
                     let size = bs.len();
                     let fut = async move {
                         // FIXME: we should bench here to measure the perf.
-                        w.sink(size as u64, Box::new(oio::Cursor::from(bs))).await?;
+                        w.write(size as u64, Box::new(oio::Cursor::from(bs)))
+                            .await?;
                         Ok((size, w))
                     };
                     self.state = State::Write(Box::pin(fut));

--- a/core/src/types/writer.rs
+++ b/core/src/types/writer.rs
@@ -83,8 +83,7 @@ impl Writer {
     pub async fn write(&mut self, bs: impl Into<Bytes>) -> Result<()> {
         if let State::Idle(Some(w)) = &mut self.state {
             let bs = bs.into();
-            w.write(bs.len() as u64, Box::new(oio::Cursor::from(bs)))
-                .await
+            w.write(Box::new(oio::Cursor::from(bs))).await
         } else {
             unreachable!(
                 "writer state invalid while write, expect Idle, actual {}",
@@ -132,7 +131,7 @@ impl Writer {
     {
         if let State::Idle(Some(w)) = &mut self.state {
             let s = Box::new(oio::into_stream(size, sink_from.map_ok(|v| v.into())));
-            w.write(size, s).await
+            w.write(s).await
         } else {
             unreachable!(
                 "writer state invalid while sink, expect Idle, actual {}",
@@ -177,7 +176,7 @@ impl Writer {
     {
         if let State::Idle(Some(w)) = &mut self.state {
             let s = Box::new(oio::into_stream_from_reader(size, read_from));
-            w.write(size, s).await
+            w.write(s).await
         } else {
             unreachable!(
                 "writer state invalid while copy, expect Idle, actual {}",
@@ -253,8 +252,7 @@ impl AsyncWrite for Writer {
                     let size = bs.len();
                     let fut = async move {
                         // FIXME: we should bench here to measure the perf.
-                        w.write(size as u64, Box::new(oio::Cursor::from(bs)))
-                            .await?;
+                        w.write(Box::new(oio::Cursor::from(bs))).await?;
                         Ok((size, w))
                     };
                     self.state = State::Write(Box::pin(fut));
@@ -322,8 +320,7 @@ impl tokio::io::AsyncWrite for Writer {
                     let size = bs.len();
                     let fut = async move {
                         // FIXME: we should bench here to measure the perf.
-                        w.write(size as u64, Box::new(oio::Cursor::from(bs)))
-                            .await?;
+                        w.write(Box::new(oio::Cursor::from(bs))).await?;
                         Ok((size, w))
                     };
                     self.state = State::Write(Box::pin(fut));

--- a/core/tests/behavior/write.rs
+++ b/core/tests/behavior/write.rs
@@ -1145,11 +1145,6 @@ pub async fn test_writer_write(op: Operator) -> Result<()> {
 
 /// Streaming data into writer
 pub async fn test_writer_sink(op: Operator) -> Result<()> {
-    let cap = op.info().full_capability();
-    if !(cap.write && cap.write_can_sink) {
-        return Ok(());
-    }
-
     let path = uuid::Uuid::new_v4().to_string();
     let size = 5 * 1024 * 1024; // write file with 5 MiB
     let content_a = gen_fixed_bytes(size);
@@ -1185,11 +1180,6 @@ pub async fn test_writer_sink(op: Operator) -> Result<()> {
 
 /// Reading data into writer
 pub async fn test_writer_copy(op: Operator) -> Result<()> {
-    let cap = op.info().full_capability();
-    if !(cap.write && cap.write_can_sink) {
-        return Ok(());
-    }
-
     let path = uuid::Uuid::new_v4().to_string();
     let size = 5 * 1024 * 1024; // write file with 5 MiB
     let content_a = gen_fixed_bytes(size);


### PR DESCRIPTION
This PR is going to do the following changes:

- Migrate Writer to stream based instead.
- Add `size()` in oio::Stream so that we can know the size of this stream.
- Migrate all services to stream based (some service need further work).