### PR TITLE
chore: update release related docs and script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -53,7 +53,12 @@ PACKAGES=(
     "integrations\/"
 )
 for package in "${PACKAGES[@]}"; do
-  sed -i "/${package}/d" Cargo.toml
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS system sed usage is different from others
+    sed -i '' "/${package}/d" Cargo.toml
+  else
+    sed -i "/${package}/d" Cargo.toml
+  fi
 done
 
 echo "> Start package"

--- a/website/community/committers/release.md
+++ b/website/community/committers/release.md
@@ -158,8 +158,7 @@ After bump version PR gets merged, we can create a GitHub release for the releas
 
 - Create a tag at `main` branch on the `Bump Version` / `Patch up version` commit: `git tag -s "v0.36.0-rc.1"`, please correctly check out the corresponding commit instead of directly tagging on the main branch.
 - Push tags to GitHub: `git push --tags`.
-- Create Release on the newly created tag
-    - If there are breaking changes, please add the content from `upgrade.md` before.
+
 
 :::note
 


### PR DESCRIPTION
close: #3818

> Tracking issues that need handled after release
 [Create Release on the newly created tag](https://opendal.apache.org/community/committers/release#push-release-candidate-tag) (actually don't need any action on GitHub for candidate tag)
 ./scripts/release.sh cannot work on macOS, we need include it in the release docs