### PR TITLE
chore(bindings/haskell): rename library name from opendal-hs to opendal

### DIFF
--- a/.github/workflows/bindings_haskell.yml
+++ b/.github/workflows/bindings_haskell.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           cargo package --target-dir target
           cd target/package
-          tar xf opendal-hs-*.crate --strip-components=1
+          tar xf opendal-*.crate --strip-components=1
           cabal sdist
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -209,7 +209,7 @@ jobs:
         working-directory: "bindings/haskell"
         run: |
           cabal haddock --haddock-html --haddock-quickjump --haddock-hyperlink-source
-          find dist-newstyle -path '**/build/**/doc' -exec cp -r {}/html/opendal-hs/ doc \;
+          find dist-newstyle -path '**/build/**/doc' -exec cp -r {}/html/opendal/ doc \;
 
       - name: Upload docs
         uses: actions/upload-artifact@v3

--- a/bindings/haskell/CONTRIBUTING.md
+++ b/bindings/haskell/CONTRIBUTING.md
@@ -69,8 +69,8 @@ LD_LIBRARY_PATH=../../target/debug cabal test
 
 ```text
 ...(Build Info)
-Test suite opendal-hs-test: RUNNING...
-Test suite opendal-hs-test: PASS
+Test suite opendal-test: RUNNING...
+Test suite opendal-test: PASS
 Test suite logged to: 
 ...(Log Path)
 1 of 1 test suites (1 of 1 test cases) passed.
@@ -84,7 +84,7 @@ To generate the documentation:
 cabal haddock
 ```
 
-If your `cabal` version is greater than `3.8`, you can use `cabal haddock --open` to open the documentation in your browser. Otherwise, you can visit the documentation from `dist-newstyle/build/$ARCH/ghc-$VERSION/opendal-hs-$VERSION/doc/html/opendal-hs/index.html`.
+If your `cabal` version is greater than `3.8`, you can use `cabal haddock --open` to open the documentation in your browser. Otherwise, you can visit the documentation from `dist-newstyle/build/$ARCH/ghc-$VERSION/opendal-$VERSION/doc/html/opendal/index.html`.
 
 ## Misc
 

--- a/bindings/haskell/README.md
+++ b/bindings/haskell/README.md
@@ -62,4 +62,4 @@ To generate the documentation:
 cabal haddock
 ```
 
-If your `cabal` version is greater than `3.8`, you can use `cabal haddock --open` to open the documentation in your browser. Otherwise, you can visit the documentation from `dist-newstyle/build/$ARCH/ghc-$VERSION/opendal-hs-$VERSION/doc/html/opendal-hs/index.html`.
+If your `cabal` version is greater than `3.8`, you can use `cabal haddock --open` to open the documentation in your browser. Otherwise, you can visit the documentation from `dist-newstyle/build/$ARCH/ghc-$VERSION/opendal-$VERSION/doc/html/opendal/index.html`.

--- a/bindings/haskell/opendal.cabal
+++ b/bindings/haskell/opendal.cabal
@@ -16,7 +16,7 @@ cabal-version:      3.0
 -- specific language governing permissions and limitations
 -- under the License.
 
-name:               opendal-hs
+name:               opendal
 version:            0.1.0.0
 license:            Apache-2.0
 synopsis:           OpenDAL Haskell Binding
@@ -36,6 +36,13 @@ custom-setup
 source-repository head
     type:     git
     location: https://github.com/apache/incubator-opendal
+    subdir:   bindings/haskell
+
+source-repository this
+    type:     git
+    location: https://github.com/apache/incubator-opendal
+    tag:      v0.40.0
+    subdir:   bindings/haskell
 
 common base
     ghc-options:      -Wall
@@ -64,13 +71,13 @@ library
     hs-source-dirs:   haskell-src
     extra-bundled-libraries: opendal_hs
 
-test-suite opendal-hs-test
+test-suite opendal-test
     import:           base
     type:             exitcode-stdio-1.0
     main-is:          Spec.hs
     other-modules:    BasicTest
     hs-source-dirs:   test
     build-depends:    
-        opendal-hs,
+        opendal,
         tasty >= 1.5 && < 1.6,
         tasty-hunit >= 0.10.1 && < 0.11,


### PR DESCRIPTION
update #3102, #3104 

Update:
- rename library name from opendal-hs to opendal
- add `source-repository this` in cabal config file.