### PR TITLE
refactor!: Revert the bump of MSRV to 1.75

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,8 +161,8 @@ jobs:
   check_msrv:
     runs-on: ubuntu-latest
     env:
-      # OpenDAL's MSRV is 1.75.
-      OPENDAL_MSRV: "1.75"
+      # OpenDAL's MSRV is 1.67.
+      OPENDAL_MSRV: "1.67"
     steps:
       - uses: actions/checkout@v4
       - name: Setup msrv of rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/incubator-opendal"
-rust-version = "1.75"
+rust-version = "1.67"
 version = "0.44.1"
 
 [workspace.dependencies]


### PR DESCRIPTION
This reverts commit 3edaa8fdbe0b6a5e38a87138c13ef9516da73f12.

See https://github.com/apache/incubator-opendal/pull/3951 for more details.