### PR TITLE
feat(prometheus): add bytes metrics as counter

### DIFF
--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -179,7 +179,7 @@ impl PrometheusClientMetrics {
         self.bytes_histogram
             .get_or_create(&labels)
             .observe(bytes as f64);
-        self.bytes_total.get_or_create(&labels).inc_by(bytes as f64);
+        self.bytes_total.get_or_create(&labels).inc_by(bytes as u64);
     }
 
     fn observe_request_duration(&self, scheme: Scheme, op: Operation, duration: Duration) {

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -124,12 +124,15 @@ struct PrometheusClientMetrics {
     request_duration_seconds: Family<OperationLabels, Histogram>,
     /// The histogram of bytes
     bytes_histogram: Family<OperationLabels, Histogram>,
+    /// The counter of bytes
+    bytes_total: Family<OperationLabels, Counter>,
 }
 
 impl PrometheusClientMetrics {
     pub fn register(registry: &mut Registry) -> Self {
         let requests_total = Family::default();
         let errors_total = Family::default();
+        let bytes_total = Family::default();
         let request_duration_seconds = Family::<OperationLabels, _>::new_with_constructor(|| {
             let buckets = histogram::exponential_buckets(0.01, 2.0, 16);
             Histogram::new(buckets)
@@ -139,19 +142,21 @@ impl PrometheusClientMetrics {
             Histogram::new(buckets)
         });
 
-        registry.register("opendal_requests_total", "", requests_total.clone());
-        registry.register("opendal_errors_total", "", errors_total.clone());
+        registry.register("opendal_requests", "", requests_total.clone());
+        registry.register("opendal_errors", "", errors_total.clone());
         registry.register(
             "opendal_request_duration_seconds",
             "",
             request_duration_seconds.clone(),
         );
         registry.register("opendal_bytes_histogram", "", bytes_histogram.clone());
+        registry.register("opendal_bytes", "", bytes_total.clone());
         Self {
             requests_total,
             errors_total,
             request_duration_seconds,
             bytes_histogram,
+            bytes_total,
         }
     }
 
@@ -174,6 +179,7 @@ impl PrometheusClientMetrics {
         self.bytes_histogram
             .get_or_create(&labels)
             .observe(bytes as f64);
+        self.bytes_total.get_or_create(&labels).inc_by(bytes as f64);
     }
 
     fn observe_request_duration(&self, scheme: Scheme, op: Operation, duration: Duration) {


### PR DESCRIPTION
in the previous PR I converted the metrics in PrometheusLayer as it into PrometheusClientLayer, but I missed an important metric not included in the PrometheusLayer before is the bytes total metrics.

we already have a histogram about the bytes which is useful for us to find out the distribution of the size on different IO requests. however, a bytes metric in counter is more useful for us to get the IO bandwidth infomation, which is important for us to diagnose the issues on IO.

this PR also fixed a naming issue about counters in PrometheusClientLayer, the prometheus-client tend to append a `_total` suffix in a dump way for every counters, if we name a counter as `opendal_errors_total` what we finally get is `opendal_errors_total_total`, which is bad :(