### PR TITLE
 Add go meta in opendal.apache.org/go to allow serving modules with go proxy

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	github.com/goproxy/goproxy v0.0.1
 )


### PR DESCRIPTION
 #3205 