### PR TITLE
refactor(services/oss): Refactor `oss_put_object` signatures by using OpWrite

### DIFF
--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -556,13 +556,10 @@ impl Accessor for OssBackend {
                 v.if_none_match(),
                 v.override_content_disposition(),
             )?,
-            PresignOperation::Write(v) => self.core.oss_put_object_request(
-                path,
-                None,
-                v,
-                AsyncBody::Empty,
-                true,
-            )?,
+            PresignOperation::Write(v) => {
+                self.core
+                    .oss_put_object_request(path, None, v, AsyncBody::Empty, true)?
+            }
         };
 
         self.core.sign_query(&mut req, args.expire()).await?;

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -437,7 +437,7 @@ impl Accessor for OssBackend {
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let resp = self
             .core
-            .oss_put_object(path, None, None, None, None, AsyncBody::Empty)
+            .oss_put_object(path, None, &OpWrite::default(), AsyncBody::Empty)
             .await?;
         let status = resp.status();
 
@@ -559,9 +559,7 @@ impl Accessor for OssBackend {
             PresignOperation::Write(v) => self.core.oss_put_object_request(
                 path,
                 None,
-                v.content_type(),
-                v.content_disposition(),
-                v.cache_control(),
+                v,
                 AsyncBody::Empty,
                 true,
             )?,

--- a/core/src/services/oss/core.rs
+++ b/core/src/services/oss/core.rs
@@ -377,13 +377,7 @@ impl OssCore {
         args: &OpWrite,
         body: AsyncBody,
     ) -> Result<Response<IncomingAsyncBody>> {
-        let mut req = self.oss_put_object_request(
-            path,
-            size,
-            args,
-            body,
-            false,
-        )?;
+        let mut req = self.oss_put_object_request(path, size, args, body, false)?;
 
         self.sign(&mut req).await?;
         self.send(req).await

--- a/core/src/services/oss/core.rs
+++ b/core/src/services/oss/core.rs
@@ -152,9 +152,7 @@ impl OssCore {
         &self,
         path: &str,
         size: Option<u64>,
-        content_type: Option<&str>,
-        content_disposition: Option<&str>,
-        cache_control: Option<&str>,
+        args: &OpWrite,
         body: AsyncBody,
         is_presign: bool,
     ) -> Result<Request<AsyncBody>> {
@@ -166,15 +164,15 @@ impl OssCore {
 
         req = req.header(CONTENT_LENGTH, size.unwrap_or_default());
 
-        if let Some(mime) = content_type {
+        if let Some(mime) = args.content_type() {
             req = req.header(CONTENT_TYPE, mime);
         }
 
-        if let Some(pos) = content_disposition {
+        if let Some(pos) = args.content_disposition() {
             req = req.header(CONTENT_DISPOSITION, pos);
         }
 
-        if let Some(cache_control) = cache_control {
+        if let Some(cache_control) = args.cache_control() {
             req = req.header(CACHE_CONTROL, cache_control)
         }
 
@@ -376,17 +374,13 @@ impl OssCore {
         &self,
         path: &str,
         size: Option<u64>,
-        content_type: Option<&str>,
-        content_disposition: Option<&str>,
-        cache_control: Option<&str>,
+        args: &OpWrite,
         body: AsyncBody,
     ) -> Result<Response<IncomingAsyncBody>> {
         let mut req = self.oss_put_object_request(
             path,
             size,
-            content_type,
-            content_disposition,
-            cache_control,
+            args,
             body,
             false,
         )?;

--- a/core/src/services/oss/writer.rs
+++ b/core/src/services/oss/writer.rs
@@ -48,13 +48,9 @@ impl OssWriter {
 #[async_trait]
 impl oio::MultipartUploadWrite for OssWriter {
     async fn write_once(&self, size: u64, body: AsyncBody) -> Result<()> {
-        let mut req = self.core.oss_put_object_request(
-            &self.path,
-            Some(size),
-            &self.op,
-            body,
-            false,
-        )?;
+        let mut req =
+            self.core
+                .oss_put_object_request(&self.path, Some(size), &self.op, body, false)?;
 
         self.core.sign(&mut req).await?;
 

--- a/core/src/services/oss/writer.rs
+++ b/core/src/services/oss/writer.rs
@@ -51,9 +51,7 @@ impl oio::MultipartUploadWrite for OssWriter {
         let mut req = self.core.oss_put_object_request(
             &self.path,
             Some(size),
-            self.op.content_type(),
-            self.op.content_disposition(),
-            self.op.cache_control(),
+            &self.op,
             body,
             false,
         )?;


### PR DESCRIPTION
#3064 
- Refactor `oss_put_object` `oss_put_object_request` function in services/oss core.rs
- Usage of `oss_put_object_request` in writer.rs and backend.rs also changed