### PR TITLE
feat: Make PrometheusClientLayer Clonable

### DIFF
--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -110,7 +110,6 @@ impl<A: Accessor> Layer<A> for PrometheusClientLayer {
     }
 }
 
-
 impl<A: Accessor> Layer<A> for &PrometheusClientLayer {
     type LayeredAccessor = PrometheusAccessor<A>;
 

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -110,6 +110,23 @@ impl<A: Accessor> Layer<A> for PrometheusClientLayer {
     }
 }
 
+
+impl<A: Accessor> Layer<A> for &PrometheusClientLayer {
+    type LayeredAccessor = PrometheusAccessor<A>;
+
+    fn layer(&self, inner: A) -> Self::LayeredAccessor {
+        let meta = inner.info();
+        let scheme = meta.scheme();
+
+        let metrics = Arc::new(self.metrics.clone());
+        PrometheusAccessor {
+            inner,
+            metrics,
+            scheme,
+        }
+    }
+}
+
 type OperationLabels = [(&'static str, &'static str); 2];
 type ErrorLabels = [(&'static str, &'static str); 3];
 

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -81,13 +81,15 @@ use crate::*;
 ///     Ok(())
 /// }
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PrometheusClientLayer {
     metrics: PrometheusClientMetrics,
 }
 
 impl PrometheusClientLayer {
-    /// create PrometheusClientLayer while registering itself to this registry.
+    /// Create PrometheusClientLayer while registering itself to this registry. Please keep in caution
+    /// that do NOT call this method multiple times with a same registry. If you want initialize multiple 
+    /// [`PrometheusClientLayer`] with a single registry, you should use [`clone`] instead.
     pub fn new(registry: &mut Registry) -> Self {
         let metrics = PrometheusClientMetrics::register(registry);
         Self { metrics }
@@ -95,22 +97,6 @@ impl PrometheusClientLayer {
 }
 
 impl<A: Accessor> Layer<A> for PrometheusClientLayer {
-    type LayeredAccessor = PrometheusAccessor<A>;
-
-    fn layer(&self, inner: A) -> Self::LayeredAccessor {
-        let meta = inner.info();
-        let scheme = meta.scheme();
-
-        let metrics = Arc::new(self.metrics.clone());
-        PrometheusAccessor {
-            inner,
-            metrics,
-            scheme,
-        }
-    }
-}
-
-impl<A: Accessor> Layer<A> for &PrometheusClientLayer {
     type LayeredAccessor = PrometheusAccessor<A>;
 
     fn layer(&self, inner: A) -> Self::LayeredAccessor {

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -88,7 +88,7 @@ pub struct PrometheusClientLayer {
 
 impl PrometheusClientLayer {
     /// Create PrometheusClientLayer while registering itself to this registry. Please keep in caution
-    /// that do NOT call this method multiple times with a same registry. If you want initialize multiple 
+    /// that do NOT call this method multiple times with a same registry. If you want initialize multiple
     /// [`PrometheusClientLayer`] with a single registry, you should use [`clone`] instead.
     pub fn new(registry: &mut Registry) -> Self {
         let metrics = PrometheusClientMetrics::register(registry);


### PR DESCRIPTION
we met an issue in https://github.com/datafuselabs/databend/pull/13373 , as sometimes we'd call `build_operator()` on some queries, this causes duplicated metrics get registered into the registry, which finally produced millions of metrics.

the solution is to make the PrometheusClientLayer a singleton, but currently the PrometheusClientLayer have to be moved. we need allow it passing a reference before making the singleton in the `layer()` call.