### PR TITLE
chore(bindings/haskell): make cargo build type same with cabal

### DIFF
--- a/.github/workflows/bindings_haskell.yml
+++ b/.github/workflows/bindings_haskell.yml
@@ -54,15 +54,19 @@ jobs:
       - name: Restore haskell cache
         uses: actions/cache/restore@v3
         with:
-          key: ${{ runner.os }}-haskell-${{ hashFiles('**/*.cabal') }}
-          path: ~/.cabal/store
+          key: ${{ runner.os }}-haskell-${{ hashFiles('**/*.cabal', '**/Setup.hs') }}
+          path: |
+            ~/.cabal/store
+            bindings/haskell/dist-newstyle
           restore-keys: ${{ runner.os }}-haskell-
       - name: Build & Test
         working-directory: "bindings/haskell"
         run: |
-          LD_LIBRARY_PATH=../../target/release cabal test
+          LD_LIBRARY_PATH=../../target/debug cabal test
       - name: Save haskell cache
         uses: actions/cache/save@v3
         with:
-          key: ${{ runner.os }}-haskell-${{ hashFiles('**/*.cabal') }}
-          path: ~/.cabal/store
+          key: ${{ runner.os }}-haskell-${{ hashFiles('**/*.cabal', '**/Setup.hs') }}
+          path: |
+            ~/.cabal/store
+            bindings/haskell/dist-newstyle

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -199,8 +199,10 @@ jobs:
       - name: Restore haskell cache
         uses: actions/cache/restore@v3
         with:
-          key: ${{ runner.os }}-haskell-${{ hashFiles('**/*.cabal') }}
-          path: ~/.cabal/store
+          key: ${{ runner.os }}-haskell-${{ hashFiles('**/*.cabal', '**/Setup.hs') }}
+          path: |
+            ~/.cabal/store
+            bindings/haskell/dist-newstyle
           restore-keys: ${{ runner.os }}-haskell-
 
       - name: Build Docs
@@ -212,8 +214,10 @@ jobs:
       - name: Save haskell cache
         uses: actions/cache/save@v3
         with:
-          key: ${{ runner.os }}-haskell-${{ hashFiles('**/*.cabal') }}
-          path: ~/.cabal/store
+          key: ${{ runner.os }}-haskell-${{ hashFiles('**/*.cabal', '**/Setup.hs') }}
+          path: |
+            ~/.cabal/store
+            bindings/haskell/dist-newstyle
 
       - name: Upload docs
         uses: actions/upload-artifact@v3

--- a/bindings/haskell/Setup.hs
+++ b/bindings/haskell/Setup.hs
@@ -41,7 +41,7 @@ rustConfHook (description, buildInfo) flags = do
   let packageDescription = localPkgDescr localBuildInfo
       library = fromJust $ PD.library packageDescription
       libraryBuildInfo = PD.libBuildInfo library
-  dir <- getLibDir
+  dir <- getLibDir $ fromFlagOrDefault False (configProf flags)
   return
     localBuildInfo
       { localPkgDescr =
@@ -60,24 +60,27 @@ rustConfHook (description, buildInfo) flags = do
 rustBuildHook :: PD.PackageDescription -> LocalBuildInfo -> UserHooks -> BuildFlags -> IO ()
 rustBuildHook pkg_descr lbi hooks flags = do
   putStrLn "Building Rust code..."
-  rawSystemExit (fromFlag $ buildVerbosity flags) "cargo" ["build", "--release"]
+  let cargoArgs = if isRelease then ["build", "--release"] else ["build"]
+  rawSystemExit (fromFlag $ buildVerbosity flags) "cargo" cargoArgs
   createHSLink
   putStrLn "Build Rust code success!"
   buildHook simpleUserHooks pkg_descr lbi hooks flags
   where
     createHSLink = do
-      dir <- getLibDir
+      dir <- getLibDir isRelease
       ghcVersion <- init <$> readProcess "ghc" ["--numeric-version"] ""
       let srcPath = dir ++ "/libopendal_hs." ++ getDynamicLibExtension lbi
       let destPath = dir ++ "/libopendal_hs-ghc" ++ ghcVersion ++ "." ++ getDynamicLibExtension lbi
       exist <- doesFileExist destPath
       when (not exist) $ createFileLink srcPath destPath
+    isRelease = withProfLib lbi
 
-getLibDir :: IO String
-getLibDir = do
+getLibDir :: Bool -> IO String
+getLibDir isRelease = do
   cargoPath <- readProcess "cargo" ["locate-project", "--workspace", "--message-format=plain"] ""
   let dir = take (length cargoPath - 11) cargoPath -- <dir>/Cargo.toml -> <dir>
-  return $ dir ++ "/target/release"
+  let targetDir = if isRelease then "release" else "debug"
+  return $ dir ++ "/target/" ++ targetDir
 
 getDynamicLibExtension :: LocalBuildInfo -> String
 getDynamicLibExtension lbi =


### PR DESCRIPTION
Update:
- make cargo build type same with cabal
- save cabal build cache in ci, previously only saved installation package cache