### PR TITLE
refactor: simplify `bindings_python.yml`

### DIFF
--- a/.github/workflows/bindings_python.yml
+++ b/.github/workflows/bindings_python.yml
@@ -19,15 +19,12 @@ name: Bindings Python CI
 
 on:
   push:
-    branches:
-      - main
     tags:
       - '*'
   pull_request:
     branches:
       - main
     paths:
-      - "bindings/python/**"
       - ".github/workflows/bindings_python.yml"
   workflow_dispatch:
 
@@ -42,7 +39,6 @@ jobs:
 
   sdist:
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
     steps:
       - uses: actions/checkout@v4
       - uses: PyO3/maturin-action@v1
@@ -58,7 +54,6 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
     strategy:
       matrix:
         target: [x86_64, aarch64, armv7l]
@@ -82,7 +77,6 @@ jobs:
 
   windows:
     runs-on: windows-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
     steps:
       - uses: actions/checkout@v4
       - uses: PyO3/maturin-action@v1
@@ -98,7 +92,6 @@ jobs:
 
   macos:
     runs-on: macos-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
     steps:
       - uses: actions/checkout@v4
       - uses: PyO3/maturin-action@v1


### PR DESCRIPTION
Only run python bindings build test on tag push, workflow dispatch or pull requests that modifies `bindings_python.yml` file.