### PR TITLE
fix(ci): try enable corepack before setup-node action

### DIFF
--- a/.github/services/redis/redis_with_cluster_tls/action.yml
+++ b/.github/services/redis/redis_with_cluster_tls/action.yml
@@ -27,7 +27,6 @@ runs:
       shell: bash
       working-directory: fixtures/redis
       run: |
-
         # Install the CA in the system
 
         sudo cp ssl/ca.crt /usr/local/share/ca-certificates

--- a/.github/workflows/behavior_test_binding_nodejs.yml
+++ b/.github/workflows/behavior_test_binding_nodejs.yml
@@ -54,14 +54,15 @@ jobs:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}
 
+      - name: Corepack
+        working-directory: bindings/nodejs
+        run: corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: yarn
           cache-dependency-path: "bindings/nodejs/yarn.lock"
-      - name: Corepack
-        working-directory: bindings/nodejs
-        run: corepack enable
+
       - name: Install dependencies
         working-directory: bindings/nodejs
         run: yarn install --immutable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,15 +90,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Corepack
+        working-directory: bindings/nodejs
+        run: corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: yarn
           cache-dependency-path: "bindings/nodejs/yarn.lock"
 
-      - name: Corepack
-        working-directory: bindings/nodejs
-        run: corepack enable
       - name: Install dependencies
         working-directory: bindings/nodejs
         run: yarn install --immutable

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -821,6 +821,7 @@ impl RetryLayer {
     }
 }
 
+/// Format opendal error to napi error.
 fn format_napi_error(err: opendal::Error) -> Error {
     Error::from_reason(format!("{}", err))
 }


### PR DESCRIPTION
close #3607 

Advanced the `corepack enable` step. 
I'm not sure if it's fully resolved. I have checked to see if anyone else has raised this issue, but found nothing.