### PR TITLE
Fix read result not full

### DIFF
--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -441,10 +441,11 @@ impl opendal_reader {
             panic!("The buffer given is pointing at NULL");
         }
         let buf = unsafe { std::slice::from_raw_parts_mut(buf, len) };
-        let r = (*self.inner).read(buf);
+        let r = (*self.inner).read_exact(buf);
+
         match r {
-            Ok(n) => opendal_result_reader_read {
-                size: n,
+            Ok(_) => opendal_result_reader_read {
+                size: len,
                 error: std::ptr::null_mut(),
             },
             Err(e) => {


### PR DESCRIPTION
After actual testing, it was found that using `self.inner.read` will read data based on the size of internal bytes. By using `self.inner.read_exact`, can read the input buffer size directly.