### PR TITLE
chore(bindings/python): improve ASF branding

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Build Docs
         working-directory: bindings/python
-        run: pdoc --output-dir ./docs opendal
+        run: pdoc -t ./template --output-dir ./docs opendal
 
       - name: Upload docs
         uses: actions/upload-artifact@v3

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -103,5 +103,5 @@ Build API docs:
 
 ```shell
 maturin develop -E docs
-pdoc opendal
+pdoc -t ./template opendal
 ```

--- a/bindings/python/template/module.html.jinja2
+++ b/bindings/python/template/module.html.jinja2
@@ -1,0 +1,13 @@
+{% extends "default/module.html.jinja2" %}
+{% block nav_title %}
+<h1>Apache OpenDAL™</h1>
+{% endblock %}
+{% block module_contents %}
+{{ super() }}
+<footer>
+Copyright © 2022-<script>document.write(new Date().getFullYear())</script>,
+The Apache Software Foundation Apache OpenDAL, OpenDAL, Apache, Apache Incubator, the Apache feather,
+the Apache Incubator logo and the Apache OpenDAL project logo are either registered trademarks or
+trademarks of the Apache Software Foundation.
+</footer>
+{% endblock %}

--- a/bindings/python/template/module.html.jinja2
+++ b/bindings/python/template/module.html.jinja2
@@ -1,7 +1,28 @@
+{#
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+#}
+
 {% extends "default/module.html.jinja2" %}
+
 {% block nav_title %}
 <h1>Apache OpenDAL™</h1>
 {% endblock %}
+
 {% block module_contents %}
 {{ super() }}
 <footer>


### PR DESCRIPTION
This closes https://github.com/apache/incubator-opendal/issues/3848.

Potential improvement:

* Better footer style (CSS)
* If the logo gets changed to "Apache OpenDAL™" itself [1], we can change the nav_title refers to the logo.

<img width="1728" alt="image" src="https://github.com/apache/incubator-opendal/assets/18818196/a3cd7974-4907-427b-932f-2ecd2a2111fe">
