### PR TITLE
chore(bindings/java): improve build.py script

### DIFF
--- a/bindings/java/tools/build.py
+++ b/bindings/java/tools/build.py
@@ -28,26 +28,22 @@ def classifier_to_target(classifier: str) -> str:
         return 'aarch64-apple-darwin'
     if classifier == 'osx-x86_64':
         return 'x86_64-apple-darwin'
+    if classifier == 'linux-aarch_64':
+        return 'aarch64-unknown-linux-gnu'
     if classifier == 'linux-x86_64':
         return 'x86_64-unknown-linux-gnu'
     if classifier == 'windows-x86_64':
         return 'x86_64-pc-windows-msvc'
-    if classifier == 'linux-aarch_64':
-        return 'aarch64-unknown-linux-gnu'
     raise Exception(f'Unsupported classifier: {classifier}')
 
 
 def get_cargo_artifact_name(classifier: str) -> str:
-    if classifier == 'osx-aarch_64':
+    if classifier.startswith('osx'):
         return 'libopendal_java.dylib'
-    if classifier == 'osx-x86_64':
-        return 'libopendal_java.dylib'
-    if classifier == 'linux-x86_64':
+    if classifier.startswith('linux'):
         return 'libopendal_java.so'
-    if classifier == 'windows-x86_64':
+    if classifier.startswith('windows'):
         return 'opendal_java.dll'
-    if classifier == 'linux-aarch_64':
-        return 'libopendal_java.so'
     raise Exception(f'Unsupported classifier: {classifier}')
 
 


### PR DESCRIPTION
https://github.com/apache/incubator-opendal/pull/3527 infers me that we can improve this script so that users on other arch can simply use `-Dcargo-build.target=aarch64-unknown-linux-gnu` instead of having to modify the script.

Ref - https://github.com/trustin/os-maven-plugin/blob/43ed4d4bdc647ec369d152bfd18698f0997aa65b/README.md?plain=1#L9-L23

I don't have environment to test other OSes, so leave them blank for anyone encounters it to fix.

cc @Xuanwo @amunra