### PR TITLE
docs: Remove not released bindings docs from top level header

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -133,22 +133,6 @@ const config = {
                 label: 'Java Binding',
                 to: 'pathname:///docs/java/'
               },
-              {
-                label: 'C Binding',
-                to: 'pathname:///docs/c/'
-              },
-              {
-                label: 'Lua Binding',
-                to: 'pathname:///docs/lua/'
-              },
-              {
-                label: 'Haskell Binding',
-                to: 'pathname:///docs/haskell/'
-              },
-              {
-                label: 'C++ Binding',
-                to: 'pathname:///docs/cpp/'
-              }
             ]
           },
           {


### PR DESCRIPTION
Let's hide them until we have better UI/UX to show stable versioned docs and dev docs.