### PR TITLE
feat: allow using `prometheus-client` crate with PrometheusClientLayer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,6 +1573,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3580,6 +3586,7 @@ dependencies = [
  "pin-project",
  "pretty_assertions",
  "prometheus",
+ "prometheus-client",
  "prost",
  "quick-xml",
  "rand 0.8.5",
@@ -4491,6 +4498,29 @@ dependencies = [
  "protobuf",
  "reqwest",
  "thiserror",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c99afa9a01501019ac3a14d71d9f94050346f55ca471ce90c799a15c58f61e2"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot 0.12.1",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -83,8 +83,10 @@ layers-all = [
 layers-chaos = ["dep:rand"]
 # Enable layers metrics support
 layers-metrics = ["dep:metrics"]
-# Enable layers prometheus support
+# Enable layers prometheus support, with tikv/prometheus-rs crate
 layers-prometheus = ["dep:prometheus"]
+# Enable layers prometheus support, with prometheus-client crate
+layers-prometheus-client = ["dep:prometheus-client"]
 # Enable layers madsim support
 layers-madsim = ["dep:madsim"]
 # Enable layers minitrace support.
@@ -99,9 +101,6 @@ layers-throttle = ["dep:governor"]
 layers-await-tree = ["dep:await-tree"]
 # Enable layers async-backtrace support.
 layers-async-backtrace = ["dep:async-backtrace"]
-
-# Enable prometheus-client instead of prometheus-rs.
-use-prometheus-client = ["dep:prometheus-client"]
 
 services-atomicserver = ["dep:atomic_lib"]
 services-azblob = [

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -100,6 +100,9 @@ layers-await-tree = ["dep:await-tree"]
 # Enable layers async-backtrace support.
 layers-async-backtrace = ["dep:async-backtrace"]
 
+# Enable prometheus-client instead of prometheus-rs.
+use-prometheus-client = ["dep:prometheus-client"]
+
 services-atomicserver = ["dep:atomic_lib"]
 services-azblob = [
   "dep:sha2",
@@ -243,6 +246,7 @@ percent-encoding = "2"
 persy = { version = "1.4.4", optional = true }
 pin-project = "1"
 prometheus = { version = "0.13", features = ["process"], optional = true }
+prometheus-client = { version = "0.21.2", optional = true }
 prost = { version = "0.11", optional = true }
 quick-xml = { version = "0.29", features = ["serialize", "overlapped-lists"] }
 rand = { version = "0.8", optional = true }

--- a/core/src/layers/mod.rs
+++ b/core/src/layers/mod.rs
@@ -56,6 +56,11 @@ mod prometheus;
 #[cfg(feature = "layers-prometheus")]
 pub use self::prometheus::PrometheusLayer;
 
+#[cfg(feature = "layers-prometheus-client")]
+mod prometheus_client;
+#[cfg(feature = "layers-prometheus-client")]
+pub use self::prometheus_client::PrometheusClientLayer;
+
 mod retry;
 pub use self::retry::RetryInterceptor;
 pub use self::retry::RetryLayer;
@@ -94,5 +99,6 @@ pub use self::await_tree::AwaitTreeLayer;
 
 #[cfg(feature = "layers-async-backtrace")]
 mod async_backtrace;
+
 #[cfg(feature = "layers-async-backtrace")]
 pub use self::async_backtrace::AsyncBacktraceLayer;

--- a/core/src/layers/mod.rs
+++ b/core/src/layers/mod.rs
@@ -99,6 +99,5 @@ pub use self::await_tree::AwaitTreeLayer;
 
 #[cfg(feature = "layers-async-backtrace")]
 mod async_backtrace;
-
 #[cfg(feature = "layers-async-backtrace")]
 pub use self::async_backtrace::AsyncBacktraceLayer;

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -21,6 +21,7 @@ use std::io;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
+use std::time::Instant;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -168,6 +169,27 @@ impl PrometheusMetrics {
             kind.into_static()
         );
     }
+
+    #[inline]
+    fn increment_request_total(&self, scheme: &str, op: Operation) {
+        self.requests_total
+            .with_label_values(&[scheme, op.into_static()])
+            .inc();
+    }
+
+    #[inline]
+    fn observe_bytes_total(&self, scheme: &str, op: Operation, bytes: usize) {
+        self.bytes_total
+            .with_label_values(&[scheme, op.into_static()])
+            .observe(bytes as f64);
+    }
+
+    #[inline]
+    fn observe_request_duration(&self, scheme: &str, op: Operation, duration: std::time::Duration) {
+        self.requests_duration_seconds
+            .with_label_values(&[scheme, op.into_static()])
+            .observe(duration.as_secs_f64());
+    }
 }
 
 #[derive(Clone)]
@@ -200,19 +222,12 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme])
-            .inc();
+        self.stats.increment_request_total(&self.scheme, Operation::CreateDir);
 
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::CreateDir.into_static()])
-            .start_timer();
+        let start_time = Instant::now();
         let create_res = self.inner.create_dir(path, args).await;
 
-        timer.observe_duration();
+        self.stats.observe_request_duration(&self.scheme, Operation::CreateDir, start_time.elapsed());
         create_res.map_err(|e| {
             self.stats
                 .increment_errors_total(Operation::CreateDir, e.kind());
@@ -221,26 +236,15 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::Read.into_static()])
-            .inc();
-
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Read.into_static()])
-            .start_timer();
+        self.stats.increment_request_total(&self.scheme, Operation::Read);
+        let start_time = Instant::now();
 
         let read_res = self
             .inner
             .read(path, args)
             .map(|v| {
                 v.map(|(rp, r)| {
-                    self.stats
-                        .bytes_total
-                        .with_label_values(&[&self.scheme, Operation::Read.into_static()])
-                        .observe(rp.metadata().content_length() as f64);
+                    self.stats.observe_bytes_total(&self.scheme, Operation::Read, rp.metadata().content_length() as usize);
                     (
                         rp,
                         PrometheusMetricWrapper::new(
@@ -253,7 +257,8 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
                 })
             })
             .await;
-        timer.observe_duration();
+        self.stats.observe_request_duration(&self.scheme, Operation::Read, start_time.elapsed());
+
         read_res.map_err(|e| {
             self.stats.increment_errors_total(Operation::Read, e.kind());
             e
@@ -261,16 +266,8 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::Write.into_static()])
-            .inc();
-
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Write.into_static()])
-            .start_timer();
+        self.stats.increment_request_total(&self.scheme, Operation::Write);
+        let start_time = Instant::now();
 
         let write_res = self
             .inner
@@ -289,7 +286,8 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
                 })
             })
             .await;
-        timer.observe_duration();
+
+        self.stats.observe_request_duration(&self.scheme, Operation::Write, start_time.elapsed());
         write_res.map_err(|e| {
             self.stats
                 .increment_errors_total(Operation::Write, e.kind());
@@ -298,15 +296,8 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::Stat.into_static()])
-            .inc();
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Stat.into_static()])
-            .start_timer();
+        self.stats.increment_request_total(&self.scheme, Operation::Stat);
+        let start_time = Instant::now();
 
         let stat_res = self
             .inner
@@ -315,7 +306,8 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
                 self.stats.increment_errors_total(Operation::Stat, e.kind());
             })
             .await;
-        timer.observe_duration();
+
+        self.stats.observe_request_duration(&self.scheme, Operation::Stat, start_time.elapsed());
         stat_res.map_err(|e| {
             self.stats.increment_errors_total(Operation::Stat, e.kind());
             e
@@ -323,19 +315,13 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::Stat.into_static()])
-            .inc();
+        self.stats.increment_request_total(&self.scheme, Operation::Delete);
+        let start_time = Instant::now();
 
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Stat.into_static()])
-            .start_timer();
 
         let delete_res = self.inner.delete(path, args).await;
-        timer.observe_duration();
+
+        self.stats.observe_request_duration(&self.scheme, Operation::Delete, start_time.elapsed());
         delete_res.map_err(|e| {
             self.stats
                 .increment_errors_total(Operation::Delete, e.kind());
@@ -344,20 +330,12 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::List.into_static()])
-            .inc();
-
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::List.into_static()])
-            .start_timer();
+        self.stats.increment_request_total(&self.scheme, Operation::List);
+        let start_time = Intant::now();
 
         let list_res = self.inner.list(path, args).await;
 
-        timer.observe_duration();
+        self.stats.observe_request_duration(&self.scheme, Operation::List, start_time.elapsed());
         list_res.map_err(|e| {
             self.stats.increment_errors_total(Operation::List, e.kind());
             e
@@ -365,19 +343,12 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::Batch.into_static()])
-            .inc();
+        self.stats.increment_request_total(&self.scheme, Operation::Batch);
+        let start_time = Instant::now();
 
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Batch.into_static()])
-            .start_timer();
         let result = self.inner.batch(args).await;
 
-        timer.observe_duration();
+        self.stats.observe_request_duration(&self.scheme, Operation::Batch, start_time.elapsed());
         result.map_err(|e| {
             self.stats
                 .increment_errors_total(Operation::Batch, e.kind());
@@ -386,19 +357,12 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::Presign.into_static()])
-            .inc();
+        self.stats.increment_request_total(&self.scheme, Operation::Presign);
+        let start_time = Instant::now();
 
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Presign.into_static()])
-            .start_timer();
         let result = self.inner.presign(path, args).await;
-        timer.observe_duration();
 
+        self.stats.observe_request_duration(&self.scheme, Operation::Presign, start_time.elapsed());
         result.map_err(|e| {
             self.stats
                 .increment_errors_total(Operation::Presign, e.kind());
@@ -407,20 +371,12 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingCreateDir.into_static()])
-            .inc();
+        self.stats.increment_request_total(&self.scheme, Operation::BlockingCreateDir);
+        let start_time = Instant::now();
 
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::BlockingCreateDir.into_static()])
-            .start_timer();
         let result = self.inner.blocking_create_dir(path, args);
 
-        timer.observe_duration();
-
+        self.stats.observe_request_duration(&self.scheme, Operation::BlockingCreateDir, start_time.elapsed());
         result.map_err(|e| {
             self.stats
                 .increment_errors_total(Operation::BlockingCreateDir, e.kind());
@@ -429,21 +385,11 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingRead.into_static()])
-            .inc();
+        self.stats.increment_request_total(&self.scheme, Operation::BlockingRead);
+        let start_time = Instant::now();
 
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme])
-            .start_timer();
         let result = self.inner.blocking_read(path, args).map(|(rp, r)| {
-            self.stats
-                .bytes_total
-                .with_label_values(&[&self.scheme, Operation::BlockingRead.into_static()])
-                .observe(rp.metadata().content_length() as f64);
+            self.stats.observe_bytes_total(&self.scheme, Operation::BlockingRead, rp.metadata().content_length() as usize);
             (
                 rp,
                 PrometheusMetricWrapper::new(
@@ -454,7 +400,8 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
                 ),
             )
         });
-        timer.observe_duration();
+
+        self.stats.observe_request_duration(&self.scheme, Operation::BlockingRead, start_time.elapsed());
         result.map_err(|e| {
             self.stats
                 .increment_errors_total(Operation::BlockingRead, e.kind());
@@ -463,16 +410,9 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingWrite.into_static()])
-            .inc();
+        self.stats.increment_request_total(&self.scheme, Operation::BlockingWrite);
+        let start_time = Instant::now();
 
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::BlockingWrite.into_static()])
-            .start_timer();
         let result = self.inner.blocking_write(path, args).map(|(rp, r)| {
             (
                 rp,
@@ -484,7 +424,8 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
                 ),
             )
         });
-        timer.observe_duration();
+
+        self.stats.observe_request_duration(&self.scheme, Operation::BlockingWrite, start_time.elapsed());
         result.map_err(|e| {
             self.stats
                 .increment_errors_total(Operation::BlockingWrite, e.kind());
@@ -493,18 +434,11 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     fn blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingStat.into_static()])
-            .inc();
+        self.stats.increment_request_total(&self.scheme, Operation::BlockingStat);
+        let start_time = Instant::now();
 
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::BlockingStat.into_static()])
-            .start_timer();
         let result = self.inner.blocking_stat(path, args);
-        timer.observe_duration();
+        self.stats.observe_request_duration(&self.scheme, Operation::BlockingStat, start_time.elapsed());
         result.map_err(|e| {
             self.stats
                 .increment_errors_total(Operation::BlockingStat, e.kind());
@@ -513,19 +447,12 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     fn blocking_delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingDelete.into_static()])
-            .inc();
+        self.stats.increment_request_total(&self.scheme, Operation::BlockingDelete);
+        let start_time = Instant::now();
 
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::BlockingDelete.into_static()])
-            .start_timer();
         let result = self.inner.blocking_delete(path, args);
-        timer.observe_duration();
 
+        self.stats.observe_request_duration(&self.scheme, Operation::BlockingDelete, start_time.elapsed());
         result.map_err(|e| {
             self.stats
                 .increment_errors_total(Operation::BlockingDelete, e.kind());
@@ -534,19 +461,12 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingList.into_static()])
-            .inc();
+        self.stats.increment_request_total(&self.scheme, Operation::BlockingList);
+        let start_time = Instant::now();
 
-        let timer = self
-            .stats
-            .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::BlockingList.into_static()])
-            .start_timer();
         let result = self.inner.blocking_list(path, args);
-        timer.observe_duration();
 
+        self.stats.observe_request_duration(&self.scheme, Operation::BlockingList, start_time.elapsed());
         result.map_err(|e| {
             self.stats
                 .increment_errors_total(Operation::BlockingList, e.kind());
@@ -578,10 +498,7 @@ impl<R: oio::Read> oio::Read for PrometheusMetricWrapper<R> {
     fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
         self.inner.poll_read(cx, buf).map(|res| match res {
             Ok(bytes) => {
-                self.stats
-                    .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::Read.into_static()])
-                    .observe(bytes as f64);
+                self.stats.observe_bytes_total(&self.scheme, self.op, bytes);
                 Ok(bytes)
             }
             Err(e) => {
@@ -604,10 +521,7 @@ impl<R: oio::Read> oio::Read for PrometheusMetricWrapper<R> {
     fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
         self.inner.poll_next(cx).map(|res| match res {
             Some(Ok(bytes)) => {
-                self.stats
-                    .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::Read.into_static()])
-                    .observe(bytes.len() as f64);
+                self.stats.observe_bytes_total(&self.scheme, self.op, bytes.len());
                 Some(Ok(bytes))
             }
             Some(Err(e)) => {
@@ -624,10 +538,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for PrometheusMetricWrapper<R> {
         self.inner
             .read(buf)
             .map(|n| {
-                self.stats
-                    .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::BlockingRead.into_static()])
-                    .observe(n as f64);
+                self.stats.observe_bytes_total(&self.scheme, self.op, n);
                 n
             })
             .map_err(|e| {
@@ -646,10 +557,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for PrometheusMetricWrapper<R> {
     fn next(&mut self) -> Option<Result<Bytes>> {
         self.inner.next().map(|res| match res {
             Ok(bytes) => {
-                self.stats
-                    .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::BlockingRead.into_static()])
-                    .observe(bytes.len() as f64);
+                self.stats.observe_bytes_total(&self.scheme, self.op, n);
                 Ok(bytes)
             }
             Err(e) => {
@@ -666,10 +574,7 @@ impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
         self.inner
             .poll_write(cx, bs)
             .map_ok(|n| {
-                self.stats
-                    .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::Write.into_static()])
-                    .observe(n as f64);
+                self.stats.observe_bytes_total(&self.scheme, self.op, n);
                 n
             })
             .map_err(|err| {
@@ -698,10 +603,7 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for PrometheusMetricWrapper<R> {
         self.inner
             .write(bs)
             .map(|n| {
-                self.stats
-                    .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::BlockingWrite.into_static()])
-                    .observe(n as f64);
+                self.stats.observe_bytes_total(&self.scheme, self.op, n);
                 n
             })
             .map_err(|err| {

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -367,8 +367,11 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
 
         let result = self.inner.presign(path, args).await;
 
-        self.metrics
-            .observe_request_duration(self.scheme, Operation::Presign, start_time.elapsed());
+        self.metrics.observe_request_duration(
+            self.scheme,
+            Operation::Presign,
+            start_time.elapsed(),
+        );
         result.map_err(|e| {
             self.metrics
                 .increment_errors_total(self.scheme, Operation::Presign, e.kind());
@@ -389,8 +392,11 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
             start_time.elapsed(),
         );
         result.map_err(|e| {
-            self.metrics
-                .increment_errors_total(self.scheme, Operation::BlockingCreateDir, e.kind());
+            self.metrics.increment_errors_total(
+                self.scheme,
+                Operation::BlockingCreateDir,
+                e.kind(),
+            );
             e
         })
     }

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -31,6 +31,7 @@ use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::histogram::Histogram;
 use prometheus_client::registry::Registry;
+use  prometheus_client::metrics::histogram;
 
 use crate::raw::Accessor;
 use crate::raw::*;
@@ -87,7 +88,7 @@ pub struct PrometheusClientLayer {
 
 impl PrometheusClientLayer {
     /// create PrometheusClientLayer while registering itself to this registry.
-    pub fn with_registry(registry: &mut Registry) -> Self {
+    pub fn new(registry: &mut Registry) -> Self {
         let metrics = PrometheusClientMetrics::register(registry);
         Self { metrics }
     }
@@ -126,21 +127,21 @@ impl PrometheusClientMetrics {
     pub fn register(registry: &mut Registry) -> Self {
         let requests_total = Family::default();
         let request_duration_seconds = Family::<VecLabels, _>::new_with_constructor(|| {
-            let buckets = prometheus_client::metrics::histogram::exponential_buckets(0.01, 2.0, 16);
+            let buckets = histogram::exponential_buckets(0.01, 2.0, 16);
             Histogram::new(buckets)
         });
         let bytes_histogram = Family::<VecLabels, _>::new_with_constructor(|| {
-            let buckets = prometheus_client::metrics::histogram::exponential_buckets(1.0, 2.0, 16);
+            let buckets = histogram::exponential_buckets(1.0, 2.0, 16);
             Histogram::new(buckets)
         });
 
-        registry.register("requests_total", "", requests_total.clone());
+        registry.register("opendal_requests_total", "", requests_total.clone());
         registry.register(
-            "request_duration_seconds",
+            "opendal_request_duration_seconds",
             "",
             request_duration_seconds.clone(),
         );
-        registry.register("bytes_histogram", "", bytes_histogram.clone());
+        registry.register("opendal_bytes_histogram", "", bytes_histogram.clone());
         Self {
             requests_total,
             request_duration_seconds,

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -242,11 +242,6 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
             .read(path, args)
             .map(|v| {
                 v.map(|(rp, r)| {
-                    self.stats.observe_bytes_total(
-                        self.scheme,
-                        Operation::Read,
-                        rp.metadata().content_length() as usize,
-                    );
                     (
                         rp,
                         PrometheusMetricWrapper::new(
@@ -413,11 +408,6 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
         let start_time = Instant::now();
 
         let result = self.inner.blocking_read(path, args).map(|(rp, r)| {
-            self.stats.observe_bytes_total(
-                self.scheme,
-                Operation::BlockingRead,
-                rp.metadata().content_length() as usize,
-            );
             (
                 rp,
                 PrometheusMetricWrapper::new(


### PR DESCRIPTION
I'm currently working on switching to prometheus from metrics-rs in databend at https://github.com/datafuselabs/databend/pull/12787 , but unfortunately the PrometheusLayer in opendal uses the `tikv/prometheus-rs` crate, but databend uses `prometheus-client` from the prometheus official.

This PR addes a feature option `use-prometheus-client` to allow switching to `prometheus-client` with the PrometheusLayer. When `use-prometheus-client` is enabled, we can pass a `prometheus_client::registry::Registry` to a `PrometheusLayer`.

To support both of the prometheus client, this PR also make a small refactor to collect the metrics writing logics into a trait `PrometheusLayerMetrics`.

I believe the official prometheus may have longer term of support, maybe we can have a schedule to migrate to it while deprecate the older prometheus library's support?
