### PR TITLE
docs: Add pants as a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ OpenDAL is an active open-source project. We are always open to people who want 
 - [RisingWave](https://github.com/risingwavelabs/risingwave): A Distributed SQL Database for Stream Processing
 - [Vector](https://github.com/vectordotdev/vector): A high-performance observability data pipeline.
 - [OctoBase](https://github.com/toeverything/OctoBase): the open-source database behind [AFFiNE](https://github.com/toeverything/affine), local-first, yet collaborative.
+- [Pants](https://github.com/pantsbuild/pants): A fast, scalable, user-friendly build system for codebases of all sizes.
 
 ## License
 


### PR DESCRIPTION
This fixes #3179 by noting that https://www.pantsbuild.org uses OpenDAL, as of https://github.com/pantsbuild/pants/pull/19827, with usage going to expand to GHAC (https://github.com/pantsbuild/pants/pull/19831) soon, and potentially blob stores like S3 after that.