### PR TITLE
fix(core): Build with redis features and Rust < 1.72

### DIFF
--- a/core/src/services/mod.rs
+++ b/core/src/services/mod.rs
@@ -152,9 +152,9 @@ pub use self::persy::Persy;
 #[cfg(feature = "services-redis")]
 mod redis;
 #[cfg(feature = "services-redis")]
-pub use redis::Redis;
+pub use self::redis::Redis;
 #[cfg(feature = "services-redis")]
-pub use redis::RedisConfig;
+pub use self::redis::RedisConfig;
 
 #[cfg(feature = "services-rocksdb")]
 mod rocksdb;


### PR DESCRIPTION
Just need to be explicit about using our own redis mod rather than the redis crate.

Fixes #3595