### PR TITLE
feat(services/hdfs): add atomic_write_dir to hdfsconfig debug

### DIFF
--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -64,6 +64,7 @@ impl Debug for HdfsConfig {
             )
             .field("user", &self.user)
             .field("enable_append", &self.enable_append)
+            .field("atomic_write_dir", &self.atomic_write_dir)
             .finish_non_exhaustive()
     }
 }


### PR DESCRIPTION
wrt #3875 
Missed adding `atomic_write_dir` to HdfsConfig fmt
cc @Xuanwo 