### PR TITLE
feat(core/bench): Add benchmark for concurrent write

### DIFF
--- a/core/benches/ops/write.rs
+++ b/core/benches/ops/write.rs
@@ -68,18 +68,18 @@ fn bench_write_with_concurrent(c: &mut Criterion, name: &str, op: Operator) {
 
     let mut rng = thread_rng();
 
-    for concurrent in [2, 4] {
+    for concurrent in [1, 2, 4, 8] {
         let content = gen_bytes(&mut rng, 5 * 1024 * 1024);
         let path = uuid::Uuid::new_v4().to_string();
 
-        group.throughput(criterion::Throughput::Bytes(4 * 5 * 1024 * 1024));
+        group.throughput(criterion::Throughput::Bytes(16 * 5 * 1024 * 1024));
         group.bench_with_input(
             concurrent.to_string(),
             &(op.clone(), &path, content.clone()),
             |b, (op, path, content)| {
                 b.to_async(&*TEST_RUNTIME).iter(|| async {
                     let mut w = op.writer_with(path).concurrent(concurrent).await.unwrap();
-                    for _ in 0..4 {
+                    for _ in 0..16 {
                         w.write(content.clone()).await.unwrap();
                     }
                     w.close().await.unwrap();


### PR DESCRIPTION
This PR will add benchmark for concurrent write.

Seems cool!

```rust
service_oss_write_with_concurrent/1
                        time:   [1.3195 s 1.3575 s 1.3909 s]
                        thrpt:  [57.517 MiB/s 58.932 MiB/s 60.630 MiB/s]
service_oss_write_with_concurrent/2
                        time:   [754.59 ms 773.29 ms 795.32 ms]
                        thrpt:  [100.59 MiB/s 103.45 MiB/s 106.02 MiB/s]
service_oss_write_with_concurrent/4
                        time:   [453.25 ms 465.07 ms 476.84 ms]
                        thrpt:  [167.77 MiB/s 172.02 MiB/s 176.50 MiB/s]
service_oss_write_with_concurrent/8
                        time:   [276.45 ms 286.87 ms 300.81 ms]
                        thrpt:  [265.95 MiB/s 278.87 MiB/s 289.39 MiB/s]
Found 1 outliers among 10 measurements (10.00%)
```