### PR TITLE
chore(bindings/haskell): support co-log-0.6.0 && ghc-9.4

### DIFF
--- a/.github/workflows/bindings_haskell.yml
+++ b/.github/workflows/bindings_haskell.yml
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Haskell toolchain (ghc-9.2.8)
+      - name: Setup Haskell toolchain (ghc-9.4.8)
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
-          ghcup install ghc 9.2.8 --set
+          ghcup install ghc 9.4.8 --set
           ghcup install cabal --set
           cabal update
       - name: Setup Rust toolchain

--- a/bindings/haskell/opendal.cabal
+++ b/bindings/haskell/opendal.cabal
@@ -25,7 +25,7 @@ description:
 author:             OpenDAL Contributors
 maintainer:         dev@opendal.apache.org
 category:           Storage, Binding
-tested-with:        GHC ==9.2.7
+tested-with:        GHC ==9.4.8
 extra-doc-files:    README.md, CONTRIBUTING.md
 extra-source-files: src/*.rs, Cargo.toml
 
@@ -47,13 +47,13 @@ source-repository this
 common base
     ghc-options:      -Wall
     build-depends:
-        base >= 4.10 && < 4.17,
+        base >= 4.10 && < 5,
         bytestring >= 0.11.4 && < 0.12,
         mtl >= 2.2.2 && < 2.3,
         text (>= 2.0.2 && < 2.1) || (>= 1.2.5 && < 1.3),
         time >= 1.11.1 && < 1.12,
         unordered-containers >= 0.2.19 && < 0.3,
-        co-log >= 0.5.0 && < 0.6,
+        co-log >= 0.5.0 && < 0.7,
     default-language: Haskell2010
     default-extensions:
         OverloadedStrings,


### PR DESCRIPTION
close #3853

The support for `ghc-9.6` seems to need to bump `mtl`, but it has breaking change.