### PR TITLE
chore: display project logo on Rust docs

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![doc(html_logo_url = "https://raw.githubusercontent.com/apache/incubator-opendal/main/website/static/img/logo.svg")]
 #![cfg_attr(docs, feature(doc_auto_cfg))]
 
 //! Apache OpenDAL™ is a data access layer that allows users to easily and

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#![doc(html_logo_url = "https://raw.githubusercontent.com/apache/incubator-opendal/main/website/static/img/logo.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/apache/incubator-opendal/main/website/static/img/logo.svg"
+)]
 #![cfg_attr(docs, feature(doc_auto_cfg))]
 
 //! Apache OpenDAL™ is a data access layer that allows users to easily and


### PR DESCRIPTION
I suppose that we will use an "Apache OpenDAL™" logo later, so this can improve the OpenDAL branding somehow.