### PR TITLE
feat: add `get_mut()` as poll requires `&mut self`

### DIFF
--- a/core/src/raw/oio/read/api.rs
+++ b/core/src/raw/oio/read/api.rs
@@ -215,7 +215,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<usize>> {
         let this = self.project();
-        Pin::new(this.reader).poll_read(cx, this.buf)
+        Pin::new(this.reader).get_mut().poll_read(cx, this.buf)
     }
 }
 
@@ -234,7 +234,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<u64>> {
         let this = self.project();
-        Pin::new(this.reader).poll_seek(cx, *this.pos)
+        Pin::new(this.reader).get_mut().poll_seek(cx, *this.pos)
     }
 }
 
@@ -252,7 +252,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
         let this = self.project();
-        Pin::new(this.reader).poll_next(cx)
+        Pin::new(this.reader).get_mut().poll_next(cx)
     }
 }
 

--- a/core/src/raw/oio/stream/api.rs
+++ b/core/src/raw/oio/stream/api.rs
@@ -188,7 +188,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
         let this = self.project();
-        Pin::new(this.inner).poll_next(cx)
+        Pin::new(this.inner).get_mut().poll_next(cx)
     }
 }
 
@@ -206,7 +206,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
         let this = self.project();
-        Pin::new(this.inner).poll_reset(cx)
+        Pin::new(this.inner).get_mut().poll_reset(cx)
     }
 }
 

--- a/core/src/raw/oio/write/api.rs
+++ b/core/src/raw/oio/write/api.rs
@@ -170,7 +170,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<usize>> {
         let this = self.project();
-        Pin::new(this.writer).poll_write(cx, *this.buf)
+        Pin::new(this.writer).get_mut().poll_write(cx, *this.buf)
     }
 }
 
@@ -188,7 +188,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
         let this = self.project();
-        Pin::new(this.writer).poll_abort(cx)
+        Pin::new(this.writer).get_mut().poll_abort(cx)
     }
 }
 
@@ -206,7 +206,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
         let this = self.project();
-        Pin::new(this.writer).poll_close(cx)
+        Pin::new(this.writer).get_mut().poll_close(cx)
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced by this PR. -->
![image](https://github.com/apache/incubator-opendal/assets/10728152/d96b1aab-6c68-4574-af2e-795985623e99)

To address the analyzer error, we can first call `get_mut()` on `poll_x`, which requires `&mut self`. It is safe to call `get_mut()` since `this.x` all implement `Unpin`.

(I've found this error warming only exist in JetBrains IDEs. If the maintainers do not consider it necessary, I will close this pull request.)