### PR TITLE
docs(bindings/java): copyright in footer

### DIFF
--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -78,6 +78,7 @@
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <palantir-java-format.version>2.36.0</palantir-java-format.version>
         <spotless.version>2.39.0</spotless.version>
+        <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -261,6 +262,19 @@
                         <trimTrailingWhitespace/>
                         <endWithNewline/>
                     </java>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-javadoc-plugin.version}</version>
+                <configuration>
+                    <bottom>
+                        Copyright © 2022-2024, The Apache Software Foundation Apache OpenDAL, OpenDAL, Apache, Apache Incubator,
+                        the Apache feather, the Apache Incubator logo and the Apache OpenDAL project logo are either registered
+                        trademarks or trademarks of the Apache Software Foundation.
+                    </bottom>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Related: https://github.com/apache/incubator-opendal/pull/3989#issuecomment-1893034384

Add copyright to the java doc's footer.

![image](https://github.com/apache/incubator-opendal/assets/38717659/56828c7b-0291-43c9-afc2-2d30c7cf3f61)
