### PR TITLE
feat(bindings/cpp): make ReaderStream manage the lifetime of Reader

### DIFF
--- a/bindings/cpp/include/opendal.hpp
+++ b/bindings/cpp/include/opendal.hpp
@@ -197,8 +197,7 @@ private:
  * @details It provides basic read and seek operations. If you want to use it
  * like a stream, you can use `ReaderStream` instead.
  * @code{.cpp}
- * auto reader = operator.reader("path");
- * opendal::ReaderStream stream(reader);
+ * opendal::ReaderStream stream(operator.reader("path"));
  * @endcode
  */
 class Reader
@@ -221,15 +220,19 @@ private:
 /**
  * @class ReaderStream
  * @brief ReaderStream is a stream wrapper of Reader which can provide
- * `iostream` interface.
- * @note It's an undefined behavior to make multiple streams from one reader.
+ * `iostream` interface. It will keep a Reader inside so that you can ignore the
+ * lifetime of original Reader.
  */
 class ReaderStream
     : public boost::iostreams::stream<boost::reference_wrapper<Reader>> {
 public:
-  ReaderStream(Reader &reader)
+  ReaderStream(Reader &&reader)
       : boost::iostreams::stream<boost::reference_wrapper<Reader>>(
-            boost::ref(reader)) {}
+            boost::ref(reader_)),
+        reader_(std::move(reader)) {}
+
+private:
+  Reader reader_;
 };
 
 /**

--- a/bindings/cpp/tests/basic_test.cpp
+++ b/bindings/cpp/tests/basic_test.cpp
@@ -117,7 +117,7 @@ TEST_F(OpendalTest, ReaderTest) {
   reader.seek(0, std::ios::beg);
 
   // stream
-  opendal::ReaderStream stream(reader);
+  opendal::ReaderStream stream(std::move(reader));
 
   auto read_fn = [&](std::size_t to_read, std::streampos expected_tellg) {
     std::vector<char> v(to_read);


### PR DESCRIPTION
Original API seperates the lifetime of `Reader` and `ReaderStream`. Users cannot easily manage them. For example, following code will be wrong previously because of `stack-use-after-scope`.

```cpp
opendal::ReaderStream return_stream(opendal::Operator &op, std::string_view path) {
  return op.reader(path);
}
```

With this update, `ReaderStream` will take the ownership of `Reader`. Users can ignore `Reader` when using `ReaderStream`.