### PR TITLE
feat(bindings/cpp): expose reader 

### DIFF
--- a/bindings/cpp/include/opendal.hpp
+++ b/bindings/cpp/include/opendal.hpp
@@ -29,8 +29,6 @@
 
 namespace opendal {
 
-constexpr int BUFFER_SIZE = 1024 * 1024;
-
 /**
  * @enum EntryMode
  * @brief The mode of the entry
@@ -190,6 +188,10 @@ private:
 
 using Reader = rust::Box<opendal::ffi::Reader>;
 
+/**
+ * @class ReaderStreamBuf
+ * @brief The stream buffer for ReaderStream
+ */
 class ReaderStreamBuf : public std::streambuf {
 public:
   ReaderStreamBuf(Reader &&reader) : reader_(std::move(reader)) {}
@@ -204,6 +206,10 @@ private:
   Reader reader_;
 };
 
+/**
+ * @class ReaderStream
+ * @brief The stream for Reader
+ */
 class ReaderStream : public std::istream {
 public:
   ReaderStream(Reader &&reader)


### PR DESCRIPTION
## Explanation

`std::istream` is more like `BufRead` in rust, so I expose `struct Reader(BufReader<od::BlockingReader>)`. Otherwise, we need to impl a `BufReader` in c++ which will bring more unsafe code and it's more difficult to maintain.

`std::streambuf` use three following pointers to track buffer state. c++ side needs to update these pointers with rust buffer state. My implementation is to call [`fill_buf`](https://doc.rust-lang.org/1.72.0/std/io/trait.BufRead.html#tymethod.fill_buf) and [`seek`](https://doc.rust-lang.org/1.72.0/std/io/trait.Seek.html#tymethod.seek) in needed and assign [`buffer`](https://doc.rust-lang.org/1.72.0/std/io/struct.BufReader.html#method.buffer) result to the three pointers. And we call [`consume`](https://doc.rust-lang.org/1.72.0/std/io/trait.BufRead.html#tymethod.consume) in the next `fill_buf` and `seek` operation to update c++ info for rust side.

<img width="234" alt="image" src="https://github.com/apache/incubator-opendal/assets/78400701/79bdbd1a-a99f-41ff-a729-64458cc0baa2">
