### PR TITLE
Bump suppaftp to version 5.2

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -288,7 +288,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = { version = "0.10", optional = true }
 sled = { version = "0.34.7", optional = true }
-suppaftp = { version = "4.5", default-features = false, features = [
+suppaftp = { version = "5.2", default-features = false, features = [
   "async-secure",
   "async-rustls",
 ], optional = true }


### PR DESCRIPTION
The current version of suppaftp 4.7 used by OpenDAL requires async-tls 0.11, which has a security vulnerability.

fix #3347 