### PR TITLE
refactor: use TwoWays instead of TwoWaysReader and TwoWaysWriter

### DIFF
--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -33,7 +33,7 @@ use crate::raw::oio::LazyReader;
 use crate::raw::oio::PrefixLister;
 use crate::raw::oio::RangeReader;
 use crate::raw::oio::StreamableReader;
-use crate::raw::oio::TwoWaysReader;
+use crate::raw::TwoWays;
 use crate::raw::*;
 use crate::*;
 
@@ -471,10 +471,8 @@ impl<A: Accessor> LayeredAccessor for CompleteAccessor<A> {
     type Inner = A;
     type Reader = CompleteReader<A, A::Reader>;
     type BlockingReader = CompleteReader<A, A::BlockingReader>;
-    type Writer = oio::TwoWaysWriter<
-        CompleteWriter<A::Writer>,
-        oio::ExactBufWriter<CompleteWriter<A::Writer>>,
-    >;
+    type Writer =
+        TwoWays<CompleteWriter<A::Writer>, oio::ExactBufWriter<CompleteWriter<A::Writer>>>;
     type BlockingWriter = CompleteWriter<A::BlockingWriter>;
     type Lister = CompleteLister<A, A::Lister>;
     type BlockingLister = CompleteLister<A, A::BlockingLister>;
@@ -540,8 +538,8 @@ impl<A: Accessor> LayeredAccessor for CompleteAccessor<A> {
         let w = CompleteWriter::new(w);
 
         let w = match buffer_size {
-            None => oio::TwoWaysWriter::One(w),
-            Some(size) => oio::TwoWaysWriter::Two(oio::ExactBufWriter::new(w, size)),
+            None => TwoWays::One(w),
+            Some(size) => TwoWays::Two(oio::ExactBufWriter::new(w, size)),
         };
 
         Ok((rp, w))
@@ -676,7 +674,7 @@ impl<A: Accessor> LayeredAccessor for CompleteAccessor<A> {
 }
 
 pub type CompleteReader<A, R> =
-    TwoWaysReader<InnerCompleteReader<A, R>, BufferReader<InnerCompleteReader<A, R>>>;
+    TwoWays<InnerCompleteReader<A, R>, BufferReader<InnerCompleteReader<A, R>>>;
 
 type InnerCompleteReader<A, R> = FourWaysReader<
     LazyReader<A, R>,

--- a/core/src/raw/enum_utils.rs
+++ b/core/src/raw/enum_utils.rs
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::io::SeekFrom;
+use std::task::{Context, Poll};
+
+use crate::raw::*;
+use crate::*;
+
+/// TwoWays is used to implement [`Read`] or [`Writer`] based on two ways.
+///
+/// Users can wrap two different readers/writers together.
+pub enum TwoWays<ONE, TWO> {
+    /// The first type for the [`TwoWays`].
+    One(ONE),
+    /// The second type for the [`TwoWays`].
+    Two(TWO),
+}
+
+impl<ONE: oio::Read, TWO: oio::Read> oio::Read for TwoWays<ONE, TWO> {
+    fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
+        match self {
+            Self::One(one) => one.poll_read(cx, buf),
+            Self::Two(two) => two.poll_read(cx, buf),
+        }
+    }
+
+    fn poll_seek(&mut self, cx: &mut Context<'_>, pos: SeekFrom) -> Poll<Result<u64>> {
+        match self {
+            Self::One(one) => one.poll_seek(cx, pos),
+            Self::Two(two) => two.poll_seek(cx, pos),
+        }
+    }
+
+    fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<bytes::Bytes>>> {
+        match self {
+            Self::One(one) => one.poll_next(cx),
+            Self::Two(two) => two.poll_next(cx),
+        }
+    }
+}
+
+impl<ONE: oio::BlockingRead, TWO: oio::BlockingRead> oio::BlockingRead for TwoWays<ONE, TWO> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        match self {
+            Self::One(one) => one.read(buf),
+            Self::Two(two) => two.read(buf),
+        }
+    }
+
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        match self {
+            Self::One(one) => one.seek(pos),
+            Self::Two(two) => two.seek(pos),
+        }
+    }
+
+    fn next(&mut self) -> Option<Result<bytes::Bytes>> {
+        match self {
+            Self::One(one) => one.next(),
+            Self::Two(two) => two.next(),
+        }
+    }
+}
+
+impl<ONE: oio::Write, TWO: oio::Write> oio::Write for TwoWays<ONE, TWO> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+        match self {
+            Self::One(one) => one.poll_write(cx, bs),
+            Self::Two(two) => two.poll_write(cx, bs),
+        }
+    }
+
+    fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        match self {
+            Self::One(one) => one.poll_close(cx),
+            Self::Two(two) => two.poll_close(cx),
+        }
+    }
+
+    fn poll_abort(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        match self {
+            Self::One(one) => one.poll_abort(cx),
+            Self::Two(two) => two.poll_abort(cx),
+        }
+    }
+}

--- a/core/src/raw/mod.rs
+++ b/core/src/raw/mod.rs
@@ -71,3 +71,6 @@ pub mod adapters;
 pub mod oio;
 #[cfg(feature = "tests")]
 pub mod tests;
+
+mod enum_utils;
+pub use enum_utils::TwoWays;

--- a/core/src/raw/oio/read/compose_read.rs
+++ b/core/src/raw/oio/read/compose_read.rs
@@ -15,87 +15,30 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{
-    io::SeekFrom,
-    task::{Context, Poll},
-};
+use std::io::SeekFrom;
+use std::task::{Context, Poll};
 
 use crate::raw::*;
-
-/// TwoWaysReader is used to implement [`Read`] based on two ways.
-///
-/// Users can wrap two different readers together.
-pub enum TwoWaysReader<ONE, TWO> {
-    /// The first type for the [`TwoWaysReader`].
-    One(ONE),
-    /// The second type for the [`TwoWaysReader`].
-    Two(TWO),
-}
-
-impl<ONE: oio::Read, TWO: oio::Read> oio::Read for TwoWaysReader<ONE, TWO> {
-    fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<crate::Result<usize>> {
-        match self {
-            Self::One(one) => one.poll_read(cx, buf),
-            Self::Two(two) => two.poll_read(cx, buf),
-        }
-    }
-
-    fn poll_seek(&mut self, cx: &mut Context<'_>, pos: SeekFrom) -> Poll<crate::Result<u64>> {
-        match self {
-            Self::One(one) => one.poll_seek(cx, pos),
-            Self::Two(two) => two.poll_seek(cx, pos),
-        }
-    }
-
-    fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<crate::Result<bytes::Bytes>>> {
-        match self {
-            Self::One(one) => one.poll_next(cx),
-            Self::Two(two) => two.poll_next(cx),
-        }
-    }
-}
-
-impl<ONE: oio::BlockingRead, TWO: oio::BlockingRead> oio::BlockingRead for TwoWaysReader<ONE, TWO> {
-    fn read(&mut self, buf: &mut [u8]) -> crate::Result<usize> {
-        match self {
-            Self::One(one) => one.read(buf),
-            Self::Two(two) => two.read(buf),
-        }
-    }
-
-    fn seek(&mut self, pos: SeekFrom) -> crate::Result<u64> {
-        match self {
-            Self::One(one) => one.seek(pos),
-            Self::Two(two) => two.seek(pos),
-        }
-    }
-
-    fn next(&mut self) -> Option<crate::Result<bytes::Bytes>> {
-        match self {
-            Self::One(one) => one.next(),
-            Self::Two(two) => two.next(),
-        }
-    }
-}
+use crate::*;
 
 /// FourWaysReader is used to implement [`Read`] based on four ways.
 ///
 /// Users can wrap four different readers together.
 pub enum FourWaysReader<ONE, TWO, THREE, FOUR> {
-    /// The first type for the [`TwoWaysReader`].
+    /// The first type for the [`FourWaysReader`].
     One(ONE),
-    /// The second type for the [`TwoWaysReader`].
+    /// The second type for the [`FourWaysReader`].
     Two(TWO),
-    /// The third type for the [`TwoWaysReader`].
+    /// The third type for the [`FourWaysReader`].
     Three(THREE),
-    /// The fourth type for the [`TwoWaysReader`].
+    /// The fourth type for the [`FourWaysReader`].
     Four(FOUR),
 }
 
 impl<ONE: oio::Read, TWO: oio::Read, THREE: oio::Read, FOUR: oio::Read> oio::Read
     for FourWaysReader<ONE, TWO, THREE, FOUR>
 {
-    fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<crate::Result<usize>> {
+    fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
         match self {
             Self::One(one) => one.poll_read(cx, buf),
             Self::Two(two) => two.poll_read(cx, buf),
@@ -104,7 +47,7 @@ impl<ONE: oio::Read, TWO: oio::Read, THREE: oio::Read, FOUR: oio::Read> oio::Rea
         }
     }
 
-    fn poll_seek(&mut self, cx: &mut Context<'_>, pos: SeekFrom) -> Poll<crate::Result<u64>> {
+    fn poll_seek(&mut self, cx: &mut Context<'_>, pos: SeekFrom) -> Poll<Result<u64>> {
         match self {
             Self::One(one) => one.poll_seek(cx, pos),
             Self::Two(two) => two.poll_seek(cx, pos),
@@ -113,7 +56,7 @@ impl<ONE: oio::Read, TWO: oio::Read, THREE: oio::Read, FOUR: oio::Read> oio::Rea
         }
     }
 
-    fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<crate::Result<bytes::Bytes>>> {
+    fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<bytes::Bytes>>> {
         match self {
             Self::One(one) => one.poll_next(cx),
             Self::Two(two) => two.poll_next(cx),
@@ -130,7 +73,7 @@ impl<
         FOUR: oio::BlockingRead,
     > oio::BlockingRead for FourWaysReader<ONE, TWO, THREE, FOUR>
 {
-    fn read(&mut self, buf: &mut [u8]) -> crate::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         match self {
             Self::One(one) => one.read(buf),
             Self::Two(two) => two.read(buf),
@@ -139,7 +82,7 @@ impl<
         }
     }
 
-    fn seek(&mut self, pos: SeekFrom) -> crate::Result<u64> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
         match self {
             Self::One(one) => one.seek(pos),
             Self::Two(two) => two.seek(pos),
@@ -148,7 +91,7 @@ impl<
         }
     }
 
-    fn next(&mut self) -> Option<crate::Result<bytes::Bytes>> {
+    fn next(&mut self) -> Option<Result<bytes::Bytes>> {
         match self {
             Self::One(one) => one.next(),
             Self::Two(two) => two.next(),

--- a/core/src/raw/oio/read/mod.rs
+++ b/core/src/raw/oio/read/mod.rs
@@ -54,4 +54,3 @@ pub use buffer_reader::BufferReader;
 
 mod compose_read;
 pub use compose_read::FourWaysReader;
-pub use compose_read::TwoWaysReader;

--- a/core/src/raw/oio/write/compose_write.rs
+++ b/core/src/raw/oio/write/compose_write.rs
@@ -28,7 +28,7 @@
 //!
 //! ```txt
 //! impl Accessor for OssBackend {
-//!     type Writer = oio::TwoWaysWriter<
+//!     type Writer = raw::TwoWays<
 //!         oio::MultipartUploadWriter<OssWriter>,
 //!         oio::AppendObjectWriter<OssWriter>,
 //!     >;
@@ -43,39 +43,6 @@ use std::task::Poll;
 
 use crate::raw::*;
 use crate::*;
-
-/// TwoWaysWrite is used to implement [`Write`] based on two ways.
-///
-/// Users can wrap two different writers together.
-pub enum TwoWaysWriter<ONE: oio::Write, TWO: oio::Write> {
-    /// The first type for the [`TwoWaysWriter`].
-    One(ONE),
-    /// The second type for the [`TwoWaysWriter`].
-    Two(TWO),
-}
-
-impl<ONE: oio::Write, TWO: oio::Write> oio::Write for TwoWaysWriter<ONE, TWO> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
-        match self {
-            Self::One(one) => one.poll_write(cx, bs),
-            Self::Two(two) => two.poll_write(cx, bs),
-        }
-    }
-
-    fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        match self {
-            Self::One(one) => one.poll_close(cx),
-            Self::Two(two) => two.poll_close(cx),
-        }
-    }
-
-    fn poll_abort(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        match self {
-            Self::One(one) => one.poll_abort(cx),
-            Self::Two(two) => two.poll_abort(cx),
-        }
-    }
-}
 
 /// ThreeWaysWriter is used to implement [`Write`] based on three ways.
 ///

--- a/core/src/raw/oio/write/mod.rs
+++ b/core/src/raw/oio/write/mod.rs
@@ -25,7 +25,6 @@ pub use api::Writer;
 
 mod compose_write;
 pub use compose_write::ThreeWaysWriter;
-pub use compose_write::TwoWaysWriter;
 
 mod multipart_upload_write;
 pub use multipart_upload_write::MultipartUploadPart;

--- a/core/src/services/azblob/writer.rs
+++ b/core/src/services/azblob/writer.rs
@@ -28,7 +28,7 @@ use crate::*;
 const X_MS_BLOB_TYPE: &str = "x-ms-blob-type";
 
 pub type AzblobWriters =
-    oio::TwoWaysWriter<oio::OneShotWriter<AzblobWriter>, oio::AppendObjectWriter<AzblobWriter>>;
+    TwoWays<oio::OneShotWriter<AzblobWriter>, oio::AppendObjectWriter<AzblobWriter>>;
 
 pub struct AzblobWriter {
     core: Arc<AzblobCore>,

--- a/core/src/services/azdls/writer.rs
+++ b/core/src/services/azdls/writer.rs
@@ -27,7 +27,7 @@ use crate::raw::*;
 use crate::*;
 
 pub type AzdlsWriters =
-    oio::TwoWaysWriter<oio::OneShotWriter<AzdlsWriter>, oio::AppendObjectWriter<AzdlsWriter>>;
+    TwoWays<oio::OneShotWriter<AzdlsWriter>, oio::AppendObjectWriter<AzdlsWriter>>;
 
 pub struct AzdlsWriter {
     core: Arc<AzdlsCore>,

--- a/core/src/services/azfile/writer.rs
+++ b/core/src/services/azfile/writer.rs
@@ -26,7 +26,7 @@ use crate::raw::*;
 use crate::*;
 
 pub type AzfileWriters =
-    oio::TwoWaysWriter<oio::OneShotWriter<AzfileWriter>, oio::AppendObjectWriter<AzfileWriter>>;
+    TwoWays<oio::OneShotWriter<AzfileWriter>, oio::AppendObjectWriter<AzfileWriter>>;
 
 pub struct AzfileWriter {
     core: Arc<AzfileCore>,

--- a/core/src/services/cos/writer.rs
+++ b/core/src/services/cos/writer.rs
@@ -26,7 +26,7 @@ use crate::raw::*;
 use crate::*;
 
 pub type CosWriters =
-    oio::TwoWaysWriter<oio::MultipartUploadWriter<CosWriter>, oio::AppendObjectWriter<CosWriter>>;
+    TwoWays<oio::MultipartUploadWriter<CosWriter>, oio::AppendObjectWriter<CosWriter>>;
 
 pub struct CosWriter {
     core: Arc<CosCore>,

--- a/core/src/services/obs/writer.rs
+++ b/core/src/services/obs/writer.rs
@@ -27,7 +27,7 @@ use crate::raw::*;
 use crate::*;
 
 pub type ObsWriters =
-    oio::TwoWaysWriter<oio::MultipartUploadWriter<ObsWriter>, oio::AppendObjectWriter<ObsWriter>>;
+    TwoWays<oio::MultipartUploadWriter<ObsWriter>, oio::AppendObjectWriter<ObsWriter>>;
 
 pub struct ObsWriter {
     core: Arc<ObsCore>,

--- a/core/src/services/oss/writer.rs
+++ b/core/src/services/oss/writer.rs
@@ -26,7 +26,7 @@ use crate::raw::*;
 use crate::*;
 
 pub type OssWriters =
-    oio::TwoWaysWriter<oio::MultipartUploadWriter<OssWriter>, oio::AppendObjectWriter<OssWriter>>;
+    TwoWays<oio::MultipartUploadWriter<OssWriter>, oio::AppendObjectWriter<OssWriter>>;
 
 pub struct OssWriter {
     core: Arc<OssCore>,


### PR DESCRIPTION
Use `TwoWays` instead of `TwoWaysReader` and `TwoWaysWriter`