### PR TITLE
feat: Add edge test s3_read_on_wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,6 +1558,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2286,16 @@ dependencies = [
  "opendal",
  "rand 0.8.5",
  "tokio",
+]
+
+[[package]]
+name = "edge_test_s3_read_on_wasm"
+version = "0.0.0"
+dependencies = [
+ "opendal",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -3414,9 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -7900,9 +7920,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7938,6 +7958,31 @@ name = "wasm-bindgen-shared"
 version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cf9242c0d27999b831eae4767b2a146feb0b27d332d553e605864acd2afd403"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794645f5408c9a039fd09f4d113cdfb2e7eba5ff1956b07bcf701cf4b394fe89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
 
 [[package]]
 name = "wasm-streams"

--- a/core/edge/s3_read_on_wasm/.gitignore
+++ b/core/edge/s3_read_on_wasm/.gitignore
@@ -1,0 +1,3 @@
+pkg/
+node_modules/
+dist/

--- a/core/edge/s3_read_on_wasm/Cargo.toml
+++ b/core/edge/s3_read_on_wasm/Cargo.toml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+edition = "2021"
+name = "edge_test_s3_read_on_wasm"
+publish = false
+version = "0.0.0"
+
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+opendal = { path = "../../", default-features = false, features = ["services-s3"] }
+wasm-bindgen = "0.2.89"
+wasm-bindgen-futures = "0.4.39"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.0"

--- a/core/edge/s3_read_on_wasm/README.md
+++ b/core/edge/s3_read_on_wasm/README.md
@@ -1,0 +1,42 @@
+# S3 Read on WASM
+
+This test is used to ensure opendal can run on WASM target.
+
+## Setup
+
+Start the S3 server at `http://127.0.0.1:9900`
+
+We are using the following config values, please feel free to change based on your own needs.
+
+```rust
+let mut cfg = S3::default();
+cfg.endpoint("http://127.0.0.1:9900");
+cfg.access_key_id("minioadmin");
+cfg.secret_access_key("minioadmin");
+cfg.bucket("opendal");
+cfg.region("us-east-1");
+```
+
+## Install
+
+```shell
+cargo install wasm-pack
+```
+
+## Build
+
+```shell
+wasm-pack build
+```
+
+## Test
+
+NOTE: 
+
+- You need to have Chrome installed.
+- We can't run on node.js yet.
+- We can't run on headless chrome yet.
+
+```shell
+wasm-pack test --chrome
+```

--- a/core/edge/s3_read_on_wasm/src/lib.rs
+++ b/core/edge/s3_read_on_wasm/src/lib.rs
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use opendal::services::S3;
+use opendal::Operator;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub async fn hello_world() -> String {
+    let mut cfg = S3::default();
+    cfg.endpoint("http://127.0.0.1:9900");
+    cfg.access_key_id("minioadmin");
+    cfg.secret_access_key("minioadmin");
+    cfg.bucket("opendal");
+    cfg.region("us-east-1");
+
+    let op = Operator::new(cfg).unwrap().finish();
+    op.write(
+        "test",
+        "Hello, WASM! We are from OpenDAL at rust side!"
+            .as_bytes()
+            .to_vec(),
+    )
+    .await
+    .unwrap();
+    let bs = op.read("test").await.unwrap();
+    String::from_utf8_lossy(&bs).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+    use wasm_bindgen_test::wasm_bindgen_test_configure;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    async fn test_hello_world() {
+        let s = hello_world().await;
+        assert_eq!(s, "Hello, WASM! We are from OpenDAL at rust side!")
+    }
+}

--- a/core/edge/s3_read_on_wasm/webdriver.json
+++ b/core/edge/s3_read_on_wasm/webdriver.json
@@ -1,0 +1,15 @@
+{
+  "moz:firefoxOptions": {
+    "prefs": {
+      "media.navigator.streams.fake": true,
+      "media.navigator.permission.disabled": true
+    },
+    "args": []
+  },
+  "goog:chromeOptions": {
+    "args": [
+      "--use-fake-device-for-media-stream",
+      "--use-fake-ui-for-media-stream"
+    ]
+  }
+}

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -863,8 +863,8 @@ impl Builder for S3Builder {
             #[cfg(not(target_arch = "wasm32"))]
             {
                 cfg = cfg.from_profile();
+                cfg = cfg.from_env();
             }
-            cfg = cfg.from_env();
         }
 
         if let Some(v) = self.config.region.take() {


### PR DESCRIPTION
This PR will add basic edge test for s3 read on wasm.

We can't make it running in CI yet, should be fix later.