### PR TITLE
feat(services/ghac): Allow explicitly setting ghac endpoint/token, not just env vars

### DIFF
--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -286,7 +286,11 @@ impl Builder for GhacBuilder {
             enable_create_simulation: self.enable_create_simulation,
 
             cache_url: value_or_env(self.endpoint.take(), ACTIONS_CACHE_URL, "Builder::build")?,
-            catch_token: value_or_env(self.runtime_token.take(), ACTIONS_RUNTIME_TOKEN, "Builder::build")?,
+            catch_token: value_or_env(
+                self.runtime_token.take(),
+                ACTIONS_RUNTIME_TOKEN,
+                "Builder::build",
+            )?,
             version: self
                 .version
                 .clone()


### PR DESCRIPTION
This adjusts the GitHub Actions Cache service to allow explicitly setting the URL (via `.endpoint(...)`) and the runtime token (via `.runtime_token(...)`), in addition to the defaults of reading the `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` environment variables.

This gives more control over the use of this service, such as in the Pants build system (I'm adding support in https://github.com/pantsbuild/pants/pull/19831): for Pants, the caching system runs in a background daemon that is passed some configuration by a client, and it's nice to not have to propagate environment variables into the daemon, instead, it's nicer for the client to read the environment and pass the values as 'normal' configuration.