### PR TITLE
build(bindings/java): Allow building on `linux-aarch_64`

### DIFF
--- a/bindings/java/tools/build.py
+++ b/bindings/java/tools/build.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
 
     output = basedir / 'target' / 'bindings'
     Path(output).mkdir(exist_ok=True, parents=True)
-    cmd += ['--target-dir', output]
+    cmd += ['--target-dir', str(output)]
 
     print('$ ' + subprocess.list2cmdline(cmd))
     subprocess.run(cmd, cwd=basedir, check=True)

--- a/bindings/java/tools/build.py
+++ b/bindings/java/tools/build.py
@@ -32,6 +32,8 @@ def classifier_to_target(classifier: str) -> str:
         return 'x86_64-unknown-linux-gnu'
     if classifier == 'windows-x86_64':
         return 'x86_64-pc-windows-msvc'
+    if classifier == 'linux-aarch_64':
+        return 'aarch64-unknown-linux-gnu'
     raise Exception(f'Unsupported classifier: {classifier}')
 
 
@@ -44,6 +46,8 @@ def get_cargo_artifact_name(classifier: str) -> str:
         return 'libopendal_java.so'
     if classifier == 'windows-x86_64':
         return 'opendal_java.dll'
+    if classifier == 'linux-aarch_64':
+        return 'libopendal_java.so'
     raise Exception(f'Unsupported classifier: {classifier}')
 
 


### PR DESCRIPTION
Allow building the Java bindings on Linux ARM64.

Additionally allows the script to run with older Python versions that require strings in `subprocess` calls.