### PR TITLE
feat(layer/prometheus): Support output path as a metric label

### DIFF
--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -39,6 +39,7 @@ use prometheus::Registry;
 use crate::raw::Accessor;
 use crate::raw::*;
 use crate::*;
+
 /// Add [prometheus](https://docs.rs/prometheus) for every operations.
 ///
 /// # Prometheus Metrics
@@ -107,6 +108,7 @@ pub struct PrometheusLayer {
     registry: Registry,
     requests_duration_seconds_buckets: Vec<f64>,
     bytes_total_buckets: Vec<f64>,
+    path_label_level: usize,
 }
 
 impl PrometheusLayer {
@@ -116,6 +118,7 @@ impl PrometheusLayer {
             registry,
             requests_duration_seconds_buckets: exponential_buckets(0.01, 2.0, 16).unwrap(),
             bytes_total_buckets: exponential_buckets(0.01, 2.0, 16).unwrap(),
+            path_label_level: 0,
         }
     }
 
@@ -134,6 +137,14 @@ impl PrometheusLayer {
         }
         self
     }
+
+    /// set path label level
+    /// 0: no path label, the path label will be the ""
+    /// >0: the path label will be the path split by "/" and get the last n level, like "/abc/def/ghi", if n=1, the path label will be "/abc"
+    pub fn enable_path_label(mut self, level: usize) -> Self {
+        self.path_label_level = level;
+        self
+    }
 }
 
 impl<A: Accessor> Layer<A> for PrometheusLayer {
@@ -149,11 +160,13 @@ impl<A: Accessor> Layer<A> for PrometheusLayer {
                 self.registry.clone(),
                 self.requests_duration_seconds_buckets.clone(),
                 self.bytes_total_buckets.clone(),
+                self.path_label_level,
             )),
-            scheme: scheme.to_string(),
+            scheme,
         }
     }
 }
+
 /// [`PrometheusMetrics`] provide the performance and IO metrics.
 #[derive(Debug)]
 pub struct PrometheusMetrics {
@@ -163,6 +176,8 @@ pub struct PrometheusMetrics {
     pub requests_duration_seconds: HistogramVec,
     /// Size of the specific metrics.
     pub bytes_total: HistogramVec,
+    /// The Path Level we will keep in the path label.
+    pub path_label_level: usize,
 }
 
 impl PrometheusMetrics {
@@ -171,11 +186,17 @@ impl PrometheusMetrics {
         registry: Registry,
         requests_duration_seconds_buckets: Vec<f64>,
         bytes_total_buckets: Vec<f64>,
+        path_label_level: usize,
     ) -> Self {
+        let labels = if path_label_level > 0 {
+            vec!["scheme", "operation", "path"]
+        } else {
+            vec!["scheme", "operation"]
+        };
         let requests_total = register_int_counter_vec_with_registry!(
             "requests_total",
             "Total times of create be called",
-            &["scheme", "operation"],
+            &labels,
             registry
         )
         .unwrap();
@@ -186,18 +207,16 @@ impl PrometheusMetrics {
         );
 
         let requests_duration_seconds =
-            register_histogram_vec_with_registry!(opts, &["scheme", "operation"], registry)
-                .unwrap();
+            register_histogram_vec_with_registry!(opts, &labels, registry).unwrap();
 
         let opts = histogram_opts!("bytes_total", "Total size of ", bytes_total_buckets);
-        let bytes_total =
-            register_histogram_vec_with_registry!(opts, &["scheme", "operation"], registry)
-                .unwrap();
+        let bytes_total = register_histogram_vec_with_registry!(opts, &labels, registry).unwrap();
 
         Self {
             requests_total,
             requests_duration_seconds,
             bytes_total,
+            path_label_level,
         }
     }
 
@@ -211,13 +230,34 @@ impl PrometheusMetrics {
             kind.into_static()
         );
     }
+
+    /// generate metric label
+    pub fn generate_metric_label<'a>(
+        &self,
+        scheme: &'a str,
+        operation: &'a str,
+        path_label: &'a str,
+    ) -> Vec<&'a str> {
+        match self.path_label_level {
+            0 => {
+                vec![scheme, operation]
+            }
+            n if n > 0 => {
+                let path_value = get_path_label(path_label, self.path_label_level);
+                vec![scheme, operation, path_value]
+            }
+            _ => {
+                vec![scheme, operation]
+            }
+        }
+    }
 }
 
 #[derive(Clone)]
 pub struct PrometheusAccessor<A: Accessor> {
     inner: A,
     stats: Arc<PrometheusMetrics>,
-    scheme: String,
+    scheme: Scheme,
 }
 
 impl<A: Accessor> Debug for PrometheusAccessor<A> {
@@ -243,15 +283,18 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::CreateDir.into_static(),
+            path,
+        );
+
+        self.stats.requests_total.with_label_values(&labels).inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::CreateDir.into_static()])
+            .with_label_values(&labels)
             .start_timer();
         let create_res = self.inner.create_dir(path, args).await;
 
@@ -264,15 +307,17 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::Read.into_static()])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::Read.into_static(),
+            path,
+        );
+        self.stats.requests_total.with_label_values(&labels).inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Read.into_static()])
+            .with_label_values(&labels)
             .start_timer();
 
         let read_res = self
@@ -282,7 +327,7 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
                 v.map(|(rp, r)| {
                     self.stats
                         .bytes_total
-                        .with_label_values(&[&self.scheme, Operation::Read.into_static()])
+                        .with_label_values(&labels)
                         .observe(rp.metadata().content_length() as f64);
                     (
                         rp,
@@ -290,7 +335,8 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
                             r,
                             Operation::Read,
                             self.stats.clone(),
-                            &self.scheme,
+                            self.scheme,
+                            &path.to_string(),
                         ),
                     )
                 })
@@ -304,15 +350,17 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::Write.into_static()])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::Write.into_static(),
+            path,
+        );
+        self.stats.requests_total.with_label_values(&labels).inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Write.into_static()])
+            .with_label_values(&labels)
             .start_timer();
 
         let write_res = self
@@ -326,7 +374,8 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
                             r,
                             Operation::Write,
                             self.stats.clone(),
-                            &self.scheme,
+                            self.scheme,
+                            &path.to_string(),
                         ),
                     )
                 })
@@ -341,14 +390,16 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::Stat.into_static()])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::Stat.into_static(),
+            path,
+        );
+        self.stats.requests_total.with_label_values(&labels).inc();
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Stat.into_static()])
+            .with_label_values(&labels)
             .start_timer();
 
         let stat_res = self
@@ -366,15 +417,17 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::Stat.into_static()])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::Delete.into_static(),
+            path,
+        );
+        self.stats.requests_total.with_label_values(&labels).inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Stat.into_static()])
+            .with_label_values(&labels)
             .start_timer();
 
         let delete_res = self.inner.delete(path, args).await;
@@ -387,15 +440,17 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::List.into_static()])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::List.into_static(),
+            path,
+        );
+        self.stats.requests_total.with_label_values(&labels).inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::List.into_static()])
+            .with_label_values(&labels)
             .start_timer();
 
         let list_res = self.inner.list(path, args).await;
@@ -408,15 +463,17 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::Batch.into_static()])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::Batch.into_static(),
+            "",
+        );
+        self.stats.requests_total.with_label_values(&labels).inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Batch.into_static()])
+            .with_label_values(&labels)
             .start_timer();
         let result = self.inner.batch(args).await;
 
@@ -429,15 +486,17 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::Presign.into_static()])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::Presign.into_static(),
+            path,
+        );
+        self.stats.requests_total.with_label_values(&labels).inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::Presign.into_static()])
+            .with_label_values(&labels)
             .start_timer();
         let result = self.inner.presign(path, args).await;
         timer.observe_duration();
@@ -450,15 +509,17 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingCreateDir.into_static()])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::BlockingCreateDir.into_static(),
+            path,
+        );
+        self.stats.requests_total.with_label_values(&labels).inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::BlockingCreateDir.into_static()])
+            .with_label_values(&labels)
             .start_timer();
         let result = self.inner.blocking_create_dir(path, args);
 
@@ -472,20 +533,22 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingRead.into_static()])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::BlockingRead.into_static(),
+            path,
+        );
+        self.stats.requests_total.with_label_values(&labels).inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme])
+            .with_label_values(&labels)
             .start_timer();
         let result = self.inner.blocking_read(path, args).map(|(rp, r)| {
             self.stats
                 .bytes_total
-                .with_label_values(&[&self.scheme, Operation::BlockingRead.into_static()])
+                .with_label_values(&labels)
                 .observe(rp.metadata().content_length() as f64);
             (
                 rp,
@@ -493,7 +556,8 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
                     r,
                     Operation::BlockingRead,
                     self.stats.clone(),
-                    &self.scheme,
+                    self.scheme,
+                    &path.to_string(),
                 ),
             )
         });
@@ -506,15 +570,17 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingWrite.into_static()])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::BlockingWrite.into_static(),
+            path,
+        );
+        self.stats.requests_total.with_label_values(&labels).inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::BlockingWrite.into_static()])
+            .with_label_values(&labels)
             .start_timer();
         let result = self.inner.blocking_write(path, args).map(|(rp, r)| {
             (
@@ -523,7 +589,8 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
                     r,
                     Operation::BlockingWrite,
                     self.stats.clone(),
-                    &self.scheme,
+                    self.scheme,
+                    &path.to_string(),
                 ),
             )
         });
@@ -536,15 +603,17 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     fn blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingStat.into_static()])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::BlockingStat.into_static(),
+            path,
+        );
+        self.stats.requests_total.with_label_values(&labels).inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::BlockingStat.into_static()])
+            .with_label_values(&labels)
             .start_timer();
         let result = self.inner.blocking_stat(path, args);
         timer.observe_duration();
@@ -556,15 +625,17 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     fn blocking_delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingDelete.into_static()])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::BlockingDelete.into_static(),
+            path,
+        );
+        self.stats.requests_total.with_label_values(&labels).inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::BlockingDelete.into_static()])
+            .with_label_values(&labels)
             .start_timer();
         let result = self.inner.blocking_delete(path, args);
         timer.observe_duration();
@@ -577,15 +648,17 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     }
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
-        self.stats
-            .requests_total
-            .with_label_values(&[&self.scheme, Operation::BlockingList.into_static()])
-            .inc();
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::BlockingList.into_static(),
+            path,
+        );
+        self.stats.requests_total.with_label_values(&labels).inc();
 
         let timer = self
             .stats
             .requests_duration_seconds
-            .with_label_values(&[&self.scheme, Operation::BlockingList.into_static()])
+            .with_label_values(&labels)
             .start_timer();
         let result = self.inner.blocking_list(path, args);
         timer.observe_duration();
@@ -603,27 +676,40 @@ pub struct PrometheusMetricWrapper<R> {
 
     op: Operation,
     stats: Arc<PrometheusMetrics>,
-    scheme: String,
+    scheme: Scheme,
+    path: String,
 }
 
 impl<R> PrometheusMetricWrapper<R> {
-    fn new(inner: R, op: Operation, stats: Arc<PrometheusMetrics>, scheme: &String) -> Self {
+    fn new(
+        inner: R,
+        op: Operation,
+        stats: Arc<PrometheusMetrics>,
+        scheme: Scheme,
+        path: &String,
+    ) -> Self {
         Self {
             inner,
             op,
             stats,
-            scheme: scheme.to_string(),
+            scheme,
+            path: path.to_string(),
         }
     }
 }
 
 impl<R: oio::Read> oio::Read for PrometheusMetricWrapper<R> {
     fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::Read.into_static(),
+            &self.path,
+        );
         self.inner.poll_read(cx, buf).map(|res| match res {
             Ok(bytes) => {
                 self.stats
                     .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::Read.into_static()])
+                    .with_label_values(&labels)
                     .observe(bytes as f64);
                 Ok(bytes)
             }
@@ -645,11 +731,16 @@ impl<R: oio::Read> oio::Read for PrometheusMetricWrapper<R> {
     }
 
     fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::Read.into_static(),
+            &self.path,
+        );
         self.inner.poll_next(cx).map(|res| match res {
             Some(Ok(bytes)) => {
                 self.stats
                     .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::Read.into_static()])
+                    .with_label_values(&labels)
                     .observe(bytes.len() as f64);
                 Some(Ok(bytes))
             }
@@ -664,12 +755,17 @@ impl<R: oio::Read> oio::Read for PrometheusMetricWrapper<R> {
 
 impl<R: oio::BlockingRead> oio::BlockingRead for PrometheusMetricWrapper<R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::BlockingRead.into_static(),
+            &self.path,
+        );
         self.inner
             .read(buf)
             .map(|n| {
                 self.stats
                     .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::BlockingRead.into_static()])
+                    .with_label_values(&labels)
                     .observe(n as f64);
                 n
             })
@@ -687,11 +783,16 @@ impl<R: oio::BlockingRead> oio::BlockingRead for PrometheusMetricWrapper<R> {
     }
 
     fn next(&mut self) -> Option<Result<Bytes>> {
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::BlockingRead.into_static(),
+            &self.path,
+        );
         self.inner.next().map(|res| match res {
             Ok(bytes) => {
                 self.stats
                     .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::BlockingRead.into_static()])
+                    .with_label_values(&labels)
                     .observe(bytes.len() as f64);
                 Ok(bytes)
             }
@@ -706,12 +807,17 @@ impl<R: oio::BlockingRead> oio::BlockingRead for PrometheusMetricWrapper<R> {
 #[async_trait]
 impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
     fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::Write.into_static(),
+            &self.path,
+        );
         self.inner
             .poll_write(cx, bs)
             .map_ok(|n| {
                 self.stats
                     .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::Write.into_static()])
+                    .with_label_values(&labels)
                     .observe(n as f64);
                 n
             })
@@ -738,12 +844,17 @@ impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for PrometheusMetricWrapper<R> {
     fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+        let labels = self.stats.generate_metric_label(
+            self.scheme.into_static(),
+            Operation::BlockingWrite.into_static(),
+            &self.path,
+        );
         self.inner
             .write(bs)
             .map(|n| {
                 self.stats
                     .bytes_total
-                    .with_label_values(&[&self.scheme, Operation::BlockingWrite.into_static()])
+                    .with_label_values(&labels)
                     .observe(n as f64);
                 n
             })
@@ -758,5 +869,33 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for PrometheusMetricWrapper<R> {
             self.stats.increment_errors_total(self.op, err.kind());
             err
         })
+    }
+}
+
+fn get_path_label(path: &str, path_level: usize) -> &str {
+    if path_level > 0 {
+        return path
+            .char_indices()
+            .filter(|&(_, c)| c == '/')
+            .nth(path_level - 1)
+            .map_or(path, |(i, _)| &path[..i]);
+    }
+    ""
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_path_label() {
+        let path = "abc/def/ghi";
+        assert_eq!(get_path_label(path, 0), "");
+        assert_eq!(get_path_label(path, 1), "abc");
+        assert_eq!(get_path_label(path, 2), "abc/def");
+        assert_eq!(get_path_label(path, 3), "abc/def/ghi");
+        assert_eq!(get_path_label(path, usize::MAX), "abc/def/ghi");
+
+        assert_eq!(get_path_label("", 0), "");
     }
 }


### PR DESCRIPTION
For now, we already have basic metric output in the Prometheus layer.

1. requests_total
2. requests_duration_seconds
3. bytes_total

All the metrics are grouped by scheme and operation for now.

For now, in some circumstances, we need to group by the metric by an extra path. Here's an example: if we choose to write to different devices in Linux using OpenDAL, and one of the devices has some problem, the write and read action becomes slow and slow. We can't monitor and alert for the specific device if we don't have a path label.

But on the other hand, if we output all the paths as a label in metric, the final metric we get will be extremely massive. So I chose to introduce a new config option for the people to choose how many path levels they want to export