### PR TITLE
docs: Update mysql `connection_string` config description in doc

### DIFF
--- a/core/src/services/mysql/docs.md
+++ b/core/src/services/mysql/docs.md
@@ -17,7 +17,7 @@ This service can be used to:
 ## Configuration
 
 - `root`: Set the working directory of `OpenDAL`
-- `connection_string`: Set the connection string of postgres server
+- `connection_string`: Set the connection string of mysql server
 - `table`: Set the table of mysql
 - `key_field`: Set the key field of mysql
 - `value_field`: Set the value field of mysql


### PR DESCRIPTION
docs: update mysql `connection_string` config description in doc #3387 

Fix #3387