### PR TITLE
feat: add `get_mut()` as poll requires `&mut self`

### DIFF
--- a/core/src/raw/oio/read/api.rs
+++ b/core/src/raw/oio/read/api.rs
@@ -215,7 +215,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<usize>> {
         let this = self.project();
-        Pin::new(this.reader).poll_read(cx, this.buf)
+        Pin::new(this.reader).get_mut().poll_read(cx, this.buf)
     }
 }
 
@@ -234,7 +234,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<u64>> {
         let this = self.project();
-        Pin::new(this.reader).poll_seek(cx, *this.pos)
+        Pin::new(this.reader).get_mut().poll_seek(cx, *this.pos)
     }
 }
 
@@ -252,7 +252,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
         let this = self.project();
-        Pin::new(this.reader).poll_next(cx)
+        Pin::new(this.reader).get_mut().poll_next(cx)
     }
 }
 

--- a/core/src/raw/oio/stream/api.rs
+++ b/core/src/raw/oio/stream/api.rs
@@ -188,7 +188,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
         let this = self.project();
-        Pin::new(this.inner).poll_next(cx)
+        Pin::new(this.inner).get_mut().poll_next(cx)
     }
 }
 
@@ -206,7 +206,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
         let this = self.project();
-        Pin::new(this.inner).poll_reset(cx)
+        Pin::new(this.inner).get_mut().poll_reset(cx)
     }
 }
 

--- a/core/src/raw/oio/write/api.rs
+++ b/core/src/raw/oio/write/api.rs
@@ -170,7 +170,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<usize>> {
         let this = self.project();
-        Pin::new(this.writer).poll_write(cx, *this.buf)
+        Pin::new(this.writer).get_mut().poll_write(cx, *this.buf)
     }
 }
 
@@ -188,7 +188,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
         let this = self.project();
-        Pin::new(this.writer).poll_abort(cx)
+        Pin::new(this.writer).get_mut().poll_abort(cx)
     }
 }
 
@@ -206,7 +206,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
         let this = self.project();
-        Pin::new(this.writer).poll_close(cx)
+        Pin::new(this.writer).get_mut().poll_close(cx)
     }
 }
 


### PR DESCRIPTION
Although Clippy and compiler won't complain about it, TBD
<img width="771" alt="image" src="https://github.com/apache/incubator-opendal/assets/10728152/e79a063d-89e6-471d-883a-ae530f38f88a">
