### PR TITLE
docs: fix `ghac` `vercel_artifacts` "Via Builder" code type

### DIFF
--- a/core/src/services/ghac/docs.md
+++ b/core/src/services/ghac/docs.md
@@ -62,7 +62,7 @@ Refer to [`GhacBuilder`]'s public API docs for more information.
 
 ### Via Builder
 
-```no_run
+```rust
 use std::sync::Arc;
 
 use anyhow::Result;

--- a/core/src/services/vercel_artifacts/docs.md
+++ b/core/src/services/vercel_artifacts/docs.md
@@ -24,7 +24,7 @@ You can refer to [`VercelArtifactsBuilder`]'s docs for more information
 
 ### Via Builder
 
-```no_run
+```rust
 use anyhow::Result;
 use opendal::services::VercelArtifacts;
 use opendal::Operator;


### PR DESCRIPTION
Fix 

https://opendal.apache.org/docs/services/ghac#via-builder 
https://opendal.apache.org/docs/services/vercel_artifacts#via-builder

wrong code type and without color