### PR TITLE
docs: fix incorrect word used

### DIFF
--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -90,9 +90,9 @@ impl HttpBuilder {
         self
     }
 
-    /// set password for http backend
+    /// set username for http backend
     ///
-    /// default: no password
+    /// default: no username
     pub fn username(&mut self, username: &str) -> &mut Self {
         if !username.is_empty() {
             self.config.username = Some(username.to_owned());

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -99,9 +99,9 @@ impl WebdavBuilder {
         self
     }
 
-    /// set the password for Webdav
+    /// set the username for Webdav
     ///
-    /// default: no password
+    /// default: no username
     pub fn username(&mut self, username: &str) -> &mut Self {
         if !username.is_empty() {
             self.config.username = Some(username.to_owned());


### PR DESCRIPTION
The docs comment above the function for setting the username said it set the password. I first saw this error in WebDav, but after searching I also found it in the HTTP backend, so I fixed that one as well.