### PR TITLE
refactor: List must support list without recursive

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -636,10 +636,6 @@ typedef struct opendal_capability {
    */
   bool list_with_start_after;
   /**
-   * If backend support list with using slash as delimiter.
-   */
-  bool list_without_recursive;
-  /**
    * If backend supports list without delimiter.
    */
   bool list_with_recursive;

--- a/bindings/c/src/operator_info.rs
+++ b/bindings/c/src/operator_info.rs
@@ -116,8 +116,6 @@ pub struct opendal_capability {
     pub list_with_limit: bool,
     /// If backend supports list with start after.
     pub list_with_start_after: bool,
-    /// If backend support list with using slash as delimiter.
-    pub list_without_recursive: bool,
     /// If backend supports list without delimiter.
     pub list_with_recursive: bool,
 
@@ -266,7 +264,6 @@ impl From<core::Capability> for opendal_capability {
             list_with_limit: value.list_with_limit,
             list_with_start_after: value.list_with_start_after,
             list_with_recursive: value.list_with_recursive,
-            list_without_recursive: value.list_without_recursive,
             presign: value.presign,
             presign_read: value.presign_read,
             presign_stat: value.presign_stat,

--- a/bindings/c/tests/bdd.cpp
+++ b/bindings/c/tests/bdd.cpp
@@ -75,26 +75,6 @@ TEST_F(OpendalBddTest, FeatureTest)
     opendal_metadata* meta = s.meta;
     EXPECT_TRUE(opendal_metadata_is_file(meta));
 
-    // The blocking file "test" should be renamed to "test-copy"
-    error = opendal_operator_rename(this->p, this->path.c_str(), "test-copy");
-    EXPECT_EQ(error, nullptr);
-    e = opendal_operator_is_exist(this->p, "test-copy");
-    EXPECT_EQ(e.error, nullptr);
-    EXPECT_TRUE(e.is_exist);
-    e = opendal_operator_is_exist(this->p, this->path.c_str());
-    EXPECT_EQ(e.error, nullptr);
-    EXPECT_FALSE(e.is_exist);
-
-    // The blocking file "test-copy" should be copied to "test"
-    error = opendal_operator_copy(this->p, "test-copy", this->path.c_str());
-    EXPECT_EQ(error, nullptr);
-    e = opendal_operator_is_exist(this->p, this->path.c_str());
-    EXPECT_EQ(e.error, nullptr);
-    EXPECT_TRUE(e.is_exist);
-    e = opendal_operator_is_exist(this->p, "test-copy");
-    EXPECT_EQ(e.error, nullptr);
-    EXPECT_TRUE(e.is_exist);
-
     // The blocking file "test" content length must be 13
     EXPECT_EQ(opendal_metadata_content_length(meta), 13);
 

--- a/bindings/c/tests/opinfo.cpp
+++ b/bindings/c/tests/opinfo.cpp
@@ -75,8 +75,6 @@ TEST_F(OpendalOperatorInfoTest, CapabilityTest)
     EXPECT_TRUE(full_cap.delete_);
     EXPECT_TRUE(full_cap.list);
     EXPECT_TRUE(full_cap.list_with_recursive);
-    EXPECT_TRUE(full_cap.copy);
-    EXPECT_TRUE(full_cap.rename);
 
     EXPECT_TRUE(native_cap.blocking);
     EXPECT_TRUE(native_cap.read);
@@ -90,8 +88,6 @@ TEST_F(OpendalOperatorInfoTest, CapabilityTest)
     EXPECT_TRUE(native_cap.delete_);
     EXPECT_TRUE(native_cap.list);
     EXPECT_TRUE(native_cap.list_with_recursive);
-    EXPECT_TRUE(native_cap.copy);
-    EXPECT_TRUE(native_cap.rename);
 }
 
 TEST_F(OpendalOperatorInfoTest, InfoTest)

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -153,7 +153,7 @@ fn make_operator_info<'a>(env: &mut JNIEnv<'a>, info: OperatorInfo) -> Result<JO
 fn make_capability<'a>(env: &mut JNIEnv<'a>, cap: Capability) -> Result<JObject<'a>> {
     let capability = env.new_object(
         "org/apache/opendal/Capability",
-        "(ZZZZZZZZZZZZZZZZZZJJJZZZZZZZZZZZZZZZJZ)V",
+        "(ZZZZZZZZZZZZZZZZZZJJJZZZZZZZZZZZZZZJZ)V",
         &[
             JValue::Bool(cap.stat as jboolean),
             JValue::Bool(cap.stat_with_if_match as jboolean),
@@ -183,7 +183,6 @@ fn make_capability<'a>(env: &mut JNIEnv<'a>, cap: Capability) -> Result<JObject<
             JValue::Bool(cap.list as jboolean),
             JValue::Bool(cap.list_with_limit as jboolean),
             JValue::Bool(cap.list_with_start_after as jboolean),
-            JValue::Bool(cap.list_without_recursive as jboolean),
             JValue::Bool(cap.list_with_recursive as jboolean),
             JValue::Bool(cap.presign as jboolean),
             JValue::Bool(cap.presign_read as jboolean),

--- a/bindings/java/src/main/java/org/apache/opendal/Capability.java
+++ b/bindings/java/src/main/java/org/apache/opendal/Capability.java
@@ -167,14 +167,9 @@ public class Capability {
     public final boolean listWithStartAfter;
 
     /**
-     * If backend support list with using slash as delimiter.
+     * If backend support list with recursive.
      */
-    public final boolean listWithDelimiterSlash;
-
-    /**
-     * If backend supports list without delimiter.
-     */
-    public final boolean listWithoutDelimiter;
+    public final boolean listWithRecursive;
 
     /**
      * If operator supports presign.
@@ -245,8 +240,7 @@ public class Capability {
             boolean list,
             boolean listWithLimit,
             boolean listWithStartAfter,
-            boolean listWithDelimiterSlash,
-            boolean listWithoutDelimiter,
+            boolean listWithRecursive,
             boolean presign,
             boolean presignRead,
             boolean presignStat,
@@ -283,8 +277,7 @@ public class Capability {
         this.list = list;
         this.listWithLimit = listWithLimit;
         this.listWithStartAfter = listWithStartAfter;
-        this.listWithDelimiterSlash = listWithDelimiterSlash;
-        this.listWithoutDelimiter = listWithoutDelimiter;
+        this.listWithRecursive = listWithRecursive;
         this.presign = presign;
         this.presignRead = presignRead;
         this.presignStat = presignStat;

--- a/bindings/nodejs/generated.d.ts
+++ b/bindings/nodejs/generated.d.ts
@@ -128,8 +128,6 @@ export class Capability {
   get listWithStartAfter(): boolean
   /** If backend supports list with recursive. */
   get listWithRecursive(): boolean
-  /** If backend supports list without recursive. */
-  get listWithoutRecursive(): boolean
   /** If operator supports presign. */
   get presign(): boolean
   /** If operator supports presign read. */

--- a/bindings/nodejs/src/capability.rs
+++ b/bindings/nodejs/src/capability.rs
@@ -230,12 +230,6 @@ impl Capability {
         self.0.list_with_recursive
     }
 
-    /// If backend supports list without recursive.
-    #[napi(getter)]
-    pub fn list_without_recursive(&self) -> bool {
-        self.0.list_without_recursive
-    }
-
     /// If operator supports presign.
     #[napi(getter)]
     pub fn presign(&self) -> bool {

--- a/bindings/python/src/capability.rs
+++ b/bindings/python/src/capability.rs
@@ -96,8 +96,6 @@ pub struct Capability {
     pub list_with_limit: bool,
     /// If backend supports list with start after.
     pub list_with_start_after: bool,
-    /// If backend support list with using slash as delimiter.
-    pub list_without_recursive: bool,
     /// If backend supports list without delimiter.
     pub list_with_recursive: bool,
 
@@ -155,7 +153,6 @@ impl Capability {
             list: capability.list,
             list_with_limit: capability.list_with_limit,
             list_with_start_after: capability.list_with_start_after,
-            list_without_recursive: capability.list_without_recursive,
             list_with_recursive: capability.list_with_recursive,
             presign: capability.presign,
             presign_read: capability.presign_read,

--- a/core/src/layers/immutable_index.rs
+++ b/core/src/layers/immutable_index.rs
@@ -156,7 +156,6 @@ impl<A: Accessor> LayeredAccessor for ImmutableIndexAccessor<A> {
         let cap = meta.full_capability_mut();
         cap.list = true;
         cap.list_with_recursive = true;
-        cap.list_without_recursive = true;
 
         meta
     }

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -1173,7 +1173,6 @@ mod tests {
             am.set_native_capability(Capability {
                 read: true,
                 list: true,
-                list_without_recursive: true,
                 list_with_recursive: true,
                 batch: true,
                 ..Default::default()

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -182,20 +182,20 @@ impl<S: Adapter> Accessor for Backend<S> {
         Ok(RpDelete::default())
     }
 
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
         let p = build_abs_path(&self.root, path);
         let res = self.kv.scan(&p).await?;
         let lister = KvLister::new(&self.root, res);
-        let lister = HierarchyLister::new(lister, path);
+        let lister = HierarchyLister::new(lister, path, args.recursive());
 
         Ok((RpList::default(), lister))
     }
 
-    fn blocking_list(&self, path: &str, _: OpList) -> Result<(RpList, Self::BlockingLister)> {
+    fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingLister)> {
         let p = build_abs_path(&self.root, path);
         let res = self.kv.blocking_scan(&p)?;
         let lister = KvLister::new(&self.root, res);
-        let lister = HierarchyLister::new(lister, path);
+        let lister = HierarchyLister::new(lister, path, args.recursive());
 
         Ok((RpList::default(), lister))
     }

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -89,14 +89,6 @@ impl<S: Adapter> Accessor for Backend<S> {
             cap.delete = true;
         }
 
-        if cap.read && cap.write {
-            cap.copy = true;
-        }
-
-        if cap.read && cap.write && cap.delete {
-            cap.rename = true;
-        }
-
         if cap.list {
             cap.list_with_recursive = true;
         }
@@ -203,68 +195,6 @@ impl<S: Adapter> Accessor for Backend<S> {
         let lister = KvLister::new(&self.root, res);
 
         Ok((RpList::default(), lister))
-    }
-
-    async fn rename(&self, from: &str, to: &str, _: OpRename) -> Result<RpRename> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_abs_path(&self.root, to);
-
-        let bs = match self.kv.get(&from).await? {
-            // TODO: we can reuse the metadata in value to build content range.
-            Some(bs) => bs,
-            None => return Err(Error::new(ErrorKind::NotFound, "kv doesn't have this path")),
-        };
-
-        self.kv.set(&to, &bs).await?;
-
-        self.kv.delete(&from).await?;
-        Ok(RpRename::default())
-    }
-
-    fn blocking_rename(&self, from: &str, to: &str, _: OpRename) -> Result<RpRename> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_abs_path(&self.root, to);
-
-        let bs = match self.kv.blocking_get(&from)? {
-            // TODO: we can reuse the metadata in value to build content range.
-            Some(bs) => bs,
-            None => return Err(Error::new(ErrorKind::NotFound, "kv doesn't have this path")),
-        };
-
-        self.kv.blocking_set(&to, &bs)?;
-
-        self.kv.blocking_delete(&from)?;
-        Ok(RpRename::default())
-    }
-
-    async fn copy(&self, from: &str, to: &str, _: OpCopy) -> Result<RpCopy> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_abs_path(&self.root, to);
-
-        let bs = match self.kv.get(&from).await? {
-            // TODO: we can reuse the metadata in value to build content range.
-            Some(bs) => bs,
-            None => return Err(Error::new(ErrorKind::NotFound, "kv doesn't have this path")),
-        };
-
-        self.kv.set(&to, &bs).await?;
-
-        Ok(RpCopy::default())
-    }
-
-    fn blocking_copy(&self, from: &str, to: &str, _: OpCopy) -> Result<RpCopy> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_abs_path(&self.root, to);
-
-        let bs = match self.kv.blocking_get(&from)? {
-            // TODO: we can reuse the metadata in value to build content range.
-            Some(bs) => bs,
-            None => return Err(Error::new(ErrorKind::NotFound, "kv doesn't have this path")),
-        };
-
-        self.kv.blocking_set(&to, &bs)?;
-
-        Ok(RpCopy::default())
     }
 }
 

--- a/core/src/raw/adapters/typed_kv/backend.rs
+++ b/core/src/raw/adapters/typed_kv/backend.rs
@@ -97,13 +97,6 @@ impl<S: Adapter> Accessor for Backend<S> {
             cap.list_with_recursive = true;
         }
 
-        if cap.read && cap.write {
-            cap.copy = true;
-        }
-
-        if cap.read && cap.write && cap.delete {
-            cap.rename = true;
-        }
         cap.blocking = true;
 
         am.set_native_capability(cap);
@@ -206,66 +199,6 @@ impl<S: Adapter> Accessor for Backend<S> {
         let lister = KvLister::new(&self.root, res);
 
         Ok((RpList::default(), lister))
-    }
-
-    async fn rename(&self, from: &str, to: &str, _: OpRename) -> Result<RpRename> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_abs_path(&self.root, to);
-
-        let bs = match self.kv.get(&from).await? {
-            // TODO: we can reuse the metadata in value to build content range.
-            Some(bs) => bs,
-            None => return Err(Error::new(ErrorKind::NotFound, "kv doesn't have this path")),
-        };
-
-        self.kv.set(&to, bs).await?;
-        self.kv.delete(&from).await?;
-        Ok(RpRename::default())
-    }
-
-    fn blocking_rename(&self, from: &str, to: &str, _: OpRename) -> Result<RpRename> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_abs_path(&self.root, to);
-
-        let bs = match self.kv.blocking_get(&from)? {
-            // TODO: we can reuse the metadata in value to build content range.
-            Some(bs) => bs,
-            None => return Err(Error::new(ErrorKind::NotFound, "kv doesn't have this path")),
-        };
-
-        self.kv.blocking_set(&to, bs)?;
-        self.kv.blocking_delete(&from)?;
-        Ok(RpRename::default())
-    }
-
-    async fn copy(&self, from: &str, to: &str, _: OpCopy) -> Result<RpCopy> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_abs_path(&self.root, to);
-
-        let bs = match self.kv.get(&from).await? {
-            // TODO: we can reuse the metadata in value to build content range.
-            Some(bs) => bs,
-            None => return Err(Error::new(ErrorKind::NotFound, "kv doesn't have this path")),
-        };
-
-        self.kv.set(&to, bs).await?;
-
-        Ok(RpCopy::default())
-    }
-
-    fn blocking_copy(&self, from: &str, to: &str, _: OpCopy) -> Result<RpCopy> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_abs_path(&self.root, to);
-
-        let bs = match self.kv.blocking_get(&from)? {
-            // TODO: we can reuse the metadata in value to build content range.
-            Some(bs) => bs,
-            None => return Err(Error::new(ErrorKind::NotFound, "kv doesn't have this path")),
-        };
-
-        self.kv.blocking_set(&to, bs)?;
-
-        Ok(RpCopy::default())
     }
 }
 

--- a/core/src/raw/adapters/typed_kv/backend.rs
+++ b/core/src/raw/adapters/typed_kv/backend.rs
@@ -186,20 +186,20 @@ impl<S: Adapter> Accessor for Backend<S> {
         Ok(RpDelete::default())
     }
 
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
         let p = build_abs_path(&self.root, path);
         let res = self.kv.scan(&p).await?;
         let lister = KvLister::new(&self.root, res);
-        let lister = HierarchyLister::new(lister, path);
+        let lister = HierarchyLister::new(lister, path, args.recursive());
 
         Ok((RpList::default(), lister))
     }
 
-    fn blocking_list(&self, path: &str, _: OpList) -> Result<(RpList, Self::BlockingLister)> {
+    fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingLister)> {
         let p = build_abs_path(&self.root, path);
         let res = self.kv.blocking_scan(&p)?;
         let lister = KvLister::new(&self.root, res);
-        let lister = HierarchyLister::new(lister, path);
+        let lister = HierarchyLister::new(lister, path, args.recursive());
 
         Ok((RpList::default(), lister))
     }

--- a/core/src/raw/oio/list/flat_list.rs
+++ b/core/src/raw/oio/list/flat_list.rs
@@ -84,15 +84,6 @@ where
 {
     /// Create a new flat lister
     pub fn new(acc: A, path: &str) -> FlatLister<A, L> {
-        #[cfg(debug_assertions)]
-        {
-            let meta = acc.info();
-            debug_assert!(
-                meta.full_capability().list_without_recursive,
-                "service doesn't support list hierarchy, it must be a bug"
-            );
-        }
-
         FlatLister {
             acc: Some(acc),
             root: path.to_string(),
@@ -254,7 +245,6 @@ mod tests {
         fn info(&self) -> AccessorInfo {
             let mut am = AccessorInfo::default();
             am.full_capability_mut().list = true;
-            am.full_capability_mut().list_without_recursive = true;
 
             am
         }

--- a/core/src/raw/oio/list/hierarchy_list.rs
+++ b/core/src/raw/oio/list/hierarchy_list.rs
@@ -37,11 +37,12 @@ pub struct HierarchyLister<P> {
     lister: P,
     path: String,
     visited: HashSet<String>,
+    recursive: bool,
 }
 
 impl<P> HierarchyLister<P> {
     /// Create a new hierarchy lister
-    pub fn new(lister: P, path: &str) -> HierarchyLister<P> {
+    pub fn new(lister: P, path: &str, recursive: bool) -> HierarchyLister<P> {
         let path = if path == "/" {
             "".to_string()
         } else {
@@ -52,6 +53,7 @@ impl<P> HierarchyLister<P> {
             lister,
             path,
             visited: HashSet::default(),
+            recursive,
         }
     }
 
@@ -130,6 +132,9 @@ impl<P: oio::List> oio::List for HierarchyLister<P> {
                 None => return Poll::Ready(Ok(None)),
             };
 
+            if self.recursive {
+                return Poll::Ready(Ok(Some(entry)));
+            }
             if self.keep_entry(&mut entry) {
                 return Poll::Ready(Ok(Some(entry)));
             }
@@ -144,6 +149,10 @@ impl<P: oio::BlockingList> oio::BlockingList for HierarchyLister<P> {
                 Some(entry) => entry,
                 None => return Ok(None),
             };
+
+            if self.recursive {
+                return Ok(Some(entry));
+            }
 
             if self.keep_entry(&mut entry) {
                 return Ok(Some(entry));
@@ -196,7 +205,7 @@ mod tests {
         let lister = MockLister::new(vec![
             "x/x/", "x/y/", "y/", "x/x/x", "y/y", "xy/", "z", "y/a",
         ]);
-        let mut lister = HierarchyLister::new(lister, "");
+        let mut lister = HierarchyLister::new(lister, "", false);
 
         let mut entries = Vec::default();
 

--- a/core/src/raw/oio/list/hierarchy_list.rs
+++ b/core/src/raw/oio/list/hierarchy_list.rs
@@ -75,6 +75,11 @@ impl<P> HierarchyLister<P> {
             return false;
         }
 
+        // Don't return already visited path.
+        if self.visited.contains(e.path()) {
+            return false;
+        }
+
         let prefix_len = self.path.len();
 
         let idx = if let Some(idx) = e.path()[prefix_len..].find('/') {

--- a/core/src/services/alluxio/backend.rs
+++ b/core/src/services/alluxio/backend.rs
@@ -204,7 +204,6 @@ impl Accessor for AlluxioBackend {
                 delete: true,
 
                 list: true,
-                list_without_recursive: true,
 
                 ..Default::default()
             });

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -575,7 +575,6 @@ impl Accessor for AzblobBackend {
                 copy: true,
 
                 list: true,
-                list_without_recursive: true,
                 list_with_recursive: true,
 
                 presign: self.has_sas_token,

--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -255,7 +255,6 @@ impl Accessor for AzdlsBackend {
                 rename: true,
 
                 list: true,
-                list_without_recursive: true,
 
                 ..Default::default()
             });

--- a/core/src/services/azfile/backend.rs
+++ b/core/src/services/azfile/backend.rs
@@ -270,7 +270,6 @@ impl Accessor for AzfileBackend {
                 rename: true,
 
                 list: true,
-                list_without_recursive: true,
 
                 ..Default::default()
             });

--- a/core/src/services/b2/backend.rs
+++ b/core/src/services/b2/backend.rs
@@ -310,7 +310,6 @@ impl Accessor for B2Backend {
                 list_with_limit: true,
                 list_with_start_after: true,
                 list_with_recursive: true,
-                list_without_recursive: true,
 
                 presign: true,
                 presign_read: true,

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -288,7 +288,6 @@ impl Accessor for CosBackend {
                 copy: true,
 
                 list: true,
-                list_without_recursive: true,
                 list_with_recursive: true,
 
                 presign: true,

--- a/core/src/services/dashmap/backend.rs
+++ b/core/src/services/dashmap/backend.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use std::collections::HashMap;
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 
 use async_trait::async_trait;
 use dashmap::DashMap;
@@ -62,9 +62,17 @@ impl Builder for DashmapBuilder {
 /// Backend is used to serve `Accessor` support in dashmap.
 pub type DashmapBackend = typed_kv::Backend<Adapter>;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Adapter {
     inner: DashMap<String, typed_kv::Value>,
+}
+
+impl Debug for Adapter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DashmapAdapter")
+            .field("size", &self.inner.len())
+            .finish_non_exhaustive()
+    }
 }
 
 #[async_trait]

--- a/core/src/services/dbfs/backend.rs
+++ b/core/src/services/dbfs/backend.rs
@@ -177,7 +177,6 @@ impl Accessor for DbfsBackend {
                 rename: true,
 
                 list: true,
-                list_without_recursive: true,
 
                 ..Default::default()
             });

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -265,7 +265,6 @@ impl Accessor for FsBackend {
                 delete: true,
 
                 list: true,
-                list_without_recursive: true,
 
                 copy: true,
                 rename: true,

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -306,7 +306,6 @@ impl Accessor for FtpBackend {
                 create_dir: true,
 
                 list: true,
-                list_without_recursive: true,
 
                 ..Default::default()
             });

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -348,7 +348,6 @@ impl Accessor for GcsBackend {
                 list: true,
                 list_with_limit: true,
                 list_with_start_after: true,
-                list_without_recursive: true,
                 list_with_recursive: true,
 
                 batch: true,

--- a/core/src/services/gdrive/backend.rs
+++ b/core/src/services/gdrive/backend.rs
@@ -58,7 +58,6 @@ impl Accessor for GdriveBackend {
                 read: true,
 
                 list: true,
-                list_without_recursive: true,
 
                 write: true,
 

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -196,7 +196,6 @@ impl Accessor for HdfsBackend {
                 delete: true,
 
                 list: true,
-                list_without_recursive: true,
 
                 rename: true,
                 blocking: true,

--- a/core/src/services/huggingface/backend.rs
+++ b/core/src/services/huggingface/backend.rs
@@ -261,7 +261,6 @@ impl Accessor for HuggingfaceBackend {
                 read_with_range: true,
 
                 list: true,
-                list_without_recursive: true,
                 list_with_recursive: true,
 
                 ..Default::default()

--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -180,7 +180,6 @@ impl Accessor for IpfsBackend {
                 read_with_range: true,
 
                 list: true,
-                list_without_recursive: true,
 
                 ..Default::default()
             });

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -84,7 +84,6 @@ impl Accessor for IpmfsBackend {
                 delete: true,
 
                 list: true,
-                list_without_recursive: true,
 
                 ..Default::default()
             });

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -294,7 +294,6 @@ impl Accessor for ObsBackend {
                 copy: true,
 
                 list: true,
-                list_without_recursive: true,
                 list_with_recursive: true,
 
                 presign: true,

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -80,7 +80,6 @@ impl Accessor for OnedriveBackend {
                 delete: true,
                 create_dir: true,
                 list: true,
-                list_without_recursive: true,
                 ..Default::default()
             });
 

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -425,7 +425,6 @@ impl Accessor for OssBackend {
                 list: true,
                 list_with_limit: true,
                 list_with_start_after: true,
-                list_without_recursive: true,
                 list_with_recursive: true,
 
                 presign: true,

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -1016,7 +1016,6 @@ impl Accessor for S3Backend {
                 list_with_limit: true,
                 list_with_start_after: true,
                 list_with_recursive: true,
-                list_without_recursive: true,
 
                 presign: true,
                 presign_stat: true,

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -267,7 +267,6 @@ impl Accessor for SftpBackend {
 
                 list: true,
                 list_with_limit: true,
-                list_without_recursive: true,
 
                 copy: self.copyable,
                 rename: true,

--- a/core/src/services/swift/backend.rs
+++ b/core/src/services/swift/backend.rs
@@ -237,7 +237,6 @@ impl Accessor for SwiftBackend {
                 delete: true,
 
                 list: true,
-                list_without_recursive: true,
                 list_with_recursive: true,
 
                 ..Default::default()

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -248,7 +248,6 @@ impl Accessor for WebdavBackend {
                 rename: true,
 
                 list: true,
-                list_without_recursive: true,
 
                 ..Default::default()
             });

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -417,7 +417,6 @@ impl Accessor for WebhdfsBackend {
                 delete: true,
 
                 list: true,
-                list_without_recursive: true,
 
                 ..Default::default()
             });

--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -132,8 +132,6 @@ pub struct Capability {
     pub list_with_start_after: bool,
     /// If backend supports list with recursive.
     pub list_with_recursive: bool,
-    /// If backend supports list without recursive.
-    pub list_without_recursive: bool,
 
     /// If operator supports presign.
     pub presign: bool,

--- a/core/tests/behavior/list.rs
+++ b/core/tests/behavior/list.rs
@@ -261,7 +261,8 @@ pub async fn test_list_sub_dir(op: Operator) -> Result<()> {
 
 /// List dir should also to list nested dir.
 pub async fn test_list_nested_dir(op: Operator) -> Result<()> {
-    let dir = format!("{}/{}/", uuid::Uuid::new_v4(), uuid::Uuid::new_v4());
+    let parent = format!("{}/", uuid::Uuid::new_v4());
+    let dir = format!("{parent}{}/", uuid::Uuid::new_v4());
 
     let file_name = uuid::Uuid::new_v4().to_string();
     let file_path = format!("{dir}{file_name}");
@@ -273,6 +274,11 @@ pub async fn test_list_nested_dir(op: Operator) -> Result<()> {
         .await
         .expect("creat must succeed");
     op.create_dir(&dir_path).await.expect("creat must succeed");
+
+    let obs = op.list(&parent).await?;
+    assert_eq!(obs.len(), 1, "parent should only got 1 entry");
+    assert_eq!(obs[0].path(), dir);
+    assert_eq!(obs[0].metadata().mode(), EntryMode::DIR);
 
     let mut obs = op.lister(&dir).await?;
     let mut objects = HashMap::new();


### PR DESCRIPTION
This PR is the follow-up for [RFC: List Recursive](https://opendal.apache.org/docs/rust/opendal/docs/rfcs/rfc_3526_list_recursive/index.html).

We split this change out to avoid the change from `delimiter` to `recursive` is too large.