### PR TITLE
chore(bindings/java): use JDK 8 time APIs

### DIFF
--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -212,11 +212,14 @@ fn make_metadata<'a>(env: &mut JNIEnv<'a>, metadata: Metadata) -> Result<JObject
         metadata.last_modified().map_or_else(
             || Ok::<JObject<'_>, error::Error>(JObject::null()),
             |v| {
-                Ok(env.new_object(
-                    "java/util/Date",
-                    "(J)V",
-                    &[JValue::Long(v.timestamp_millis())],
-                )?)
+                Ok(env
+                    .call_static_method(
+                        "java/time/Instant",
+                        "ofEpochMilli",
+                        "(J)Ljava/time/Instant;",
+                        &[JValue::Long(v.timestamp_millis())],
+                    )?
+                    .l()?)
             },
         )?
     } else {
@@ -268,7 +271,7 @@ fn make_metadata<'a>(env: &mut JNIEnv<'a>, metadata: Metadata) -> Result<JObject
     let result = env
         .new_object(
             "org/apache/opendal/Metadata",
-            "(IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;)V",
+            "(IJLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/time/Instant;Ljava/lang/String;)V",
             &[
                 JValue::Int(mode as jint),
                 JValue::Long(content_length),

--- a/bindings/java/src/main/java/org/apache/opendal/Metadata.java
+++ b/bindings/java/src/main/java/org/apache/opendal/Metadata.java
@@ -19,7 +19,7 @@
 
 package org.apache.opendal;
 
-import java.util.Date;
+import java.time.Instant;
 import lombok.Data;
 
 /**
@@ -31,54 +31,62 @@ public class Metadata {
      * Mode of the entry.
      */
     public final EntryMode mode;
+
     /**
      * Content Length of the entry.
-     *
+     * <p>
      * Note: For now, this value is only available when calling on result of `stat`, otherwise it will be -1.
      */
     public final long contentLength;
+
     /**
      * Content-Disposition of the entry.
-     *
+     * <p>
      * Note: For now, this value is only available when calling on result of `stat`, otherwise it will be null.
      */
     public final String contentDisposition;
+
     /**
      * Content MD5 of the entry.
-     *
+     * <p>
      * Note: For now, this value is only available when calling on result of `stat`, otherwise it will be null.
      */
     public final String contentMd5;
+
     /**
      * Content Type of the entry.
-     *
+     * <p>
      * Note: For now, this value is only available when calling on result of `stat`, otherwise it will be null.
      */
     public final String contentType;
+
     /**
      * Cache Control of the entry.
-     *
+     * <p>
      * Note: For now, this value is only available when calling on result of `stat`, otherwise it will be null.
      */
     public final String cacheControl;
+
     /**
      * Etag of the entry.
-     *
+     * <p>
      * Note: For now, this value is only available when calling on result of `stat`, otherwise it will be null.
      */
     public final String etag;
+
     /**
      * Last Modified of the entry.
-     *
+     * <p>
      * Note: For now, this value is only available when calling on result of `stat`, otherwise it will be null.
      */
-    public final Date lastModified;
+    public final Instant lastModified;
+
     /**
      * Version of the entry.
      * Version is a string that can be used to identify the version of this entry.
      * This field may come out from the version control system, like object
      * versioning in AWS S3.
-     *
+     * <p>
      * Note: For now, this value is only available when calling on result of `stat`, otherwise it will be null.
      */
     public final String version;
@@ -91,7 +99,7 @@ public class Metadata {
             String contentType,
             String cacheControl,
             String etag,
-            Date lastModified,
+            Instant lastModified,
             String version) {
         this.mode = EntryMode.of(mode);
         this.contentLength = contentLength;


### PR DESCRIPTION
1. More precise than `Date`.
2. Can convert to `DateTime`s with `atZone` or `atOffset`.