### PR TITLE
ci: dry run publish on rc tags for python binding

### DIFF
--- a/.github/workflows/bindings_python.yml
+++ b/.github/workflows/bindings_python.yml
@@ -113,7 +113,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-')"
+    if: "startsWith(github.ref, 'refs/tags/')"
     permissions:
       contents: read
       id-token: write
@@ -123,7 +123,16 @@ jobs:
         with:
           name: wheels
           path: bindings/python/dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: "contains(github.ref, '-')"
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          packages-dir: bindings/python/dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: "!contains(github.ref, '-')"
         with:
           skip-existing: true
           packages-dir: bindings/python/dist


### PR DESCRIPTION
`pypa/gh-action-pypi-publish` dose not have a dryrun option, so we just list package files.

- Part of: #3603

cc @suyanhanx 