### PR TITLE
chore(bindings/haskell): improve ASF branding

### DIFF
--- a/bindings/haskell/README.md
+++ b/bindings/haskell/README.md
@@ -50,6 +50,7 @@ cabal test
 ## Doc
 
 To generate the documentation:
+
 ```bash
 cabal haddock
 ```

--- a/bindings/haskell/opendal.cabal
+++ b/bindings/haskell/opendal.cabal
@@ -19,9 +19,9 @@ cabal-version:      3.0
 name:               opendal
 version:            0.1.0.0
 license:            Apache-2.0
-synopsis:           OpenDAL Haskell Binding
+synopsis:           Apache OpenDAL™ Haskell Binding
 description:
-    OpenDAL Haskell Binding. Open Data Access Layer: Access data freely, painlessly, and efficiently
+    Apache OpenDAL™ Haskell Binding. Open Data Access Layer: Access data freely, painlessly, and efficiently
 author:             OpenDAL Contributors
 maintainer:         dev@opendal.apache.org
 category:           Storage, Binding


### PR DESCRIPTION
I cannot build it locally so we may wait for CI or the author of Haskell binding to check.

Failure report:

```
$ cabal update
Downloading the latest package list from hackage.haskell.org
Package list of hackage.haskell.org has been updated.
The index-state is set to 2023-12-29T05:19:00Z.

$ cabal haddock
Resolving dependencies...
Error: cabal: Could not resolve dependencies:
[__0] trying: opendal-0.1.0.0 (user goal)
[__1] next goal: base (dependency of opendal)
[__1] rejecting: base-4.19.0.0/installed-inplace (conflict: opendal =>
base>=4.10 && <4.17)
[__1] skipping: base-4.19.0.0, base-4.18.1.0, base-4.18.0.0, base-4.17.2.1,
base-4.17.2.0, base-4.17.1.0, base-4.17.0.0 (has the same characteristics that
caused the previous version to fail: excluded by constraint '>=4.10 && <4.17'
from 'opendal')
[__1] rejecting: base-4.16.4.0, base-4.16.3.0, base-4.16.2.0, base-4.16.1.0,
base-4.16.0.0, base-4.15.1.0, base-4.15.0.0, base-4.14.3.0, base-4.14.2.0,
base-4.14.1.0, base-4.14.0.0, base-4.13.0.0, base-4.12.0.0, base-4.11.1.0,
base-4.11.0.0, base-4.10.1.0, base-4.10.0.0, base-4.9.1.0, base-4.9.0.0,
base-4.8.2.0, base-4.8.1.0, base-4.8.0.0, base-4.7.0.2, base-4.7.0.1,
base-4.7.0.0, base-4.6.0.1, base-4.6.0.0, base-4.5.1.0, base-4.5.0.0,
base-4.4.1.0, base-4.4.0.0, base-4.3.1.0, base-4.3.0.0, base-4.2.0.2,
base-4.2.0.1, base-4.2.0.0, base-4.1.0.0, base-4.0.0.0, base-3.0.3.2,
base-3.0.3.1 (constraint from non-upgradeable package requires installed
instance)
[__1] fail (backjumping, conflict set: base, opendal)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: base, opendal

$ cabal install
Error: cabal: Could not resolve dependencies:
[__0] trying: opendal-0.1.0.0 (user goal)
[__1] next goal: base (dependency of opendal)
[__1] rejecting: base-4.19.0.0/installed-inplace (conflict: opendal =>
base>=4.10 && <4.17)
[__1] skipping: base-4.19.0.0, base-4.18.1.0, base-4.18.0.0, base-4.17.2.1,
base-4.17.2.0, base-4.17.1.0, base-4.17.0.0 (has the same characteristics that
caused the previous version to fail: excluded by constraint '>=4.10 && <4.17'
from 'opendal')
[__1] rejecting: base-4.16.4.0, base-4.16.3.0, base-4.16.2.0, base-4.16.1.0,
base-4.16.0.0, base-4.15.1.0, base-4.15.0.0, base-4.14.3.0, base-4.14.2.0,
base-4.14.1.0, base-4.14.0.0, base-4.13.0.0, base-4.12.0.0, base-4.11.1.0,
base-4.11.0.0, base-4.10.1.0, base-4.10.0.0, base-4.9.1.0, base-4.9.0.0,
base-4.8.2.0, base-4.8.1.0, base-4.8.0.0, base-4.7.0.2, base-4.7.0.1,
base-4.7.0.0, base-4.6.0.1, base-4.6.0.0, base-4.5.1.0, base-4.5.0.0,
base-4.4.1.0, base-4.4.0.0, base-4.3.1.0, base-4.3.0.0, base-4.2.0.2,
base-4.2.0.1, base-4.2.0.0, base-4.1.0.0, base-4.0.0.0, base-3.0.3.2,
base-3.0.3.1 (constraint from non-upgradeable package requires installed
instance)
[__1] fail (backjumping, conflict set: base, opendal)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: base, opendal
```