### PR TITLE
docs(bindings/python): drop unnecessary patchelf

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -82,7 +82,7 @@ source venv/bin/activate
 Install `maturin`:
 
 ```shell
-pip install maturin[patchelf]
+pip install maturin
 ```
 
 Build bindings:


### PR DESCRIPTION
Also compatible with zsh (`maturin[patchelf]` needs a quote to escape).

This closes #3874.