### PR TITLE
ci(bindings/haskell): add release workflow

### DIFF
--- a/.github/workflows/bindings_haskell.yml
+++ b/.github/workflows/bindings_haskell.yml
@@ -70,3 +70,54 @@ jobs:
           path: |
             ~/.cabal/store
             bindings/haskell/dist-newstyle
+
+  package:
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Haskell toolchain (ghc-9.2.8)
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+          ghcup install ghc 9.2.8 --set
+          ghcup install cabal --set
+          cabal update
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup
+      - name: Restore haskell cache
+        uses: actions/cache/restore@v3
+        with:
+          key: ${{ runner.os }}-haskell-${{ hashFiles('**/*.cabal', '**/Setup.hs') }}
+          path: |
+            ~/.cabal/store
+            bindings/haskell/dist-newstyle
+          restore-keys: ${{ runner.os }}-haskell-
+      - name: Package
+        working-directory: "bindings/haskell"
+        run: |
+          cargo package --target-dir target
+          cd target/package
+          tar xf opendal-hs-*.crate --strip-components=1
+          cabal sdist
+      - name: Publish candidate to Hackage
+        if: "contains(github.ref, 'rc')"
+        run: |
+          cabal upload -t ${{ secrets.HACKAGE_TOKEN }} bindings/haskell/target/package/dist-newstyle/sdist/*.tar.gz
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: bindings-haskell-sdist
+          path: bindings/haskell/target/package/dist-newstyle/sdist/*.tar.gz
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc')"
+    needs: [package]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: bindings-haskell-sdist
+      - name: Publish to Hackage
+        run: |
+          cabal upload -t ${{ secrets.HACKAGE_TOKEN }} --publish bindings/haskell/target/package/dist-newstyle/sdist/*.tar.gz

--- a/.github/workflows/bindings_haskell.yml
+++ b/.github/workflows/bindings_haskell.yml
@@ -99,10 +99,6 @@ jobs:
           cd target/package
           tar xf opendal-hs-*.crate --strip-components=1
           cabal sdist
-      - name: Publish candidate to Hackage
-        if: "contains(github.ref, 'rc')"
-        run: |
-          cabal upload -t ${{ secrets.HACKAGE_TOKEN }} bindings/haskell/target/package/dist-newstyle/sdist/*.tar.gz
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -118,6 +114,14 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: bindings-haskell-sdist
+      - name: Load secret
+        id: op-load-secret
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OPENDAL_HACKAGE_TOKEN: op://services/hackage/token
       - name: Publish to Hackage
         run: |
-          cabal upload -t ${{ secrets.HACKAGE_TOKEN }} --publish bindings/haskell/target/package/dist-newstyle/sdist/*.tar.gz
+          cabal upload -t $OPENDAL_HACKAGE_TOKEN --publish bindings/haskell/target/package/dist-newstyle/sdist/*.tar.gz

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -210,14 +210,6 @@ jobs:
         run: |
           cabal haddock --haddock-html --haddock-quickjump --haddock-hyperlink-source
           find dist-newstyle -path '**/build/**/doc' -exec cp -r {}/html/opendal-hs/ doc \;
-        
-      - name: Save haskell cache
-        uses: actions/cache/save@v3
-        with:
-          key: ${{ runner.os }}-haskell-${{ hashFiles('**/*.cabal', '**/Setup.hs') }}
-          path: |
-            ~/.cabal/store
-            bindings/haskell/dist-newstyle
 
       - name: Upload docs
         uses: actions/upload-artifact@v3

--- a/bindings/haskell/opendal-hs.cabal
+++ b/bindings/haskell/opendal-hs.cabal
@@ -1,4 +1,4 @@
-cabal-version:      2.2
+cabal-version:      3.0
 -- Licensed to the Apache Software Foundation (ASF) under one
 -- or more contributor license agreements.  See the NOTICE file
 -- distributed with this work for additional information
@@ -22,13 +22,16 @@ license:            Apache-2.0
 synopsis:           OpenDAL Haskell Binding
 description:
     OpenDAL Haskell Binding. Open Data Access Layer: Access data freely, painlessly, and efficiently
+author:             OpenDAL Contributors
+maintainer:         dev@opendal.apache.org
 category:           Storage, Binding
 tested-with:        GHC ==9.2.7
+extra-doc-files:    README.md, CONTRIBUTING.md
+extra-source-files: src/*.rs, Cargo.toml
+
 build-type:         Custom
 custom-setup
     setup-depends:  Cabal, base, directory, process
-
-extra-source-files: src/*.rs, Cargo.toml, build.rs
 
 source-repository head
     type:     git


### PR DESCRIPTION
Update:
- add release workflow to package and update it to hackage. It will update a candidate package for rc tags, and update release package for real release.
- Each task saves the build cache, which created a conflict. So I remove the save cache task from the docs ci and now only the test ci saves the build cache to avoid conflicts.

Question:
Whose account should hackage use?
Where should we store the HACKAGE_TOKEN?