### PR TITLE
ci: Migrate GCS to Databend Labs sponsored bucket

### DIFF
--- a/.github/workflows/service_test_gcs.yml
+++ b/.github/workflows/service_test_gcs.yml
@@ -37,33 +37,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  jobs:
-    gcs:
-      runs-on: ubuntu-latest
-      if: (github.event_name == 'push' && github.repository == 'apache/incubator-opendal') || !github.event.pull_request.head.repo.fork
-      steps:
-        - uses: actions/checkout@v3
-        - name: Setup Rust toolchain
-          uses: ./.github/actions/setup
-          with:
-            need-nextest: true
+  gcs:
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'push' && github.repository == 'apache/incubator-opendal') || !github.event.pull_request.head.repo.fork
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup
+        with:
+          need-nextest: true
 
-        - name: Load secret
-          id: op-load-secret
-          uses: 1password/load-secrets-action@v1
-          with:
-            export-env: true
-          env:
-            OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-            OPENDAL_GCS_TEST: op://services/gcs/test
-            OPENDAL_GCS_ROOT: op://services/gcs/root
-            OPENDAL_GCS_BUCKET: op://services/gcs/bucket
-            OPENDAL_GCS_CREDENTIAL: op://services/gcs/credential
+      - name: Load secret
+        id: op-load-secret
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OPENDAL_GCS_TEST: op://services/gcs/test
+          OPENDAL_GCS_ROOT: op://services/gcs/root
+          OPENDAL_GCS_BUCKET: op://services/gcs/bucket
+          OPENDAL_GCS_CREDENTIAL: op://services/gcs/credential
 
-        - name: Test
-          shell: bash
-          working-directory: core
-          run: cargo nextest run gcs
+      - name: Test
+        shell: bash
+        working-directory: core
+        run: cargo nextest run gcs
 
   gcs-with-default-storage-class:
     runs-on: ubuntu-latest

--- a/.github/workflows/service_test_gcs.yml
+++ b/.github/workflows/service_test_gcs.yml
@@ -37,41 +37,58 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  gcs:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup
-        with:
-          need-nextest: true
-      - name: Test
-        shell: bash
-        working-directory: core
-        run: cargo nextest run gcs
-        env:
-          OPENDAL_GCS_TEST: ${{ secrets.OPENDAL_GCS_TEST }}
-          OPENDAL_GCS_ROOT: ${{ secrets.OPENDAL_GCS_ROOT }}
-          OPENDAL_GCS_BUCKET: ${{ secrets.OPENDAL_GCS_BUCKET }}
-          OPENDAL_GCS_CREDENTIAL: ${{ secrets.OPENDAL_GCS_CREDENTIAL }}
+  jobs:
+    gcs:
+      runs-on: ubuntu-latest
+      if: (github.event_name == 'push' && github.repository == 'apache/incubator-opendal') || !github.event.pull_request.head.repo.fork
+      steps:
+        - uses: actions/checkout@v3
+        - name: Setup Rust toolchain
+          uses: ./.github/actions/setup
+          with:
+            need-nextest: true
+
+        - name: Load secret
+          id: op-load-secret
+          uses: 1password/load-secrets-action@v1
+          with:
+            export-env: true
+          env:
+            OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+            OPENDAL_GCS_TEST: op://services/gcs/test
+            OPENDAL_GCS_ROOT: op://services/gcs/root
+            OPENDAL_GCS_BUCKET: op://services/gcs/bucket
+            OPENDAL_GCS_CREDENTIAL: op://services/gcs/credential
+
+        - name: Test
+          shell: bash
+          working-directory: core
+          run: cargo nextest run gcs
 
   gcs-with-default-storage-class:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
+    if: (github.event_name == 'push' && github.repository == 'apache/incubator-opendal') || !github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@v3
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
         with:
           need-nextest: true
+
+      - name: Load secret
+        id: op-load-secret
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OPENDAL_GCS_TEST: op://services/gcs/test
+          OPENDAL_GCS_ROOT: op://services/gcs/root
+          OPENDAL_GCS_BUCKET: op://services/gcs/bucket
+          OPENDAL_GCS_CREDENTIAL: op://services/gcs/credential
+          OPENDAL_GCS_DEFAULT_STORAGE_CLASS: STANDARD
+
       - name: Test
         shell: bash
         working-directory: core
         run: cargo nextest run gcs
-        env:
-          OPENDAL_GCS_TEST: ${{ secrets.OPENDAL_GCS_TEST }}
-          OPENDAL_GCS_ROOT: ${{ secrets.OPENDAL_GCS_ROOT }}
-          OPENDAL_GCS_BUCKET: ${{ secrets.OPENDAL_GCS_BUCKET }}
-          OPENDAL_GCS_CREDENTIAL: ${{ secrets.OPENDAL_GCS_CREDENTIAL }}
-          OPENDAL_GCS_DEFAULT_STORAGE_CLASS: STANDARD

--- a/.github/workflows/service_test_s3.yml
+++ b/.github/workflows/service_test_s3.yml
@@ -135,7 +135,7 @@ jobs:
           AWS_WEB_IDENTITY_TOKEN_FILE: tests/data/web_identity_token
           AWS_ROLE_ARN: arn:aws:iam::952853449216:role/opendal-testing-assume
           OPENDAL_S3_TEST: on
-          OPENDAL_S3_ROOT: assume
+          OPENDAL_S3_ROOT: CI/
           OPENDAL_S3_BUCKET: opendal-testing
           OPENDAL_S3_ROLE_ARN: arn:aws:iam::952853449216:role/opendal-testing
           OPENDAL_S3_REGION: ap-northeast-1


### PR DESCRIPTION
Thanks to @databendlabs sponsor and @everpcpc's hard work, OpenDAL can now use bucket maintained by databend labs now.