### PR TITLE
refactor(services/webdav): Use OpRead in `webdav_get`.

### DIFF
--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -263,7 +263,7 @@ impl Accessor for WebdavBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let resp = self.webdav_get(path, args.range()).await?;
+        let resp = self.webdav_get(path, args).await?;
         let status = resp.status();
         match status {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
@@ -408,11 +408,7 @@ impl Accessor for WebdavBackend {
 }
 
 impl WebdavBackend {
-    async fn webdav_get(
-        &self,
-        path: &str,
-        range: BytesRange,
-    ) -> Result<Response<IncomingAsyncBody>> {
+    async fn webdav_get(&self, path: &str, args: OpRead) -> Result<Response<IncomingAsyncBody>> {
         let p = build_rooted_abs_path(&self.root, path);
         let url: String = format!("{}{}", self.endpoint, percent_encode_path(&p));
 
@@ -422,6 +418,7 @@ impl WebdavBackend {
             req = req.header(header::AUTHORIZATION, auth.clone())
         }
 
+        let range = args.range();
         if !range.is_full() {
             req = req.header(header::RANGE, range.to_header());
         }


### PR DESCRIPTION
Complete the refactoring code for #3064.

This is a follow-up to #3076.