### PR TITLE
fix(services/s3): Accept List responses without ETag

### DIFF
--- a/core/src/services/s3/pager.rs
+++ b/core/src/services/s3/pager.rs
@@ -126,8 +126,10 @@ impl oio::Page for S3Pager {
 
             let mut meta = Metadata::new(EntryMode::FILE);
 
-            meta.set_etag(&object.etag);
-            meta.set_content_md5(object.etag.trim_matches('"'));
+            if let Some(etag) = &object.etag {
+                meta.set_etag(&etag);
+                meta.set_content_md5(etag.trim_matches('"'));
+            }
             meta.set_content_length(object.size);
 
             // object.last_modified provides more precious time that contains
@@ -168,7 +170,7 @@ struct OutputContent {
     size: u64,
     last_modified: String,
     #[serde(rename = "ETag")]
-    etag: String,
+    etag: Option<String>,
 }
 
 #[derive(Default, Debug, Eq, PartialEq, Deserialize)]

--- a/core/src/services/s3/pager.rs
+++ b/core/src/services/s3/pager.rs
@@ -127,7 +127,7 @@ impl oio::Page for S3Pager {
             let mut meta = Metadata::new(EntryMode::FILE);
 
             if let Some(etag) = &object.etag {
-                meta.set_etag(&etag);
+                meta.set_etag(etag);
                 meta.set_content_md5(etag.trim_matches('"'));
             }
             meta.set_content_length(object.size);

--- a/core/src/services/s3/pager.rs
+++ b/core/src/services/s3/pager.rs
@@ -207,6 +207,11 @@ mod tests {
     <Size>100</Size>
     <StorageClass>STANDARD</StorageClass>
   </Contents>
+  <Contents>
+    <Key>photos/2008</Key>
+    <LastModified>2016-05-30T23:51:29.000Z</LastModified>
+    <Size>42</Size>
+  </Contents>
 
   <CommonPrefixes>
     <Prefix>photos/2006/February/</Prefix>
@@ -234,15 +239,21 @@ mod tests {
                 OutputContent {
                     key: "photos/2006".to_string(),
                     size: 56,
-                    etag: "\"d41d8cd98f00b204e9800998ecf8427e\"".to_string(),
+                    etag: Some("\"d41d8cd98f00b204e9800998ecf8427e\"".to_string()),
                     last_modified: "2016-04-30T23:51:29.000Z".to_string(),
                 },
                 OutputContent {
                     key: "photos/2007".to_string(),
                     size: 100,
                     last_modified: "2016-04-30T23:51:29.000Z".to_string(),
-                    etag: "\"d41d8cd98f00b204e9800998ecf8427e\"".to_string(),
-                }
+                    etag: Some("\"d41d8cd98f00b204e9800998ecf8427e\"".to_string()),
+                },
+                OutputContent {
+                    key: "photos/2008".to_string(),
+                    size: 42,
+                    last_modified: "2016-05-30T23:51:29.000Z".to_string(),
+                    etag: None,
+                },
             ]
         )
     }


### PR DESCRIPTION
This allows the S3 logic to accept response for path listings that don't contain the optional `<ETag>` xml element.

The bug was originally observed when connecting to an S3 compatible server: `s3s-fs` (https://crates.io/crates/s3s-fs).

I believe s3s-fs's behaviour is correct, given that the AWS S3 request/response docs state that the `Etag` field is optional: https://docs.aws.amazon.com/AmazonS3/latest/API/API_Object.html.

Closes https://github.com/apache/incubator-opendal/issues/3477.