### PR TITLE
GcsBuilder::from_map(): respect the `credential_path` key

### DIFF
--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -214,6 +214,8 @@ impl Builder for GcsBuilder {
         map.get("bucket").map(|v| builder.bucket(v));
         map.get("endpoint").map(|v| builder.endpoint(v));
         map.get("credential").map(|v| builder.credential(v));
+        map.get("credential_path")
+            .map(|v| builder.credential_path(v));
         map.get("scope").map(|v| builder.scope(v));
         map.get("predefined_acl").map(|v| builder.predefined_acl(v));
         map.get("default_storage_class")


### PR DESCRIPTION
# Changes

Respect the `credential_path` key inside `GcsBuilder::from_map()`. This key was being completely ignored before.

---

# Background:

The following Python code wouldn't work:

```python
async def main() -> None:
    op = AsyncOperator(
        "gcs",
        bucket="banana",
        root="/",
        credential_path="banana.json",
    )

    await op.read("test.txt")
```

It would result in an authentication error, even though a path to a credential file is being provided.

After writing the Rust equivalent (which does work):

```rust
async fn gcs_debug() -> Result<()> {
    use crate::services::Gcs;
    let mut builder = Gcs::default();

    builder.root("/");
    builder.bucket("banana");
    builder.credential_path("banana.json");

    let op: Operator = Operator::new(builder)?.finish();

    op.read("test.txt").await?;

    Ok(())
}
```

it became clear that the `credential_path` argument isn't being respected in the Python bindings.

Looking at the code in `gcs/backend.rs`, it appears that `credential_path` was (I assume accidentally) omitted.