### PR TITLE
chore: add license.workspace to help cargo deny reports

### DIFF
--- a/core/edge/file_write_on_full_disk/Cargo.toml
+++ b/core/edge/file_write_on_full_disk/Cargo.toml
@@ -21,6 +21,8 @@ name = "edge_test_file_write_on_full_disk"
 publish = false
 version = "0.0.0"
 
+license.workspace = true
+
 [dependencies]
 futures = "0.3"
 opendal = { workspace = true }

--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -21,6 +21,8 @@ name = "opendal-fuzz"
 publish = false
 version = "0.0.0"
 
+license.workspace = true
+
 [package.metadata]
 cargo-fuzz = true
 


### PR DESCRIPTION
This refers to #3615.