### PR TITLE
refactor: Relax bounds on Writer::{sink, copy}

### DIFF
--- a/core/src/types/writer.rs
+++ b/core/src/types/writer.rs
@@ -132,9 +132,9 @@ impl Writer {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn sink<S, T>(&mut self, mut sink_from: S) -> Result<u64>
+    pub async fn sink<S, T>(&mut self, sink_from: S) -> Result<u64>
     where
-        S: futures::Stream<Item = Result<T>> + Send + Sync + Unpin + 'static,
+        S: futures::Stream<Item = Result<T>>,
         T: Into<Bytes>,
     {
         let w = if let State::Idle(Some(w)) = &mut self.state {
@@ -146,6 +146,7 @@ impl Writer {
             );
         };
 
+        let mut sink_from = Box::pin(sink_from);
         let mut written = 0;
         while let Some(bs) = sink_from.try_next().await? {
             let mut bs = bs.into();
@@ -190,7 +191,7 @@ impl Writer {
     /// ```
     pub async fn copy<R>(&mut self, read_from: R) -> Result<u64>
     where
-        R: futures::AsyncRead + Send + Sync + Unpin + 'static,
+        R: futures::AsyncRead,
     {
         futures::io::copy(read_from, self).await.map_err(|err| {
             Error::new(ErrorKind::Unexpected, "copy into writer failed")


### PR DESCRIPTION
This adjusts the trait bounds on the input stream (for `sink`) or reader (for `copy`) for the `opendal::Writer` type to be less strict, and thus allow more types to be passed in. 

In particular, the current implementations of these functions do not use any of the additional "information"/requirements that `Send + Sync + Unpin + 'static` imply. The `'static` bound is particularly restrictive, as it stops one being able to pass in any borrowed data, such as a `&mut dyn AsyncRead` object or similar. Without these bounds, one can pass in more readers or more streams, more simply.

There is a downside to this change: if these _implementations_ wanted to change in future to use any of these (e.g. a threaded implementation of `copy` or something), that becomes a breaking change. I would suggest that's okay: any fancy implementation like that would be best offered in _addition_ to these simple ones, exactly because they'll need to impose additional restrictions on their input types.

(Thank you for OpenDAL!)