### PR TITLE
fix: Don't call wake_by_ref in OperatorFuture

### DIFF
--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -156,8 +156,8 @@ impl HttpClient {
                 err.is_status()
             );
 
-            let mut oerr = Error::new(ErrorKind::Unexpected, "send async request")
-                .with_operation("http_util::Client::send_async")
+            let mut oerr = Error::new(ErrorKind::Unexpected, "send http request")
+                .with_operation("http_util::Client::send")
                 .with_context("url", uri.to_string())
                 .set_source(err);
             if is_temporary {

--- a/core/src/types/operator/operator_futures.rs
+++ b/core/src/types/operator/operator_futures.rs
@@ -95,22 +95,20 @@ where
     ///
     /// In general, `Empty` state should not be polled.
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        *self = match mem::replace(self.as_mut().get_mut(), OperatorFuture::Empty) {
-            OperatorFuture::Idle(inner, path, args, f) => {
-                // Wake up to make sure the future is ready after the
-                // future has been built.
-                cx.waker().wake_by_ref();
-                OperatorFuture::Poll(f(inner, path, args))
+        loop {
+            *self = match mem::replace(self.as_mut().get_mut(), OperatorFuture::Empty) {
+                OperatorFuture::Idle(inner, path, args, f) => {
+                    OperatorFuture::Poll(f(inner, path, args))
+                }
+                OperatorFuture::Poll(mut fut) => match fut.as_mut().poll(cx) {
+                    Poll::Ready(v) => return Poll::Ready(v),
+                    Poll::Pending => OperatorFuture::Poll(fut),
+                },
+                OperatorFuture::Empty => {
+                    panic!("future polled after completion");
+                }
             }
-            OperatorFuture::Poll(mut fut) => match fut.as_mut().poll(cx) {
-                Poll::Pending => OperatorFuture::Poll(fut),
-                Poll::Ready(v) => return Poll::Ready(v),
-            },
-            OperatorFuture::Empty => {
-                panic!("future polled after completion");
-            }
-        };
-        Poll::Pending
+        }
     }
 }
 


### PR DESCRIPTION
Tokyo might overlook this wake if it's experiencing a high load.