### PR TITLE
docs: fix spelling - change `MacOS` to `macOS`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ The fastest way is:
 
 OpenDAL is primarily a Rust project. To build OpenDAL, you will need to set up Rust development first. We highly recommend using [rustup](https://rustup.rs/) for the setup process.
 
-For Linux or MacOS, use the following command:
+For Linux or macOS, use the following command:
 
 ```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh

--- a/bindings/cpp/CONTRIBUTING.md
+++ b/bindings/cpp/CONTRIBUTING.md
@@ -60,7 +60,7 @@ sudo apt install libboost-all-dev
 sudo apt install doxygen graphviz
 ```
 
-For MacOS:
+For macOS:
 
 ```shell
 # install C/C++ toolchain (can be replaced by other toolchains)


### PR DESCRIPTION
https://en.wikipedia.org/wiki/MacOS