### PR TITLE
docs: Add verify script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,3 +53,9 @@ Please decide how far you trust this user to correctly verify other users' keys
 Your decision? 5 #choose 5
 Do you really want to set this key to ultimate trust? (y/N) y  #choose y
 ```
+
+## Verify
+
+```shell
+./scripts/verify.py
+```

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -26,7 +26,7 @@ BASE_DIR = os.getcwd()
 
 def check_rust():
     try:
-        subprocess.run(['cargo', '--version'], check=True)
+        subprocess.run(["cargo", "--version"], check=True)
         return True
     except FileNotFoundError:
         return False
@@ -36,7 +36,7 @@ def check_rust():
 
 def check_java():
     try:
-        subprocess.run(['java', '--version'], check=True)
+        subprocess.run(["java", "--version"], check=True)
         return True
     except FileNotFoundError:
         return False
@@ -47,16 +47,25 @@ def check_java():
 def build_core():
     print("Start building opendal core")
 
-    subprocess.run(['cargo', 'build'], check=True)
+    subprocess.run(["cargo", "build", "--release"], check=True)
 
 
 def build_java_binding():
     print("Start building opendal java binding")
 
     # change to java binding directory
-    os.chdir('bindings/java')
+    os.chdir("bindings/java")
 
-    subprocess.run(['./mvnw', 'clean', 'install', '-DskipTests=true'], check=True)
+    subprocess.run(
+        [
+            "./mvnw",
+            "clean",
+            "install",
+            "-DskipTests=true",
+            "-Dcargo-build.profile=release",
+        ],
+        check=True,
+    )
 
     # change back to base directory
     os.chdir(BASE_DIR)
@@ -64,7 +73,9 @@ def build_java_binding():
 
 def main():
     if not check_rust():
-        print("Cargo is not found, please check if rust development has been setup correctly")
+        print(
+            "Cargo is not found, please check if rust development has been setup correctly"
+        )
         print("Visit https://www.rust-lang.org/tools/install for more information")
         sys.exit(1)
 

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+import os
+
+BASE_DIR = os.getcwd()
+
+
+def check_rust():
+    try:
+        subprocess.run(['cargo', '--version'], check=True)
+        return True
+    except FileNotFoundError:
+        return False
+    except Exception as e:
+        raise Exception("Check rust met unexpected error", e)
+
+
+def check_java():
+    try:
+        subprocess.run(['java', '--version'], check=True)
+        return True
+    except FileNotFoundError:
+        return False
+    except Exception as e:
+        raise Exception("Check java met unexpected error", e)
+
+
+def build_core():
+    print("Start building opendal core")
+
+    subprocess.run(['cargo', 'build'], check=True)
+
+
+def build_java_binding():
+    print("Start building opendal java binding")
+
+    # change to java binding directory
+    os.chdir('bindings/java')
+
+    subprocess.run(['./mvnw', 'clean', 'install', '-DskipTests=true'], check=True)
+
+    # change back to base directory
+    os.chdir(BASE_DIR)
+
+
+def main():
+    if not check_rust():
+        print("Cargo is not found, please check if rust development has been setup correctly")
+        print("Visit https://www.rust-lang.org/tools/install for more information")
+        sys.exit(1)
+
+    build_core()
+
+    if check_java():
+        build_java_binding()
+    else:
+        print("Java is not found, skipped building java binding")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 import subprocess
 import sys

--- a/website/community/committers/release.md
+++ b/website/community/committers/release.md
@@ -304,6 +304,10 @@ https://github.com/apache/incubator-opendal/tree/main/scripts
 To compile from source, please refer to:
 https://github.com/apache/incubator-opendal/blob/main/CONTRIBUTING.md
 
+Here is python script in release to help you verify the release candidate:
+
+./scripts/verify.py
+
 Thanks
 
 ${name}
@@ -414,6 +418,10 @@ https://github.com/apache/incubator-opendal/tree/main/scripts
 
 To compile from source, please refer to:
 https://github.com/apache/incubator-opendal/blob/main/CONTRIBUTING.md
+
+Here is python script in release to help you verify the release candidate:
+
+./scripts/verify.py
 
 Thanks
 


### PR DESCRIPTION
Fix https://github.com/apache/incubator-opendal/issues/3147

For now, verify.py only includes rust core and java binding. We plan to expand its coverage to include more components in the future.