### PR TITLE
refactor(bindings/java): Use AllArgsConstructor to simplify Entry and Capability

### DIFF
--- a/bindings/java/src/main/java/org/apache/opendal/Capability.java
+++ b/bindings/java/src/main/java/org/apache/opendal/Capability.java
@@ -19,8 +19,11 @@
 
 package org.apache.opendal;
 
-import lombok.Data;
+import lombok.*;
 
+@Getter
+@Setter
+@AllArgsConstructor
 @Data
 public class Capability {
     /**
@@ -216,82 +219,4 @@ public class Capability {
      */
     public final boolean blocking;
 
-    public Capability(
-            boolean stat,
-            boolean statWithIfMatch,
-            boolean statWithIfNoneMatch,
-            boolean read,
-            boolean readCanSeek,
-            boolean readCanNext,
-            boolean readWithRange,
-            boolean readWithIfMatch,
-            boolean readWithIfNoneMatch,
-            boolean readWithOverrideCacheControl,
-            boolean readWithOverrideContentDisposition,
-            boolean readWithOverrideContentType,
-            boolean write,
-            boolean writeCanMulti,
-            boolean writeCanAppend,
-            boolean writeWithContentType,
-            boolean writeWithContentDisposition,
-            boolean writeWithCacheControl,
-            long writeMultiMaxSize,
-            long writeMultiMinSize,
-            long writeMultiAlignSize,
-            boolean createDir,
-            boolean delete,
-            boolean copy,
-            boolean rename,
-            boolean list,
-            boolean listWithLimit,
-            boolean listWithStartAfter,
-            boolean listWithDelimiterSlash,
-            boolean listWithoutDelimiter,
-            boolean presign,
-            boolean presignRead,
-            boolean presignStat,
-            boolean presignWrite,
-            boolean batch,
-            boolean batchDelete,
-            long batchMaxOperations,
-            boolean blocking) {
-        this.stat = stat;
-        this.statWithIfMatch = statWithIfMatch;
-        this.statWithIfNoneMatch = statWithIfNoneMatch;
-        this.read = read;
-        this.readCanSeek = readCanSeek;
-        this.readCanNext = readCanNext;
-        this.readWithRange = readWithRange;
-        this.readWithIfMatch = readWithIfMatch;
-        this.readWithIfNoneMatch = readWithIfNoneMatch;
-        this.readWithOverrideCacheControl = readWithOverrideCacheControl;
-        this.readWithOverrideContentDisposition = readWithOverrideContentDisposition;
-        this.readWithOverrideContentType = readWithOverrideContentType;
-        this.write = write;
-        this.writeCanMulti = writeCanMulti;
-        this.writeCanAppend = writeCanAppend;
-        this.writeWithContentType = writeWithContentType;
-        this.writeWithContentDisposition = writeWithContentDisposition;
-        this.writeWithCacheControl = writeWithCacheControl;
-        this.writeMultiMaxSize = writeMultiMaxSize;
-        this.writeMultiMinSize = writeMultiMinSize;
-        this.writeMultiAlignSize = writeMultiAlignSize;
-        this.createDir = createDir;
-        this.delete = delete;
-        this.copy = copy;
-        this.rename = rename;
-        this.list = list;
-        this.listWithLimit = listWithLimit;
-        this.listWithStartAfter = listWithStartAfter;
-        this.listWithDelimiterSlash = listWithDelimiterSlash;
-        this.listWithoutDelimiter = listWithoutDelimiter;
-        this.presign = presign;
-        this.presignRead = presignRead;
-        this.presignStat = presignStat;
-        this.presignWrite = presignWrite;
-        this.batch = batch;
-        this.batchDelete = batchDelete;
-        this.batchMaxOperations = batchMaxOperations;
-        this.blocking = blocking;
-    }
 }

--- a/bindings/java/src/main/java/org/apache/opendal/Entry.java
+++ b/bindings/java/src/main/java/org/apache/opendal/Entry.java
@@ -19,15 +19,13 @@
 
 package org.apache.opendal;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
+@AllArgsConstructor
 @Data
 public class Entry {
     public final String path;
     public final Metadata metadata;
 
-    public Entry(String path, Metadata metadata) {
-        this.path = path;
-        this.metadata = metadata;
-    }
 }


### PR DESCRIPTION
Hello Maintainers,

I have made improvements to ```Entry.java``` and ```Capability.java```. The getter and setter methods have been organized using Lombok. Please review these changes and merge this PR.

```java
@AllArgsConstructor
```
👆 This annotation will create all argument constructor.

Best,
F.Mohamed Abdullah