### PR TITLE
ci: support behavior test for gridfs

### DIFF
--- a/.github/services/gridfs/gridfs/action.yml
+++ b/.github/services/gridfs/gridfs/action.yml
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: gridfs_with_no_auth
-description: 'Behavior test for gridfs with no auth'
+name: gridfs
+description: 'Behavior test for gridfs'
 
 runs:
   using: "composite"

--- a/.github/services/gridfs/gridfs_with_basic_auth/action.yml
+++ b/.github/services/gridfs/gridfs_with_basic_auth/action.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: mongodb_with_basic_auth
+description: "Behavior test for gridfs with basic auth"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup MongoDB Server
+      shell: bash
+      working-directory: fixtures/mongodb
+      run: docker compose -f docker-compose-basic-auth.yml up -d --wait
+    - name: Setup
+      shell: bash
+      run: |
+        cat << EOF >> $GITHUB_ENV
+        OPENDAL_GRIDFS_CONNECTION_STRING=mongodb://127.0.0.1:27017
+        OPENDAL_GRIDFS_DATABASE=opendal
+        OPENDAL_GRIDFS_BUCKET=fs
+        EOF

--- a/.github/services/gridfs/gridfs_with_basic_auth/action.yml
+++ b/.github/services/gridfs/gridfs_with_basic_auth/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: bash
       run: |
         cat << EOF >> $GITHUB_ENV
-        OPENDAL_GRIDFS_CONNECTION_STRING=mongodb://127.0.0.1:27017
+        OPENDAL_GRIDFS_CONNECTION_STRING=mongodb://root:example@127.0.0.1:27017/admin
         OPENDAL_GRIDFS_DATABASE=opendal
         OPENDAL_GRIDFS_BUCKET=fs
         EOF

--- a/.github/services/gridfs/gridfs_with_no_auth/action.yml
+++ b/.github/services/gridfs/gridfs_with_no_auth/action.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: gridfs_with_no_auth
+description: 'Behavior test for gridfs with no auth'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup MongoDB Server
+      shell: bash
+      working-directory: fixtures/mongodb
+      run: docker compose -f docker-compose-no-auth.yml up -d --wait
+    - name: Setup
+      shell: bash
+      run: |
+        cat << EOF >> $GITHUB_ENV
+        OPENDAL_GRIDFS_CONNECTION_STRING=mongodb://127.0.0.1:27017
+        OPENDAL_GRIDFS_DATABASE=opendal
+        OPENDAL_GRIDFS_BUCKET=fs
+        EOF

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -80,6 +80,7 @@ services-all = [
   "services-vercel-artifacts",
   "services-wasabi",
   "services-mongodb",
+  "services-gridfs",
   "services-sqlite",
   "services-azfile",
   "services-libsql",
@@ -111,8 +112,10 @@ services-etcd = ["opendal/services-etcd"]
 services-foundationdb = ["opendal/services-foundationdb"]
 services-ftp = ["opendal/services-ftp"]
 services-gdrive = ["opendal/services-gdrive"]
+services-gridfs = ["opendal/services-gridfs"]
 services-hdfs = ["opendal/services-hdfs"]
 services-ipfs = ["opendal/services-ipfs"]
+services-libsql = ["opendal/services-libsql"]
 services-memcached = ["opendal/services-memcached"]
 services-mini-moka = ["opendal/services-mini-moka"]
 services-moka = ["opendal/services-moka"]
@@ -128,12 +131,10 @@ services-sftp = ["opendal/services-sftp"]
 services-sled = ["opendal/services-sled"]
 services-sqlite = ["opendal/services-sqlite"]
 services-supabase = ["opendal/services-supabase"]
+services-swift = ["opendal/services-swift"]
 services-tikv = ["opendal/services-tikv"]
 services-vercel-artifacts = ["opendal/services-vercel-artifacts"]
 services-wasabi = ["opendal/services-wasabi"]
-services-libsql = ["opendal/services-libsql"]
-services-swift = ["opendal/services-swift"]
-
 
 [dependencies]
 anyhow = "1.0.71"

--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -78,8 +78,9 @@ services-all = [
   "services-vercel-artifacts",
   "services-wasabi",
   "services-mongodb",
+  "services-gridfs",
   "services-sqlite",
-  "services-libsql"
+  "services-libsql",
 ]
 
 # Default services provided by opendal.
@@ -107,8 +108,10 @@ services-etcd = ["opendal/services-etcd"]
 services-foundationdb = ["opendal/services-foundationdb"]
 services-ftp = ["opendal/services-ftp"]
 services-gdrive = ["opendal/services-gdrive"]
+services-gridfs = ["opendal/services-gridfs"]
 services-hdfs = ["opendal/services-hdfs"]
 services-ipfs = ["opendal/services-ipfs"]
+services-libsql = ["opendal/services-libsql"]
 services-memcached = ["opendal/services-memcached"]
 services-mini-moka = ["opendal/services-mini-moka"]
 services-moka = ["opendal/services-moka"]
@@ -128,7 +131,6 @@ services-swift = ["opendal/services-swift"]
 services-tikv = ["opendal/services-tikv"]
 services-vercel-artifacts = ["opendal/services-vercel-artifacts"]
 services-wasabi = ["opendal/services-wasabi"]
-services-libsql = ["opendal/services-libsql"]
 
 [lib]
 crate-type = ["cdylib"]
@@ -141,8 +143,8 @@ napi = { version = "2.11.3", default-features = false, features = [
   "async",
 ] }
 napi-derive = "2.12.2"
-tokio = "1"
 opendal.workspace = true
+tokio = "1"
 
 [build-dependencies]
 napi-build = "2"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -78,8 +78,9 @@ services-all = [
   "services-vercel-artifacts",
   "services-wasabi",
   "services-mongodb",
+  "services-gridfs",
   "services-sqlite",
-  "services-libsql"
+  "services-libsql",
 ]
 
 # Default services provided by opendal.
@@ -107,8 +108,10 @@ services-etcd = ["opendal/services-etcd"]
 services-foundationdb = ["opendal/services-foundationdb"]
 services-ftp = ["opendal/services-ftp"]
 services-gdrive = ["opendal/services-gdrive"]
+services-gridfs = ["opendal/services-gridfs"]
 services-hdfs = ["opendal/services-hdfs"]
 services-ipfs = ["opendal/services-ipfs"]
+services-libsql = ["opendal/services-libsql"]
 services-memcached = ["opendal/services-memcached"]
 services-mini-moka = ["opendal/services-mini-moka"]
 services-moka = ["opendal/services-moka"]
@@ -128,7 +131,6 @@ services-swift = ["opendal/services-swift"]
 services-tikv = ["opendal/services-tikv"]
 services-vercel-artifacts = ["opendal/services-vercel-artifacts"]
 services-wasabi = ["opendal/services-wasabi"]
-services-libsql = ["opendal/services-libsql"]
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
close #3502. It seems we can use MongoDB docker-compose files directly, how do you think? 