### PR TITLE
chore(bindings/java): align mapping POJO pattern

### DIFF
--- a/bindings/java/src/main/java/org/apache/opendal/Capability.java
+++ b/bindings/java/src/main/java/org/apache/opendal/Capability.java
@@ -19,11 +19,9 @@
 
 package org.apache.opendal;
 
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.Data;
 
-@ToString
-@EqualsAndHashCode
+@Data
 public class Capability {
     /**
      *  If operator supports stat.

--- a/bindings/java/src/main/java/org/apache/opendal/OperatorInfo.java
+++ b/bindings/java/src/main/java/org/apache/opendal/OperatorInfo.java
@@ -19,10 +19,10 @@
 
 package org.apache.opendal;
 
+import lombok.Data;
 import lombok.NonNull;
-import lombok.ToString;
 
-@ToString
+@Data
 public class OperatorInfo {
     public final String scheme;
     public final String root;


### PR DESCRIPTION
Per https://github.com/apache/incubator-opendal/pull/3277#discussion_r1359079181

Align the POJO style -

1. Generate getters for `public final` field to satisfy where only methods are accepted.
2. Always overwrite the RequiredArgsConstructor for ensure the parameter order.

cc @Xuanwo @G-XD 