### PR TITLE
chore: update object_store unit tests and s3 endpoint docs

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -134,6 +134,7 @@ impl S3Builder {
     /// Endpoint must be full uri, e.g.
     ///
     /// - AWS S3: `https://s3.amazonaws.com` or `https://s3.{region}.amazonaws.com`
+    /// - Cloudflare R2: `https://<ACCOUNT_ID>.r2.cloudflarestorage.com`
     /// - Aliyun OSS: `https://{region}.aliyuncs.com`
     /// - Tencent COS: `https://cos.{region}.myqcloud.com`
     /// - Minio: `http://127.0.0.1:9000`

--- a/integrations/object_store/src/lib.rs
+++ b/integrations/object_store/src/lib.rs
@@ -311,7 +311,16 @@ mod tests {
 
         assert_eq!(meta.size, 13);
 
-        assert_eq!(object_store.get(&path).await.unwrap().bytes().await.unwrap(), bytes);
+        assert_eq!(
+            object_store
+                .get(&path)
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap(),
+            bytes
+        );
     }
 
     #[tokio::test]
@@ -331,7 +340,10 @@ mod tests {
             .collect::<Vec<_>>();
 
         let expected_files = vec![
-            ("data/nested/test.txt", Bytes::from_static(b"hello, world! I am nested.")),
+            (
+                "data/nested/test.txt",
+                Bytes::from_static(b"hello, world! I am nested."),
+            ),
             ("data/test.txt", Bytes::from_static(b"hello, world!")),
         ];
 
@@ -342,7 +354,16 @@ mod tests {
 
         for (location, bytes) in expected_files {
             let path: Path = location.try_into().unwrap();
-            assert_eq!(object_store.get(&path).await.unwrap().bytes().await.unwrap(), bytes);
+            assert_eq!(
+                object_store
+                    .get(&path)
+                    .await
+                    .unwrap()
+                    .bytes()
+                    .await
+                    .unwrap(),
+                bytes
+            );
         }
     }
 

--- a/integrations/object_store/src/lib.rs
+++ b/integrations/object_store/src/lib.rs
@@ -305,11 +305,13 @@ mod tests {
         let path: Path = "data/test.txt".try_into().unwrap();
 
         let bytes = Bytes::from_static(b"hello, world!");
-        object_store.put(&path, bytes).await.unwrap();
+        object_store.put(&path, bytes.clone()).await.unwrap();
 
         let meta = object_store.head(&path).await.unwrap();
 
-        assert_eq!(meta.size, 13)
+        assert_eq!(meta.size, 13);
+
+        assert_eq!(object_store.get(&path).await.unwrap().bytes().await.unwrap(), bytes);
     }
 
     #[tokio::test]
@@ -327,8 +329,21 @@ mod tests {
             .iter()
             .map(|x| x.as_ref().unwrap().location.as_ref())
             .collect::<Vec<_>>();
+
+        let expected_files = vec![
+            ("data/nested/test.txt", Bytes::from_static(b"hello, world! I am nested.")),
+            ("data/test.txt", Bytes::from_static(b"hello, world!")),
+        ];
+
+        let expected_locations = expected_files.iter().map(|x| x.0).collect::<Vec<&str>>();
+
         locations.sort();
-        assert_eq!(locations, &["data/nested/test.txt", "data/test.txt"]);
+        assert_eq!(locations, expected_locations);
+
+        for (location, bytes) in expected_files {
+            let path: Path = location.try_into().unwrap();
+            assert_eq!(object_store.get(&path).await.unwrap().bytes().await.unwrap(), bytes);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR contains two small updates, hope can help a little bit:
- add actual bytes comparing at object_store
- add Cloudflare R2 endpoint, [ref](https://developers.cloudflare.com/r2/api/s3/api/#:~:text=https%3A//%3CACCOUNT_ID%3E.r2.cloudflarestorage.com)