### PR TITLE
docs(readme): Fix capitalization about the ABFS service in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Major components of the project include:
 <summary>File Storage Services (like fs, azdls, hdfs)</summary>
 
 - fs: POSIX alike file system
-- azdls: [Azure Data Lake Storage Gen2](https://azure.microsoft.com/en-us/products/storage/data-lake-storage/) services (As known as [abfs](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-abfs-driver))
+- azdls: [Azure Data Lake Storage Gen2](https://azure.microsoft.com/en-us/products/storage/data-lake-storage/) services (As known as [ABFS](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-abfs-driver))
 - hdfs: [Hadoop Distributed File System](https://hadoop.apache.org/docs/r3.3.4/hadoop-project-dist/hadoop-hdfs/HdfsDesign.html)(HDFS)
 - ipfs: [InterPlanetary File System](https://ipfs.tech/) HTTP Gateway
 - ipmfs: [InterPlanetary File System](https://ipfs.tech/) MFS API *being worked on*


### PR DESCRIPTION
<img width="470" alt="屏幕截图 2023-11-04 233302" src="https://github.com/apache/incubator-opendal/assets/77189278/def8c2c4-1a28-474c-9ebe-0d4c62de38cf">

I think it's a better choice to capitalize absf, and it can also correspond to HDFS capitalization below.
I think it is also possible to remove As known as