### PR TITLE
refactor: Remove the requirement of passing `content_length` to writer

### DIFF
--- a/.github/workflows/service_test_webhdfs.yml
+++ b/.github/workflows/service_test_webhdfs.yml
@@ -37,7 +37,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  hdfs:
+  webhdfs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -76,7 +76,7 @@ jobs:
           OPENDAL_WEBHDFS_ROOT: /
           OPENDAL_WEBHDFS_ENDPOINT: http://127.0.0.1:9870
 
-  hdfs_with_list_batch_disabled:
+  webhdfs_with_list_batch_disabled:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/core/fuzz/fuzz_writer.rs
+++ b/core/fuzz/fuzz_writer.rs
@@ -107,7 +107,7 @@ async fn fuzz_writer(op: Operator, input: FuzzInput) -> Result<()> {
 
     let checker = WriteChecker::new(total_size);
 
-    let mut writer = op.writer_with(&path).buffer_size(8 * 1024 * 1024).await?;
+    let mut writer = op.writer_with(&path).buffer(8 * 1024 * 1024).await?;
 
     for chunk in &checker.chunks {
         writer.write(chunk.clone()).await?;

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -426,6 +426,12 @@ impl<A: Accessor> LayeredAccessor for CompleteReaderAccessor<A> {
         if !capability.write {
             return new_capability_unsupported_error(Operation::Write);
         }
+        if args.append() && !capability.write_can_append {
+            return Err(Error::new(
+                ErrorKind::Unsupported,
+                "write with append enabled is not supported",
+            ));
+        }
 
         self.inner
             .write(path, args)
@@ -437,6 +443,12 @@ impl<A: Accessor> LayeredAccessor for CompleteReaderAccessor<A> {
         let capability = self.meta.full_capability();
         if !capability.write || !capability.blocking {
             return new_capability_unsupported_error(Operation::BlockingWrite);
+        }
+        if args.append() && !capability.write_can_append {
+            return Err(Error::new(
+                ErrorKind::Unsupported,
+                "write with append enabled is not supported",
+            ));
         }
 
         self.inner

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -143,27 +143,13 @@ impl<S: Adapter> Accessor for Backend<S> {
         Ok((RpRead::new(bs.len() as u64), oio::Cursor::from(bs)))
     }
 
-    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
-
+    async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         let p = build_abs_path(&self.root, path);
 
         Ok((RpWrite::new(), KvWriter::new(self.kv.clone(), p)))
     }
 
-    fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
-
+    fn blocking_write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
         let p = build_abs_path(&self.root, path);
 
         Ok((RpWrite::new(), KvWriter::new(self.kv.clone(), p)))

--- a/core/src/raw/adapters/typed_kv/api.rs
+++ b/core/src/raw/adapters/typed_kv/api.rs
@@ -121,13 +121,13 @@ impl Value {
 /// by Typed KV Operator.
 #[derive(Copy, Clone, Default)]
 pub struct Capability {
-    /// If typed_kv operator supports get natively, it will be true.
+    /// If typed_kv operator supports get natively.
     pub get: bool,
-    /// If typed_kv operator supports set natively, it will be true.
+    /// If typed_kv operator supports set natively.
     pub set: bool,
-    /// If typed_kv operator supports delete natively, it will be true.
+    /// If typed_kv operator supports delete natively.
     pub delete: bool,
-    /// If typed_kv operator supports scan natively, it will be true.
+    /// If typed_kv operator supports scan natively.
     pub scan: bool,
 }
 

--- a/core/src/raw/adapters/typed_kv/backend.rs
+++ b/core/src/raw/adapters/typed_kv/backend.rs
@@ -393,6 +393,8 @@ impl<S> KvWriter<S> {
         let value = self.buf.take().map(Bytes::from).unwrap_or_default();
 
         let mut metadata = Metadata::new(EntryMode::FILE);
+        metadata.set_content_length(value.len() as u64);
+
         if let Some(v) = self.op.cache_control() {
             metadata.set_cache_control(v);
         }
@@ -401,11 +403,6 @@ impl<S> KvWriter<S> {
         }
         if let Some(v) = self.op.content_type() {
             metadata.set_content_type(v);
-        }
-        if let Some(v) = self.op.content_length() {
-            metadata.set_content_length(v);
-        } else {
-            metadata.set_content_length(value.len() as u64);
         }
 
         Value { metadata, value }

--- a/core/src/raw/ops.rs
+++ b/core/src/raw/ops.rs
@@ -405,9 +405,8 @@ impl OpStat {
 #[derive(Debug, Clone, Default)]
 pub struct OpWrite {
     append: bool,
+    buffer: Option<usize>,
 
-    buffer_size: Option<usize>,
-    content_length: Option<u64>,
     content_type: Option<String>,
     content_disposition: Option<String>,
     cache_control: Option<String>,
@@ -440,39 +439,23 @@ impl OpWrite {
         self
     }
 
-    /// Get the buffer size from op.
+    /// Get the buffer from op.
     ///
-    /// The buffer size is used by service to decide the buffer size of the underlying writer.
-    pub fn buffer_size(&self) -> Option<usize> {
-        self.buffer_size
+    /// The buffer is used by service to decide the buffer size of the underlying writer.
+    pub fn buffer(&self) -> Option<usize> {
+        self.buffer
     }
 
-    /// Set the buffer size of op.
+    /// Set the buffer of op.
     ///
-    /// If buffer size is set, the data will be buffered by the underlying writer.
+    /// If buffer is set, the data will be buffered by the underlying writer.
     ///
     /// ## NOTE
     ///
     /// Service could have their own minimum buffer size while perform write operations like
     /// multipart uploads. So the buffer size may be larger than the given buffer size.
-    pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
-        self.buffer_size = Some(buffer_size);
-        self
-    }
-
-    /// Get the content length from op.
-    ///
-    /// The content length is the total length of the data to be written.
-    pub fn content_length(&self) -> Option<u64> {
-        self.content_length
-    }
-
-    /// Set the content length of op.
-    ///
-    /// If the content length is not set, the content length will be
-    /// calculated automatically by buffering part of data.
-    pub fn with_content_length(mut self, content_length: u64) -> Self {
-        self.content_length = Some(content_length);
+    pub fn with_buffer(mut self, buffer: usize) -> Self {
+        self.buffer = Some(buffer);
         self
     }
 

--- a/core/src/services/azdfs/backend.rs
+++ b/core/src/services/azdfs/backend.rs
@@ -296,13 +296,6 @@ impl Accessor for AzdfsBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
-
         Ok((
             RpWrite::default(),
             oio::OneShotWriter::new(AzdfsWriter::new(self.core.clone(), args, path.to_string())),

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -272,10 +272,10 @@ impl Accessor for CosBackend {
 
                 write: true,
                 write_can_append: true,
+                write_can_multi: true,
                 write_with_content_type: true,
                 write_with_cache_control: true,
                 write_with_content_disposition: true,
-                write_without_content_length: true,
 
                 delete: true,
                 create_dir: true,
@@ -342,7 +342,7 @@ impl Accessor for CosBackend {
             CosWriters::One(oio::MultipartUploadWriter::new(writer))
         };
 
-        let w = if let Some(buffer_size) = args.buffer_size() {
+        let w = if let Some(buffer_size) = args.buffer() {
             let buffer_size = max(MINIMUM_MULTIPART_SIZE, buffer_size);
 
             let w = oio::ExactBufWriter::new(w, buffer_size);

--- a/core/src/services/dropbox/backend.rs
+++ b/core/src/services/dropbox/backend.rs
@@ -106,12 +106,6 @@ impl Accessor for DropboxBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
         Ok((
             RpWrite::default(),
             oio::OneShotWriter::new(DropboxWriter::new(

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -263,7 +263,7 @@ impl Accessor for FsBackend {
 
                 write: true,
                 write_can_append: true,
-                write_without_content_length: true,
+                write_can_multi: true,
                 create_dir: true,
                 delete: true,
 

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -42,6 +42,7 @@ use super::pager::FtpPager;
 use super::util::FtpReader;
 use super::writer::FtpWriter;
 use crate::raw::*;
+use crate::services::ftp::writer::FtpWriters;
 use crate::*;
 
 /// FTP and FTPS services support.
@@ -264,7 +265,7 @@ impl Debug for FtpBackend {
 impl Accessor for FtpBackend {
     type Reader = FtpReader;
     type BlockingReader = ();
-    type Writer = FtpWriter;
+    type Writer = FtpWriters;
     type BlockingWriter = ();
     type Pager = FtpPager;
     type BlockingPager = ();
@@ -374,10 +375,10 @@ impl Accessor for FtpBackend {
             }
         }
 
-        Ok((
-            RpWrite::new(),
-            FtpWriter::new(self.clone(), path.to_string()),
-        ))
+        let w = FtpWriter::new(self.clone(), path.to_string());
+        let w = oio::OneShotWriter::new(w);
+
+        Ok((RpWrite::new(), w))
     }
 
     async fn stat(&self, path: &str, _: OpStat) -> Result<RpStat> {

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -351,14 +351,7 @@ impl Accessor for FtpBackend {
         Ok((RpRead::new(size), FtpReader::new(r, ftp_stream)))
     }
 
-    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
-
+    async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         // Ensure the parent dir exists.
         let parent = get_parent(path);
         let paths: Vec<&str> = parent.split('/').collect();

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -362,8 +362,8 @@ impl Accessor for GcsBackend {
                 read_with_if_none_match: true,
 
                 write: true,
+                write_can_multi: true,
                 write_with_content_type: true,
-                write_without_content_length: true,
                 delete: true,
                 copy: true,
 
@@ -423,7 +423,7 @@ impl Accessor for GcsBackend {
         let w = GcsWriter::new(self.core.clone(), path, args.clone());
         let w = oio::RangeWriter::new(w);
 
-        let w = if let Some(buffer_size) = args.buffer_size() {
+        let w = if let Some(buffer_size) = args.buffer() {
             // FIXME: we should align with 256KiB instead.
             let buffer_size = max(DEFAULT_WRITE_FIXED_SIZE, buffer_size);
 

--- a/core/src/services/gdrive/backend.rs
+++ b/core/src/services/gdrive/backend.rs
@@ -166,14 +166,7 @@ impl Accessor for GdriveBackend {
         }
     }
 
-    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
-
+    async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         // As Google Drive allows files have the same name, we need to check if the file exists.
         // If the file exists, we will keep its ID and update it.
         let mut file_id: Option<String> = None;

--- a/core/src/services/gdrive/writer.rs
+++ b/core/src/services/gdrive/writer.rs
@@ -23,6 +23,7 @@ use http::StatusCode;
 
 use super::core::GdriveCore;
 use super::error::parse_error;
+use crate::raw::oio::WriteBuf;
 use crate::raw::*;
 use crate::*;
 
@@ -88,7 +89,8 @@ impl GdriveWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for GdriveWriter {
-    async fn write_once(&self, bs: Bytes) -> Result<()> {
+    async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
+        let bs = bs.bytes(bs.remaining());
         let size = bs.len();
         if self.file_id.is_none() {
             self.write_create(size as u64, bs).await?;

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -404,14 +404,7 @@ impl Accessor for GhacBackend {
         }
     }
 
-    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
-
+    async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         let req = self.ghac_reserve(path).await?;
 
         let resp = self.client.send(req).await?;

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -121,14 +121,7 @@ impl Accessor for IpmfsBackend {
         }
     }
 
-    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
-
+    async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         Ok((
             RpWrite::default(),
             oio::OneShotWriter::new(IpmfsWriter::new(self.clone(), path.to_string())),

--- a/core/src/services/ipmfs/writer.rs
+++ b/core/src/services/ipmfs/writer.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::StatusCode;
 
 use super::backend::IpmfsBackend;
 use super::error::parse_error;
+use crate::raw::oio::WriteBuf;
 use crate::raw::*;
 use crate::*;
 
@@ -38,7 +38,8 @@ impl IpmfsWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for IpmfsWriter {
-    async fn write_once(&self, bs: Bytes) -> Result<()> {
+    async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
+        let bs = oio::ChunkedBytes::from_vec(bs.vectored_bytes(bs.remaining()));
         let resp = self.backend.ipmfs_write(&self.path, bs).await?;
 
         let status = resp.status();

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -279,9 +279,9 @@ impl Accessor for ObsBackend {
 
                 write: true,
                 write_can_append: true,
+                write_can_multi: true,
                 write_with_content_type: true,
                 write_with_cache_control: true,
-                write_without_content_length: true,
 
                 delete: true,
                 create_dir: true,
@@ -380,7 +380,7 @@ impl Accessor for ObsBackend {
             ObsWriters::One(oio::MultipartUploadWriter::new(writer))
         };
 
-        let w = if let Some(buffer_size) = args.buffer_size() {
+        let w = if let Some(buffer_size) = args.buffer() {
             let buffer_size = max(MINIMUM_MULTIPART_SIZE, buffer_size);
 
             let w = oio::ExactBufWriter::new(w, buffer_size);

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -103,13 +103,6 @@ impl Accessor for OnedriveBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
-
         let path = build_rooted_abs_path(&self.root, path);
 
         Ok((

--- a/core/src/services/onedrive/writer.rs
+++ b/core/src/services/onedrive/writer.rs
@@ -23,6 +23,7 @@ use super::backend::OnedriveBackend;
 use super::error::parse_error;
 use super::graph_model::OneDriveUploadSessionCreationRequestBody;
 use super::graph_model::OneDriveUploadSessionCreationResponseBody;
+use crate::raw::oio::WriteBuf;
 use crate::raw::*;
 use crate::*;
 
@@ -45,7 +46,8 @@ impl OneDriveWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for OneDriveWriter {
-    async fn write_once(&self, bs: Bytes) -> Result<()> {
+    async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
+        let bs = bs.bytes(bs.remaining());
         let size = bs.len();
 
         if size <= Self::MAX_SIMPLE_SIZE {

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -404,10 +404,11 @@ impl Accessor for OssBackend {
 
                 write: true,
                 write_can_append: true,
+                write_can_multi: true,
                 write_with_cache_control: true,
                 write_with_content_type: true,
                 write_with_content_disposition: true,
-                write_without_content_length: true,
+
                 delete: true,
                 create_dir: true,
                 copy: true,
@@ -478,7 +479,7 @@ impl Accessor for OssBackend {
             OssWriters::One(oio::MultipartUploadWriter::new(writer))
         };
 
-        let w = if let Some(buffer_size) = args.buffer_size() {
+        let w = if let Some(buffer_size) = args.buffer() {
             let buffer_size = max(MINIMUM_MULTIPART_SIZE, buffer_size);
 
             let w = oio::ExactBufWriter::new(w, buffer_size);

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -913,9 +913,10 @@ impl Accessor for S3Backend {
                 read_with_override_content_type: true,
 
                 write: true,
+                write_can_multi: true,
                 write_with_cache_control: true,
                 write_with_content_type: true,
-                write_without_content_length: true,
+
                 create_dir: true,
                 delete: true,
                 copy: true,
@@ -979,7 +980,7 @@ impl Accessor for S3Backend {
 
         let w = oio::MultipartUploadWriter::new(writer);
 
-        let w = if let Some(buffer_size) = args.buffer_size() {
+        let w = if let Some(buffer_size) = args.buffer() {
             let buffer_size = max(MINIMUM_MULTIPART_SIZE, buffer_size);
 
             oio::TwoWaysWriter::Two(oio::ExactBufWriter::new(w, buffer_size))

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -243,7 +243,8 @@ impl Accessor for SftpBackend {
                 read_can_seek: true,
 
                 write: true,
-                write_without_content_length: true,
+                write_can_multi: true,
+
                 create_dir: true,
                 delete: true,
 

--- a/core/src/services/supabase/backend.rs
+++ b/core/src/services/supabase/backend.rs
@@ -224,13 +224,6 @@ impl Accessor for SupabaseBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
-
         Ok((
             RpWrite::default(),
             oio::OneShotWriter::new(SupabaseWriter::new(self.core.clone(), path, args)),

--- a/core/src/services/vercel_artifacts/backend.rs
+++ b/core/src/services/vercel_artifacts/backend.rs
@@ -84,13 +84,6 @@ impl Accessor for VercelArtifactsBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
-
         Ok((
             RpWrite::default(),
             oio::OneShotWriter::new(VercelArtifactsWriter::new(

--- a/core/src/services/vercel_artifacts/writer.rs
+++ b/core/src/services/vercel_artifacts/writer.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::StatusCode;
 
 use super::backend::VercelArtifactsBackend;
@@ -43,12 +42,16 @@ impl VercelArtifactsWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for VercelArtifactsWriter {
-    async fn write_once(&self, bs: Bytes) -> Result<()> {
-        let size = bs.len();
+    async fn write_once(&self, bs: &dyn oio::WriteBuf) -> Result<()> {
+        let bs = oio::ChunkedBytes::from_vec(bs.vectored_bytes(bs.remaining()));
 
         let resp = self
             .backend
-            .vercel_artifacts_put(self.path.as_str(), size as u64, AsyncBody::Bytes(bs))
+            .vercel_artifacts_put(
+                self.path.as_str(),
+                bs.len() as u64,
+                AsyncBody::ChunkedBytes(bs),
+            )
             .await?;
 
         let status = resp.status();

--- a/core/src/services/wasabi/backend.rs
+++ b/core/src/services/wasabi/backend.rs
@@ -750,13 +750,6 @@ impl Accessor for WasabiBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
-
         Ok((
             RpWrite::default(),
             oio::OneShotWriter::new(WasabiWriter::new(self.core.clone(), args, path.to_string())),

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -275,13 +275,6 @@ impl Accessor for WebdavBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
-
         self.ensure_parent_path(path).await?;
 
         let p = build_abs_path(&self.root, path);

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -474,13 +474,6 @@ impl Accessor for WebhdfsBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if args.content_length().is_none() {
-            return Err(Error::new(
-                ErrorKind::Unsupported,
-                "write without content length is not supported",
-            ));
-        }
-
         Ok((
             RpWrite::default(),
             oio::OneShotWriter::new(WebhdfsWriter::new(self.clone(), args, path.to_string())),

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use async_trait::async_trait;
-use bytes::Bytes;
 use http::StatusCode;
 
 use super::backend::WebhdfsBackend;
 use super::error::parse_error;
+use crate::raw::oio::WriteBuf;
 use crate::raw::*;
 use crate::*;
 
@@ -39,16 +39,16 @@ impl WebhdfsWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for WebhdfsWriter {
-    async fn write_once(&self, bs: Bytes) -> Result<()> {
-        let size = bs.len();
+    async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
+        let bs = oio::ChunkedBytes::from_vec(bs.vectored_bytes(bs.remaining()));
 
         let req = self
             .backend
             .webhdfs_create_object_request(
                 &self.path,
-                Some(size),
+                Some(bs.len()),
                 self.op.content_type(),
-                AsyncBody::Bytes(bs),
+                AsyncBody::ChunkedBytes(bs),
             )
             .await?;
 

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -39,8 +39,9 @@ impl WebhdfsWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for WebhdfsWriter {
+    /// Using `bytes` instead of `vectored_bytes` to allow request to be redirected.
     async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
-        let bs = oio::ChunkedBytes::from_vec(bs.vectored_bytes(bs.remaining()));
+        let bs = bs.bytes(bs.remaining());
 
         let req = self
             .backend
@@ -48,7 +49,7 @@ impl oio::OneShotWrite for WebhdfsWriter {
                 &self.path,
                 Some(bs.len()),
                 self.op.content_type(),
-                AsyncBody::ChunkedBytes(bs),
+                AsyncBody::Bytes(bs),
             )
             .await?;
 

--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -46,90 +46,85 @@ use std::fmt::Debug;
 /// - Operation with limitations should be named like `batch_max_operations`.
 #[derive(Copy, Clone, Default)]
 pub struct Capability {
-    /// If operator supports stat , it will be true.
+    /// If operator supports stat.
     pub stat: bool,
-    /// If operator supports stat with if match , it will be true.
+    /// If operator supports stat with if match.
     pub stat_with_if_match: bool,
-    /// If operator supports stat with if none match , it will be true.
+    /// If operator supports stat with if none match.
     pub stat_with_if_none_match: bool,
 
-    /// If operator supports read , it will be true.
+    /// If operator supports read.
     pub read: bool,
-    /// If operator supports seek on returning reader , it will
-    /// be true.
+    /// If operator supports seek on returning reader.
     pub read_can_seek: bool,
-    /// If operator supports next on returning reader , it will
-    /// be true.
+    /// If operator supports next on returning reader.
     pub read_can_next: bool,
-    /// If operator supports read with range , it will be true.
+    /// If operator supports read with range.
     pub read_with_range: bool,
-    /// If operator supports read with if match , it will be true.
+    /// If operator supports read with if match.
     pub read_with_if_match: bool,
-    /// If operator supports read with if none match , it will be true.
+    /// If operator supports read with if none match.
     pub read_with_if_none_match: bool,
-    /// if operator supports read with override cache control , it will be true.
+    /// if operator supports read with override cache control.
     pub read_with_override_cache_control: bool,
-    /// if operator supports read with override content disposition , it will be true.
+    /// if operator supports read with override content disposition.
     pub read_with_override_content_disposition: bool,
-    /// if operator supports read with override content type , it will be true.
+    /// if operator supports read with override content type.
     pub read_with_override_content_type: bool,
 
-    /// If operator supports write , it will be true.
+    /// If operator supports write.
     pub write: bool,
-    /// If operator supports write by append, it will be true.
+    /// If operator supports write can be called in multi times.
+    pub write_can_multi: bool,
+    /// If operator supports write by append.
     pub write_can_append: bool,
-    /// If operator supports write with without content length, it will
-    /// be true.
-    ///
-    /// This feature also be called as `Unsized` write or streaming write.
-    pub write_without_content_length: bool,
-    /// If operator supports write with content type , it will be true.
+    /// If operator supports write with content type.
     pub write_with_content_type: bool,
-    /// If operator supports write with content disposition , it will be true.
+    /// If operator supports write with content disposition.
     pub write_with_content_disposition: bool,
-    /// If operator supports write with cache control , it will be true.
+    /// If operator supports write with cache control.
     pub write_with_cache_control: bool,
 
-    /// If operator supports create dir , it will be true.
+    /// If operator supports create dir.
     pub create_dir: bool,
 
-    /// If operator supports delete , it will be true.
+    /// If operator supports delete.
     pub delete: bool,
 
-    /// If operator supports copy , it will be true.
+    /// If operator supports copy.
     pub copy: bool,
 
-    /// If operator supports rename , it will be true.
+    /// If operator supports rename.
     pub rename: bool,
 
-    /// If operator supports list , it will be true.
+    /// If operator supports list.
     pub list: bool,
-    /// If backend supports list with limit, it will be true.
+    /// If backend supports list with limit.
     pub list_with_limit: bool,
-    /// If backend supports list with start after, it will be true.
+    /// If backend supports list with start after.
     pub list_with_start_after: bool,
     /// If backend support list with using slash as delimiter.
     pub list_with_delimiter_slash: bool,
     /// If backend supports list without delimiter.
     pub list_without_delimiter: bool,
 
-    /// If operator supports presign , it will be true.
+    /// If operator supports presign.
     pub presign: bool,
-    /// If operator supports presign read , it will be true.
+    /// If operator supports presign read.
     pub presign_read: bool,
-    /// If operator supports presign stat , it will be true.
+    /// If operator supports presign stat.
     pub presign_stat: bool,
-    /// If operator supports presign write , it will be true.
+    /// If operator supports presign write.
     pub presign_write: bool,
 
-    /// If operator supports batch , it will be true.
+    /// If operator supports batch.
     pub batch: bool,
-    /// If operator supports batch delete , it will be true.
+    /// If operator supports batch delete.
     pub batch_delete: bool,
     /// The max operations that operator supports in batch.
     pub batch_max_operations: Option<usize>,
 
-    /// If operator supports blocking , it will be true.
+    /// If operator supports blocking.
     pub blocking: bool,
 }
 

--- a/core/src/types/operator/blocking_operator.rs
+++ b/core/src/types/operator/blocking_operator.rs
@@ -550,7 +550,7 @@ impl BlockingOperator {
         FunctionWrite(OperatorFunction::new(
             self.inner().clone(),
             path,
-            (OpWrite::default().with_content_length(bs.len() as u64), bs),
+            (OpWrite::default(), bs),
             |inner, path, (args, mut bs)| {
                 if !validate_path(&path, EntryMode::FILE) {
                     return Err(

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -717,7 +717,7 @@ impl Operator {
         let fut = FutureWrite(OperatorFuture::new(
             self.inner().clone(),
             path,
-            (OpWrite::default().with_content_length(bs.len() as u64), bs),
+            (OpWrite::default(), bs),
             |inner, path, (args, mut bs)| {
                 let fut = async move {
                     if !validate_path(&path, EntryMode::FILE) {

--- a/core/src/types/operator/operator_functions.rs
+++ b/core/src/types/operator/operator_functions.rs
@@ -96,19 +96,8 @@ impl FunctionWrite {
     ///
     /// Service could have their own minimum buffer size while perform write operations like
     /// multipart uploads. So the buffer size may be larger than the given buffer size.
-    pub fn buffer_size(mut self, v: usize) -> Self {
-        self.0 = self.0.map_args(|(args, bs)| (args.with_buffer_size(v), bs));
-        self
-    }
-
-    /// Set the content length of op.
-    ///
-    /// If the content length is not set, the content length will be
-    /// calculated automatically by buffering part of data.
-    pub fn content_length(mut self, v: u64) -> Self {
-        self.0 = self
-            .0
-            .map_args(|(args, bs)| (args.with_content_length(v), bs));
+    pub fn buffer(mut self, v: usize) -> Self {
+        self.0 = self.0.map_args(|(args, bs)| (args.with_buffer(v), bs));
         self
     }
 
@@ -173,17 +162,8 @@ impl FunctionWriter {
     ///
     /// Service could have their own minimum buffer size while perform write operations like
     /// multipart uploads. So the buffer size may be larger than the given buffer size.
-    pub fn buffer_size(mut self, v: usize) -> Self {
-        self.0 = self.0.map_args(|args| args.with_buffer_size(v));
-        self
-    }
-
-    /// Set the content length of op.
-    ///
-    /// If the content length is not set, the content length will be
-    /// calculated automatically by buffering part of data.
-    pub fn content_length(mut self, v: u64) -> Self {
-        self.0 = self.0.map_args(|args| args.with_content_length(v));
+    pub fn buffer(mut self, v: usize) -> Self {
+        self.0 = self.0.map_args(|args| args.with_buffer(v));
         self
     }
 

--- a/core/src/types/operator/operator_futures.rs
+++ b/core/src/types/operator/operator_futures.rs
@@ -213,17 +213,6 @@ impl Future for FuturePresignRead {
 pub struct FuturePresignWrite(pub(crate) OperatorFuture<(OpWrite, Duration), PresignedRequest>);
 
 impl FuturePresignWrite {
-    /// Set the content length of op.
-    ///
-    /// If the content length is not set, the content length will be
-    /// calculated automatically by buffering part of data.
-    pub fn content_length(mut self, v: u64) -> Self {
-        self.0 = self
-            .0
-            .map_args(|(args, dur)| (args.with_content_length(v), dur));
-        self
-    }
-
     /// Set the content type of option
     pub fn content_type(mut self, v: &str) -> Self {
         self.0 = self
@@ -403,19 +392,8 @@ impl FutureWrite {
     ///
     /// Service could have their own minimum buffer size while perform write operations like
     /// multipart uploads. So the buffer size may be larger than the given buffer size.
-    pub fn buffer_size(mut self, v: usize) -> Self {
-        self.0 = self.0.map_args(|(args, bs)| (args.with_buffer_size(v), bs));
-        self
-    }
-
-    /// Set the content length of op.
-    ///
-    /// If the content length is not set, the content length will be
-    /// calculated automatically by buffering part of data.
-    pub fn content_length(mut self, v: u64) -> Self {
-        self.0 = self
-            .0
-            .map_args(|(args, bs)| (args.with_content_length(v), bs));
+    pub fn buffer(mut self, v: usize) -> Self {
+        self.0 = self.0.map_args(|(args, bs)| (args.with_buffer(v), bs));
         self
     }
 
@@ -478,17 +456,8 @@ impl FutureWriter {
     ///
     /// Service could have their own minimum buffer size while perform write operations like
     /// multipart uploads. So the buffer size may be larger than the given buffer size.
-    pub fn buffer_size(mut self, v: usize) -> Self {
-        self.0 = self.0.map_args(|args| args.with_buffer_size(v));
-        self
-    }
-
-    /// Set the content length of op.
-    ///
-    /// If the content length is not set, the content length will be
-    /// calculated automatically by buffering part of data.
-    pub fn content_length(mut self, v: u64) -> Self {
-        self.0 = self.0.map_args(|args| args.with_content_length(v));
+    pub fn buffer(mut self, v: usize) -> Self {
+        self.0 = self.0.map_args(|args| args.with_buffer(v));
         self
     }
 

--- a/core/src/types/operator/operator_futures.rs
+++ b/core/src/types/operator/operator_futures.rs
@@ -440,7 +440,7 @@ impl FutureWriter {
     ///
     /// If the append mode is set, the data will be appended to the end of the file.
     ///
-    /// # Notes
+    /// ## Notes
     ///
     /// Service could return `Unsupported` if the underlying storage does not support append.
     pub fn append(mut self, v: bool) -> Self {

--- a/core/src/types/writer.rs
+++ b/core/src/types/writer.rs
@@ -38,20 +38,39 @@ use crate::*;
 /// Please make sure either `close` or `abort` has been called before
 /// dropping the writer otherwise the data could be lost.
 ///
-/// ## Notes
+/// ## Usage
 ///
-/// Writer can be used in two ways:
+/// ### Write Multiple Chunks
 ///
-/// - Sized: write data with a known size by specify the content length.
-/// - Unsized: write data with an unknown size, also known as streaming.
+/// Some services support to write multiple chunks of data into given path. Services that doesn't
+/// support write multiple chunks will return [`ErrorKind::Unsupported`] error when calling `write`
+/// at the second time.
 ///
-/// All services will support `sized` writer and provide special optimization if
-/// the given data size is the same as the content length, allowing them to
-/// be written in one request.
+/// ```no_build
+/// let mut w = op.writer("path/to/file").await?;
+/// w.write(bs).await?;
+/// w.write(bs).await?;
+/// w.close().await?
+/// ```
 ///
-/// Some services also supports `unsized` writer. They MAY buffer part of the data
-/// and flush them into storage at needs. And finally, the file will be available
-/// after `close` has been called.
+/// Our writer also provides [`Writer::sink`] and [`Writer::copy`] support.
+///
+/// Besides, our writer implements [`AsyncWrite`] and [`tokio::io::AsyncWrite`].
+///
+/// ### Write with append enabled
+///
+/// Writer also supports to write with append enabled. This is useful when users want to append
+/// some data to the end of the file.
+///
+/// - If file doesn't exist, it will be created and just like calling `write`.
+/// - If file exists, data will be appended to the end of the file.
+///
+/// Possible Errors:
+///
+/// - Some services store normal file and appendable file in different way. Trying to append
+///   on non-appendable file could return [`ErrorKind::ConditionNotMatch`] error.
+/// - Services that doesn't support append will return [`ErrorKind::Unsupported`] error when
+///   creating writer with `append` enabled.
 pub struct Writer {
     inner: oio::Writer,
 }

--- a/core/src/types/writer.rs
+++ b/core/src/types/writer.rs
@@ -105,7 +105,6 @@ impl Writer {
     /// async fn sink_example(op: Operator) -> Result<()> {
     ///     let mut w = op
     ///         .writer_with("path/to/file")
-    ///         .content_length(2 * 4096)
     ///         .await?;
     ///     let stream = stream::iter(vec![vec![0; 4096], vec![1; 4096]]).map(Ok);
     ///     w.sink(stream).await?;
@@ -154,7 +153,7 @@ impl Writer {
     ///
     /// #[tokio::main]
     /// async fn copy_example(op: Operator) -> Result<()> {
-    ///     let mut w = op.writer_with("path/to/file").content_length(4096).await?;
+    ///     let mut w = op.writer_with("path/to/file").await?;
     ///     let reader = Cursor::new(vec![0; 4096]);
     ///     w.copy(reader).await?;
     ///     w.close().await?;

--- a/core/tests/behavior/write.rs
+++ b/core/tests/behavior/write.rs
@@ -1111,7 +1111,7 @@ pub async fn test_delete_stream(op: Operator) -> Result<()> {
 
 /// Append data into writer
 pub async fn test_writer_write(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().write_without_content_length) {
+    if !(op.info().full_capability().write_can_multi) {
         return Ok(());
     }
 
@@ -1148,7 +1148,7 @@ pub async fn test_writer_write(op: Operator) -> Result<()> {
 /// Streaming data into writer
 pub async fn test_writer_sink(op: Operator) -> Result<()> {
     let cap = op.info().full_capability();
-    if !(cap.write && cap.write_without_content_length) {
+    if !(cap.write && cap.write_can_multi) {
         return Ok(());
     }
 
@@ -1158,7 +1158,7 @@ pub async fn test_writer_sink(op: Operator) -> Result<()> {
     let content_b = gen_fixed_bytes(size);
     let stream = stream::iter(vec![content_a.clone(), content_b.clone()]).map(Ok);
 
-    let mut w = op.writer_with(&path).buffer_size(5 * 1024 * 1024).await?;
+    let mut w = op.writer_with(&path).buffer(5 * 1024 * 1024).await?;
     w.sink(stream).await?;
     w.close().await?;
 
@@ -1185,7 +1185,7 @@ pub async fn test_writer_sink(op: Operator) -> Result<()> {
 /// Reading data into writer
 pub async fn test_writer_copy(op: Operator) -> Result<()> {
     let cap = op.info().full_capability();
-    if !(cap.write && cap.write_without_content_length) {
+    if !(cap.write && cap.write_can_multi) {
         return Ok(());
     }
 
@@ -1194,7 +1194,7 @@ pub async fn test_writer_copy(op: Operator) -> Result<()> {
     let content_a = gen_fixed_bytes(size);
     let content_b = gen_fixed_bytes(size);
 
-    let mut w = op.writer_with(&path).buffer_size(5 * 1024 * 1024).await?;
+    let mut w = op.writer_with(&path).buffer(5 * 1024 * 1024).await?;
 
     let mut content = Bytes::from([content_a.clone(), content_b.clone()].concat());
     while !content.is_empty() {
@@ -1226,7 +1226,7 @@ pub async fn test_writer_copy(op: Operator) -> Result<()> {
 
 /// Copy data from reader to writer
 pub async fn test_writer_futures_copy(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().write_without_content_length) {
+    if !(op.info().full_capability().write_can_multi) {
         return Ok(());
     }
 
@@ -1234,7 +1234,7 @@ pub async fn test_writer_futures_copy(op: Operator) -> Result<()> {
     let (content, size): (Vec<u8>, usize) =
         gen_bytes_with_range(10 * 1024 * 1024..20 * 1024 * 1024);
 
-    let mut w = op.writer_with(&path).buffer_size(8 * 1024 * 1024).await?;
+    let mut w = op.writer_with(&path).buffer(8 * 1024 * 1024).await?;
 
     // Wrap a buf reader here to make sure content is read in 1MiB chunks.
     let mut cursor = BufReader::with_capacity(1024 * 1024, Cursor::new(content.clone()));
@@ -1258,7 +1258,7 @@ pub async fn test_writer_futures_copy(op: Operator) -> Result<()> {
 
 /// Add test for unsized writer
 pub async fn test_fuzz_unsized_writer(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_without_content_length {
+    if !op.info().full_capability().write_can_multi {
         warn!("{op:?} doesn't support write without content length, test skip");
         return Ok(());
     }
@@ -1267,7 +1267,7 @@ pub async fn test_fuzz_unsized_writer(op: Operator) -> Result<()> {
 
     let mut fuzzer = ObjectWriterFuzzer::new(&path, None);
 
-    let mut w = op.writer_with(&path).buffer_size(8 * 1024 * 1024).await?;
+    let mut w = op.writer_with(&path).buffer(8 * 1024 * 1024).await?;
 
     for _ in 0..100 {
         match fuzzer.fuzz() {


### PR DESCRIPTION
This PR will remove `content_length` from `OpWrite` so that users don't need to specify them by hand.

Close https://github.com/apache/incubator-opendal/issues/3033