### PR TITLE
build(bindings/java): support explicit cargo build target

### DIFF
--- a/.github/workflows/bindings_java.yml
+++ b/.github/workflows/bindings_java.yml
@@ -70,14 +70,9 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: '8'
           cache: 'maven'
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          version: "23.4"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and test
         working-directory: bindings/java
         # `mvn install` and `mvn artifact:compare` are required to verify reproducible builds:
@@ -86,3 +81,24 @@ jobs:
         run: |
           ./mvnw clean install -DskipTests
           ./mvnw verify artifact:compare
+
+  centos-containered-test:
+    runs-on: ubuntu-latest
+    container: centos/python-38-centos7
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up rustup
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup-init.sh
+          sh rustup-init.sh -y --default-toolchain none
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+          cache: 'maven'
+      - name: Build and test
+        working-directory: bindings/java
+        run: |
+          source "$HOME/.cargo/env"
+          ./mvnw clean verify -Dcargo-build.target=x86_64-unknown-linux-musl

--- a/.github/workflows/bindings_java.yml
+++ b/.github/workflows/bindings_java.yml
@@ -81,24 +81,3 @@ jobs:
         run: |
           ./mvnw clean install -DskipTests
           ./mvnw verify artifact:compare
-
-  centos-containered-test:
-    runs-on: ubuntu-latest
-    container: centos/python-38-centos7
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up rustup
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup-init.sh
-          sh rustup-init.sh -y --default-toolchain none
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '8'
-          cache: 'maven'
-      - name: Build and test
-        working-directory: bindings/java
-        run: |
-          source "$HOME/.cargo/env"
-          ./mvnw clean verify -Dcargo-build.target=x86_64-unknown-linux-musl

--- a/bindings/java/.cargo/config
+++ b/bindings/java/.cargo/config
@@ -1,0 +1,9 @@
+[target.x86_64-unknown-linux-musl]
+rustflags = [
+    "-C", "target-feature=-crt-static",
+]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = [
+    "-C", "target-feature=-crt-static",
+]

--- a/bindings/java/.cargo/config
+++ b/bindings/java/.cargo/config
@@ -1,3 +1,5 @@
+# See also https://github.com/rust-lang/rust/issues/44991
+
 [target.x86_64-unknown-linux-musl]
 rustflags = [
     "-C", "target-feature=-crt-static",

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -55,6 +55,7 @@
         <!-- customized properties -->
         <cargo-build.profile>dev</cargo-build.profile>
         <cargo-build.features>default</cargo-build.features>
+        <cargo-build.target/> <!-- override cargo build target; e.g., use musl instead -->
         <jni.classifier>${os.detected.classifier}</jni.classifier>
 
         <!-- library dependencies -->
@@ -177,6 +178,8 @@
                                 <argument>${project.basedir}/tools/build.py</argument>
                                 <argument>--classifier</argument>
                                 <argument>${jni.classifier}</argument>
+                                <argument>--target</argument>
+                                <argument>${cargo-build.target}</argument>
                                 <argument>--profile</argument>
                                 <argument>${cargo-build.profile}</argument>
                                 <argument>--features</argument>

--- a/bindings/java/tools/build.py
+++ b/bindings/java/tools/build.py
@@ -52,6 +52,7 @@ if __name__ == '__main__':
 
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument('--classifier', type=str, required=True)
+    parser.add_argument('--target', type=str, default='')
     parser.add_argument('--profile', type=str, default='dev')
     parser.add_argument('--features', type=str, default='default')
     args = parser.parse_args()
@@ -61,12 +62,15 @@ if __name__ == '__main__':
     if args.features:
         cmd += ['--features', args.features]
 
-    target = classifier_to_target(args.classifier)
-    if target:
-        command = ['rustup', 'target', 'add', target]
-        print('$ ' + subprocess.list2cmdline(command))
-        subprocess.run(command, cwd=basedir, check=True)
-        cmd += ['--target', target]
+    if args.target:
+        target = args.target
+    else:
+        target = classifier_to_target(args.classifier)
+
+    command = ['rustup', 'target', 'add', target]
+    print('$ ' + subprocess.list2cmdline(command))
+    subprocess.run(command, cwd=basedir, check=True)
+    cmd += ['--target', target]
 
     output = basedir / 'target' / 'bindings'
     Path(output).mkdir(exist_ok=True, parents=True)

--- a/bindings/java/tools/build.py
+++ b/bindings/java/tools/build.py
@@ -17,7 +17,7 @@
 # under the License.
 
 
-from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, BooleanOptionalAction
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from pathlib import Path
 import shutil
 import subprocess


### PR DESCRIPTION
This closes https://github.com/apache/incubator-opendal/issues/3160.

With this patch, it's expected to fix the original issue with:

```
./mvnw verify -Dcargo-build.target=x86_64-unknown-linux-musl
```

@G-XD please give it a try.