### PR TITLE
feat(core): fix token leak in OneDrive

### DIFF
--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -55,7 +55,7 @@ impl Debug for OnedriveBackend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut de = f.debug_struct("OneDriveBackend");
         de.field("root", &self.root);
-        de.field("access_token", &self.access_token);
+        de.field("access_token", &"<redacted>");
         de.finish()
     }
 }

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -42,8 +42,8 @@ use super::error::parse_error;
 use super::error::parse_s3_error_code;
 use super::pager::S3Pager;
 use super::writer::S3Writer;
+use super::writer::S3Writers;
 use crate::raw::*;
-use crate::services::s3::writer::S3Writers;
 use crate::*;
 
 /// Allow constructing correct region endpoint if user gives a global endpoint.

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -198,7 +198,7 @@ impl WebhdfsBackend {
     /// create object or make a directory
     ///
     /// TODO: we should split it into mkdir and create
-    pub async fn webhdfs_create_object_request(
+    pub fn webhdfs_create_object_request(
         &self,
         path: &str,
         size: Option<usize>,
@@ -430,9 +430,12 @@ impl Accessor for WebhdfsBackend {
 
     /// Create a file or directory
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
-        let req = self
-            .webhdfs_create_object_request(path, Some(0), &OpWrite::default(), AsyncBody::Empty)
-            .await?;
+        let req = self.webhdfs_create_object_request(
+            path,
+            Some(0),
+            &OpWrite::default(),
+            AsyncBody::Empty,
+        )?;
 
         let resp = self.client.send(req).await?;
 

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -43,15 +43,12 @@ impl oio::OneShotWrite for WebhdfsWriter {
     async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
         let bs = bs.bytes(bs.remaining());
 
-        let req = self
-            .backend
-            .webhdfs_create_object_request(
-                &self.path,
-                Some(bs.len()),
-                &self.op,
-                AsyncBody::Bytes(bs),
-            )
-            .await?;
+        let req = self.backend.webhdfs_create_object_request(
+            &self.path,
+            Some(bs.len()),
+            &self.op,
+            AsyncBody::Bytes(bs),
+        )?;
 
         let resp = self.backend.client.send(req).await?;
 


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced by this PR. -->

1. Hide token info in OneDrive
2. Format import sequence and path
3. Drop async as there's no await inside
