### PR TITLE
chore(bindings/cpp): update CMakeLists.txt to prepare release

### DIFF
--- a/.github/workflows/bindings_cpp.yml
+++ b/.github/workflows/bindings_cpp.yml
@@ -55,13 +55,15 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -GNinja ..
+          cmake -GNinja -DOPENDAL_DEV=ON ..
           ninja
           ./opendal_cpp_test
 
       - name: Run tests with valgrind
-        working-directory: "bindings/cpp/build"
+        working-directory: "bindings/cpp"
         run: |
-          cmake -GNinja -DENABLE_ADDRESS_SANITIZER=OFF ..
+          mkdir build-valgrind
+          cd build-valgrind
+          cmake -GNinja -DOPENDAL_ENABLE_TESTING=ON ..
           ninja
           valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose ./opendal_cpp_test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -239,7 +239,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -GNinja -DDOCS_ONLY=ON ..
+          cmake -GNinja -DOPENDAL_DOCS_ONLY=ON ..
           ninja docs
 
       - name: Upload docs

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -57,7 +57,7 @@ if (OPENDAL_ENABLE_DOCUMENTATION OR OPENDAL_DOCS_ONLY)
     endif()
 endif()
 
-# get cargo traget dir using cargo locate-project
+# get cargo target dir using cargo locate-project
 # we should this because the target dir is different for development and release
 execute_process(COMMAND cargo locate-project --workspace --message-format plain
     OUTPUT_VARIABLE CARGO_TARGET_DIR

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -25,53 +25,91 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-option(ENABLE_ADDRESS_SANITIZER "Enable address sanitizer" ON)
-option(DOCS_ONLY "Only build documentation" OFF)
+option(OPENDAL_ENABLE_ADDRESS_SANITIZER "Enable address sanitizer" OFF)
+option(OPENDAL_ENABLE_DOCUMENTATION "Enable generating document for opendal" OFF)
+option(OPENDAL_DOCS_ONLY "Only build documentation (dev only for quick ci)" OFF)
+option(OPENDAL_ENABLE_TESTING "Enable building test binary for opendal" OFF)
+option(OPENDAL_DEV "Enable dev mode" OFF)
 
-# Documentation
-set(PROJECT_DOCUMENT_SOURCE ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/README.md)
-string(REPLACE ";" " " PROJECT_DOCUMENT_SOURCE "${PROJECT_DOCUMENT_SOURCE}")
-file(DOWNLOAD https://cdn.jsdelivr.net/gh/jothepro/doxygen-awesome-css@2.2.1/doxygen-awesome.min.css ${CMAKE_BINARY_DIR}/doxygen-awesome.css)
-find_package(Doxygen REQUIRED)
-set(DOXYGEN_IN ${CMAKE_SOURCE_DIR}/Doxyfile)
-set(DOXYGEN_OUT ${CMAKE_BINARY_DIR}/Doxyfile.out)
-configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
-add_custom_target(docs
-    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    COMMENT "Generating API documentation with Doxygen"
-    VERBATIM)
-
-if (DOCS_ONLY)
-    return()
+if (OPENDAL_DEV)
+    set(OPENDAL_ENABLE_ADDRESS_SANITIZER ON)
+    set(OPENDAL_ENABLE_DOCUMENTATION ON)
+    set(OPENDAL_ENABLE_TESTING ON)
 endif()
 
-# cargo target dir must be absolute, otherwise some build target cannot find it
-get_filename_component(CARGO_TARGET_DIR ${CMAKE_SOURCE_DIR}/../../target ABSOLUTE)
-set(CARGO_MANIFEST ${CMAKE_SOURCE_DIR}/Cargo.toml)
-set(RUST_SOURCE_FILE ${CMAKE_SOURCE_DIR}/src/lib.rs)
-set(RUST_BRIDGE_CPP ${CARGO_TARGET_DIR}/cxxbridge/opendal-cpp/src/lib.rs.cc)
-set(RUST_LIB ${CARGO_TARGET_DIR}/debug/${CMAKE_STATIC_LIBRARY_PREFIX}opendal_cpp${CMAKE_STATIC_LIBRARY_SUFFIX})
-set(CPP_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include ${CARGO_TARGET_DIR}/cxxbridge/opendal-cpp/src)
-file(GLOB_RECURSE CPP_SOURCE_FILE src/*.cpp)
+# Documentation
+if (OPENDAL_ENABLE_DOCUMENTATION OR OPENDAL_DOCS_ONLY)
+    set(PROJECT_DOCUMENT_SOURCE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/README.md)
+    string(REPLACE ";" " " PROJECT_DOCUMENT_SOURCE "${PROJECT_DOCUMENT_SOURCE}")
+    file(DOWNLOAD https://cdn.jsdelivr.net/gh/jothepro/doxygen-awesome-css@2.2.1/doxygen-awesome.min.css ${CMAKE_BINARY_DIR}/doxygen-awesome.css)
+    find_package(Doxygen REQUIRED)
+    set(DOXYGEN_IN ${PROJECT_SOURCE_DIR}/Doxyfile)
+    set(DOXYGEN_OUT ${CMAKE_BINARY_DIR}/Doxyfile.out)
+    configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
+    add_custom_target(docs
+        COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMENT "Generating API documentation with Doxygen"
+        VERBATIM)
 
-add_custom_command(
-        OUTPUT ${RUST_BRIDGE_CPP} ${RUST_LIB}
-        COMMAND cargo build --manifest-path ${CARGO_MANIFEST}
-        DEPENDS ${RUST_SOURCE_FILE}
-        USES_TERMINAL
-        COMMENT "Running cargo..."
-)
+    if (OPENDAL_DOCS_ONLY)
+        return()
+    endif()
+endif()
+
+# get cargo traget dir using cargo locate-project
+# we should this because the target dir is different for development and release
+execute_process(COMMAND cargo locate-project --workspace --message-format plain
+    OUTPUT_VARIABLE CARGO_TARGET_DIR
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+string(REGEX REPLACE "/Cargo.toml\n$" "/target" CARGO_TARGET_DIR "${CARGO_TARGET_DIR}")
+set(CARGO_MANIFEST ${PROJECT_SOURCE_DIR}/Cargo.toml)
+set(RUST_SOURCE_FILE ${PROJECT_SOURCE_DIR}/src/lib.rs)
+set(RUST_BRIDGE_CPP ${CARGO_TARGET_DIR}/cxxbridge/opendal-cpp/src/lib.rs.cc)
+set(RUST_HEADER_FILE ${CARGO_TARGET_DIR}/cxxbridge/opendal-cpp/src/lib.rs.h)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(RUST_LIB ${CARGO_TARGET_DIR}/debug/${CMAKE_STATIC_LIBRARY_PREFIX}opendal_cpp${CMAKE_STATIC_LIBRARY_SUFFIX})
+else()
+    set(RUST_LIB ${CARGO_TARGET_DIR}/release/${CMAKE_STATIC_LIBRARY_PREFIX}opendal_cpp${CMAKE_STATIC_LIBRARY_SUFFIX})
+endif()
+set(CPP_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include ${CARGO_TARGET_DIR}/cxxbridge/opendal-cpp/src)
+file(GLOB_RECURSE CPP_SOURCE_FILE src/*.cpp)
+file(GLOB_RECURSE CPP_HEADER_FILE include/*.h)
+
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_custom_command(
+            OUTPUT ${RUST_BRIDGE_CPP} ${RUST_LIB} ${RUST_HEADER_FILE}
+            COMMAND cargo build --manifest-path ${CARGO_MANIFEST}
+            DEPENDS ${RUST_SOURCE_FILE}
+            USES_TERMINAL
+            COMMENT "Running cargo..."
+    )
+else()
+    add_custom_command(
+            OUTPUT ${RUST_BRIDGE_CPP} ${RUST_LIB} ${RUST_HEADER_FILE}
+            COMMAND cargo build --manifest-path ${CARGO_MANIFEST} --release
+            DEPENDS ${RUST_SOURCE_FILE}
+            USES_TERMINAL
+            COMMENT "Running cargo..."
+    )
+endif()
 
 find_package(Boost REQUIRED COMPONENTS date_time iostreams)
 
 add_library(opendal_cpp STATIC ${CPP_SOURCE_FILE} ${RUST_BRIDGE_CPP})
-target_include_directories(opendal_cpp PUBLIC ${CPP_INCLUDE_DIR} Boost::date_time)
+target_sources(opendal_cpp PUBLIC ${CPP_HEADER_FILE})
+target_sources(opendal_cpp PRIVATE ${RUST_HEADER_FILE})
+target_include_directories(opendal_cpp PUBLIC ${CPP_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
 target_link_libraries(opendal_cpp PUBLIC ${RUST_LIB})
 target_link_libraries(opendal_cpp PRIVATE ${CMAKE_DL_LIBS} Boost::date_time)
 set_target_properties(opendal_cpp
         PROPERTIES ADDITIONAL_CLEAN_FILES ${CARGO_TARGET_DIR}
 )
+
+if (OPENDAL_ENABLE_ADDRESS_SANITIZER)
+    target_compile_options(opendal_cpp PRIVATE -fsanitize=leak,address,undefined -fno-omit-frame-pointer -fno-common -O1)
+    target_link_options(opendal_cpp PRIVATE -fsanitize=leak,address,undefined)
+endif()
 
 # Platform-specific test configuration
 if(WIN32)
@@ -86,29 +124,29 @@ if(WIN32)
 endif()
 
 # Tests
-enable_testing()
-find_package(GTest REQUIRED)
-file(GLOB_RECURSE TEST_SOURCE_FILE tests/*.cpp)
-add_executable(opendal_cpp_test ${TEST_SOURCE_FILE})
-target_include_directories(opendal_cpp_test PUBLIC ${CPP_INCLUDE_DIR} ${GTEST_INCLUDE_DIRS})
-target_link_libraries(opendal_cpp_test ${GTEST_LDFLAGS} GTest::gtest_main opendal_cpp)
-target_compile_options(opendal_cpp_test PRIVATE ${GTEST_CFLAGS})
+if (OPENDAL_ENABLE_TESTING)
+    enable_testing()
+    find_package(GTest REQUIRED)
+    file(GLOB_RECURSE TEST_SOURCE_FILE tests/*.cpp)
+    add_executable(opendal_cpp_test ${TEST_SOURCE_FILE})
+    target_include_directories(opendal_cpp_test PUBLIC ${CPP_INCLUDE_DIR} ${GTEST_INCLUDE_DIRS})
+    target_link_libraries(opendal_cpp_test ${GTEST_LDFLAGS} GTest::gtest_main opendal_cpp)
+    target_compile_options(opendal_cpp_test PRIVATE ${GTEST_CFLAGS})
 
-# enable address sanitizers
-if (ENABLE_ADDRESS_SANITIZER)
-    target_compile_options(opendal_cpp PRIVATE -fsanitize=leak,address,undefined -fno-omit-frame-pointer -fno-common -O1)
-    target_link_options(opendal_cpp PRIVATE -fsanitize=leak,address,undefined)
-    target_compile_options(opendal_cpp_test PRIVATE -fsanitize=leak,address,undefined -fno-omit-frame-pointer -fno-common -O1)
-    target_link_options(opendal_cpp_test PRIVATE -fsanitize=leak,address,undefined)
-endif()
+    # enable address sanitizers
+    if (OPENDAL_ENABLE_ADDRESS_SANITIZER)
+        target_compile_options(opendal_cpp_test PRIVATE -fsanitize=leak,address,undefined -fno-omit-frame-pointer -fno-common -O1)
+        target_link_options(opendal_cpp_test PRIVATE -fsanitize=leak,address,undefined)
+    endif()
 
-# Platform-specific test configuration
-if(WIN32)
-    target_link_libraries(opendal_cpp_test userenv ws2_32 bcrypt)
-endif()
-if(APPLE)
-    target_link_libraries(opendal_cpp_test "-framework CoreFoundation -framework Security")
-endif()
+    # Platform-specific test configuration
+    if(WIN32)
+        target_link_libraries(opendal_cpp_test userenv ws2_32 bcrypt)
+    endif()
+    if(APPLE)
+        target_link_libraries(opendal_cpp_test "-framework CoreFoundation -framework Security")
+    endif()
 
-include(GoogleTest)
-gtest_discover_tests(opendal_cpp_test)
+    include(GoogleTest)
+    gtest_discover_tests(opendal_cpp_test)
+endif()

--- a/bindings/cpp/CONTRIBUTING.md
+++ b/bindings/cpp/CONTRIBUTING.md
@@ -91,7 +91,7 @@ mkdir build
 cd build
 
 # Add -DCMAKE_EXPORT_COMPILE_COMMANDS=1 to generate compile_commands.json for clangd
-cmake -GNinja .. 
+cmake -DOPENDAL_DEV=ON -GNinja .. 
 
 ninja
 ```
@@ -107,9 +107,7 @@ ninja clean
 
 ## Test
 
-To build and run the tests. (Note that you need to install GTest)
-
-You should build the project first. Then run:
+To run the tests. (Note that you need to install GTest)
 
 ```shell
 ninja test

--- a/bindings/cpp/README.md
+++ b/bindings/cpp/README.md
@@ -16,22 +16,59 @@ int main() {
 }
 ```
 
-## Build
+## Compiling
+
+### Prerequisites
+
+- CMake >= 3.10
+- C++ compiler with C++17 support
+- The boost library
+
+### Build
 
 ```bash
 mkdir build
 cd build
-
-# Add -DCMAKE_EXPORT_COMPILE_COMMANDS=1 to generate compile_commands.json for clangd
-cmake -DCMAKE_BUILD_TYPE=Debug -GNinja .. 
-
-ninja
+# Add -DOPENDAL_DEV=ON to make development environment for OpenDAL
+cmake ..
+make
 ```
 
-## Test
+### Test
 
-You should build the project first. Then run:
+You should build the project with `OPENDAL_ENABLE_TESTING` option. Then run:
 
 ```bash
-ninja test
+make test
+```
+
+### Docs
+
+You should build the project with `OPENDAL_ENABLE_DOCUMENTATION` option. Then run:
+
+```bash
+make docs
+```
+
+### CMake Options
+
+- `OPENDAL_DEV`: Enable development environment for OpenDAL. It will enable most development options. With this option, you don't need to set other options. Default: `OFF`
+- `OPENDAL_ENABLE_ADDRESS_SANITIZER`: Enable address sanitizer. Default: `OFF`
+- `OPENDAL_ENABLE_DOCUMENTATION`: Enable documentation. Default: `OFF`
+- `OPENDAL_DOCS_ONLY`: Only build documentation. Default: `OFF`
+- `OPENDAL_ENABLE_TESTING`: Enable testing. Default: `OFF`
+
+## Using
+
+### CMake
+
+Because the project repo includes rust core code, we can't use `git submodule` directly to add it. So we recommend using `FetchContent` to add the library.
+
+```cmake
+FetchContent_Declare(
+    opendal-cpp
+    URL     https://github.com/apache/incubator-opendal/releases/download/<newest-tag>/opendal-cpp-<newest-tag>.tar.gz
+    URL_HASH SHA256=<newest-tag-sha256>
+)
+FetchContent_MakeAvailable(opendal-cpp)
 ```


### PR DESCRIPTION
Update:
- set test and docs as an option in CMakeLists.txt so that library users don't have to build test binary and documents.
- run `cargo build --release` when setting `CMAKE_BUILD_TYPE` to `Release`
- fix missing headers when using it as external library