### PR TITLE
ci(bindings/nodejs): add aarch64 build support

### DIFF
--- a/.github/workflows/bindings_nodejs.yml
+++ b/.github/workflows/bindings_nodejs.yml
@@ -74,47 +74,55 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
+    strategy:
+      matrix:
+        settings:
+          - target: x86_64-unknown-linux-gnu
+            build: |
+              docker run \
+              -v .:/build \
+              -e NAPI_TARGET=x86_64-unknown-linux-gnu \
+              -w /build/bindings/nodejs \
+              ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian \
+              bash -c "yarn build"
+              cd bindings/nodejs
+              # change owner to current user
+              sudo chown -R 1001:121 *.node
+          - target: aarch64-unknown-linux-gnu
+            build: |
+              docker run \
+              -v .:/build \
+              -e NAPI_TARGET=aarch64-unknown-linux-gnu \
+              -w /build/bindings/nodejs \
+              ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64 \
+              bash -c "set -e &&
+              rustup target add aarch64-unknown-linux-gnu &&
+              yarn build --target aarch64-unknown-linux-gnu &&
+              aarch64-unknown-linux-gnu-strip *.node"
+              cd bindings/nodejs
+              # change owner to current user
+              sudo chown -R 1001:121 *.node
+          - target: aarch64-unknown-linux-musl
+            build: |
+              docker run \
+              -v .:/build \
+              -e NAPI_TARGET=aarch64-unknown-linux-musl \
+              -w /build/bindings/nodejs \
+              ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine \
+              bash -c "set -e &&
+              rustup target add aarch64-unknown-linux-musl &&
+              yarn build --target aarch64-unknown-linux-musl &&
+              /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip *.node"
+              cd bindings/nodejs
+              # change owner to current user
+              sudo chown -R 1001:121 *.node
 
     # Notes: this defaults only apply on run tasks.
     defaults:
       run:
         working-directory: "bindings/nodejs"
 
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: yarn
-          cache-dependency-path: "bindings/nodejs/yarn.lock"
-      - name: Corepack
-        run: corepack enable
-      - name: Install dependencies
-        run: yarn install --immutable
-      - name: Build
-        run: |
-          docker run \
-            -v ${{ github.workspace }}:/build \
-            -e NAPI_TARGET=x86_64-unknown-linux-gnu \
-            -w /build/bindings/nodejs \
-            ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian \
-            bash -c "yarn build"
-          # change owner to current user
-          sudo chown -R 1001:121 *.node
-      - uses: actions/upload-artifact@v3
-        with:
-          name: bindings-linux
-          path: bindings/nodejs/*.node
-
-  windows:
-    runs-on: windows-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
-
-    # Notes: this defaults only apply on run tasks.
-    defaults:
-      run:
-        working-directory: "bindings/nodejs"
+    name: linux - ${{ matrix.settings.target }}
 
     steps:
       - uses: actions/checkout@v4
@@ -129,10 +137,53 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
       - name: Build
-        run: yarn build
+        shell: bash
+        working-directory: .
+        run: ${{ matrix.settings.build }}
       - uses: actions/upload-artifact@v3
         with:
-          name: bindings-windows
+          name: bindings-linux-${{ matrix.settings.target }}
+          path: bindings/nodejs/*.node
+
+  windows:
+    runs-on: windows-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    strategy:
+      matrix:
+        settings:
+          - target: x86_64-pc-windows-msvc
+            build: yarn build
+          - target: aarch64-pc-windows-msvc
+            build: |
+              rustup target add aarch64-pc-windows-msvc;
+              set NAPI_TARGET=aarch64-pc-windows-msvc;
+              yarn build
+
+
+    # Notes: this defaults only apply on run tasks.
+    defaults:
+      run:
+        working-directory: "bindings/nodejs"
+
+    name: windows - ${{ matrix.settings.target }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: yarn
+          cache-dependency-path: "bindings/nodejs/yarn.lock"
+      - name: Corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build
+        run: ${{ matrix.settings.build }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: bindings-windows-${{ matrix.settings.target }}
           path: bindings/nodejs/*.node
 
   macos:
@@ -142,7 +193,6 @@ jobs:
       matrix:
         settings:
           - target: x86_64-apple-darwin
-            test: yarn test
             build: |
               yarn build
               strip -x *.node

--- a/bindings/nodejs/.cargo/config.toml
+++ b/bindings/nodejs/.cargo/config.toml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-musl-gcc"

--- a/bindings/nodejs/npm/linux-arm64-gnu/README.md
+++ b/bindings/nodejs/npm/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@opendal/lib-linux-arm64-gnu`
+
+This is the **aarch64-unknown-linux-gnu** binary for `opendal`

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@opendal/lib-linux-arm64-gnu",
+  "repository": "git@github.com/apache/incubator-opendal.git",
+  "version": "0.42.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "opendal.linux-arm64-gnu.node",
+  "files": [
+    "opendal.linux-arm64-gnu.node"
+  ],
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">= 10"
+  },
+  "libc": [
+    "glibc"
+  ]
+}

--- a/bindings/nodejs/npm/linux-arm64-musl/README.md
+++ b/bindings/nodejs/npm/linux-arm64-musl/README.md
@@ -1,0 +1,3 @@
+# `@opendal/lib-linux-arm64-musl`
+
+This is the **aarch64-unknown-linux-musl** binary for `opendal`

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@opendal/lib-linux-arm64-musl",
+  "repository": "git@github.com/apache/incubator-opendal.git",
+  "version": "0.42.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "opendal.linux-arm64-musl.node",
+  "files": [
+    "opendal.linux-arm64-musl.node"
+  ],
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">= 10"
+  },
+  "libc": [
+    "glibc"
+  ]
+}

--- a/bindings/nodejs/npm/win32-arm64-msvc/README.md
+++ b/bindings/nodejs/npm/win32-arm64-msvc/README.md
@@ -1,0 +1,3 @@
+# `@opendal/lib-win32-arm64-msvc`
+
+This is the **aarch64-pc-windows-msvc** binary for `opendal`

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@opendal/lib-win32-arm64-msvc",
+  "repository": "git@github.com/apache/incubator-opendal.git",
+  "version": "0.42.0",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "opendal.win32-arm64-msvc.node",
+  "files": [
+    "opendal.win32-arm64-msvc.node"
+  ],
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">= 10"
+  }
+}

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -15,7 +15,10 @@
     "triples": {
       "defaults": true,
       "additional": [
-        "aarch64-apple-darwin"
+        "aarch64-apple-darwin",
+        "aarch64-unknown-linux-gnu",
+        "aarch64-unknown-linux-musl",
+        "aarch64-pc-windows-msvc"
       ]
     }
   },


### PR DESCRIPTION
This PR adds support for aarch64 build on Linux and win32 systems.
- aarch64-unknown-linux-gnu
- aarch64-unknown-linux-musl
- aarch64-pc-windows-msvc

All the job steps have been tested except publish.