### PR TITLE
refactor(services/azdls): Use OpWrite instead of passing all args as parameters

### DIFF
--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -262,9 +262,12 @@ impl Accessor for AzdlsBackend {
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
-        let mut req =
-            self.core
-                .azdls_create_request(path, "directory", None, None, AsyncBody::Empty)?;
+        let mut req = self.core.azdls_create_request(
+            path,
+            "directory",
+            &OpWrite::default(),
+            AsyncBody::Empty,
+        )?;
 
         self.core.sign(&mut req).await?;
 

--- a/core/src/services/azdls/core.rs
+++ b/core/src/services/azdls/core.rs
@@ -142,8 +142,7 @@ impl AzdlsCore {
         &self,
         path: &str,
         resource: &str,
-        content_type: Option<&str>,
-        content_disposition: Option<&str>,
+        args: &OpWrite,
         body: AsyncBody,
     ) -> Result<Request<AsyncBody>> {
         let p = build_abs_path(&self.root, path)
@@ -162,11 +161,11 @@ impl AzdlsCore {
         // Content length must be 0 for create request.
         req = req.header(CONTENT_LENGTH, 0);
 
-        if let Some(ty) = content_type {
+        if let Some(ty) = args.content_type() {
             req = req.header(CONTENT_TYPE, ty)
         }
 
-        if let Some(pos) = content_disposition {
+        if let Some(pos) = args.content_disposition() {
             req = req.header(CONTENT_DISPOSITION, pos)
         }
 
@@ -324,8 +323,12 @@ impl AzdlsCore {
 
         if !parts.is_empty() {
             let parent_path = parts.join("/");
-            let mut req =
-                self.azdls_create_request(&parent_path, "directory", None, None, AsyncBody::Empty)?;
+            let mut req = self.azdls_create_request(
+                &parent_path,
+                "directory",
+                &OpWrite::default(),
+                AsyncBody::Empty,
+            )?;
 
             self.sign(&mut req).await?;
 

--- a/core/src/services/azdls/writer.rs
+++ b/core/src/services/azdls/writer.rs
@@ -42,13 +42,9 @@ impl AzdlsWriter {
 #[async_trait]
 impl oio::OneShotWrite for AzdlsWriter {
     async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
-        let mut req = self.core.azdls_create_request(
-            &self.path,
-            "file",
-            self.op.content_type(),
-            self.op.content_disposition(),
-            AsyncBody::Empty,
-        )?;
+        let mut req =
+            self.core
+                .azdls_create_request(&self.path, "file", &self.op, AsyncBody::Empty)?;
 
         self.core.sign(&mut req).await?;
 


### PR DESCRIPTION
Refactored services/azdls as part of #3064 