### PR TITLE
ci: Pin Kvrocks docker image to 2.5.1 to avoid test failure

### DIFF
--- a/.github/workflows/service_test_redis.yml
+++ b/.github/workflows/service_test_redis.yml
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       redis:
-        image: apache/kvrocks
+        image: apache/kvrocks:2.5.1
         ports:
           - 6379:6666
     steps:


### PR DESCRIPTION
This closes #3191 