### PR TITLE
docs: add trademark information to every possible published readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The first and most prominent mentions must use the full form: **Apache OpenDALâ„
 
 For more details, see the [Apache Product Name Usage Guide](https://www.apache.org/foundation/marks/guide).
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ The first and most prominent mentions must use the full form: **Apache OpenDALâ„
 
 For more details, see the [Apache Product Name Usage Guide](https://www.apache.org/foundation/marks/guide).
 
-## License
+## Trademarks & Licenses
 
-Licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bin/oay/README.md
+++ b/bin/oay/README.md
@@ -16,7 +16,7 @@ Our first milestone is to provide S3 APIs.
 
 Only `list_object_v2` with `start_after` is supported.
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bin/oay/README.md
+++ b/bin/oay/README.md
@@ -15,3 +15,9 @@ Our first milestone is to provide S3 APIs.
 ### S3 API
 
 Only `list_object_v2` with `start_after` is supported.
+
+## Trademarks & Licenses
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bin/ofs/README.md
+++ b/bin/ofs/README.md
@@ -1,3 +1,9 @@
 # OpenDAL File System
 
 OpenDAL File System (ofs) is a userspace filesystem backing by OpenDAL.
+
+## Trademarks & Licenses
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bin/ofs/README.md
+++ b/bin/ofs/README.md
@@ -2,7 +2,7 @@
 
 OpenDAL File System (ofs) is a userspace filesystem backing by OpenDAL.
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bin/oli/README.md
+++ b/bin/oli/README.md
@@ -88,7 +88,7 @@ If you have any questions or suggestions about `oli`, please feel free to open a
 
 As `oli` is a part of Apache OpenDAL, you should follow the [CONTRIBUTION](https://github.com/apache/incubator-opendal/blob/main/CONTRIBUTING.md) documentation. There are still lots works to do with `oli`, you could track them on this [GitHub Issue](https://github.com/apache/incubator-opendal/issues/422).
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bin/oli/README.md
+++ b/bin/oli/README.md
@@ -87,3 +87,9 @@ Contribution is not only about code, but also about documentation, examples, and
 If you have any questions or suggestions about `oli`, please feel free to open an issue on GitHub.
 
 As `oli` is a part of Apache OpenDAL, you should follow the [CONTRIBUTION](https://github.com/apache/incubator-opendal/blob/main/CONTRIBUTING.md) documentation. There are still lots works to do with `oli`, you could track them on this [GitHub Issue](https://github.com/apache/incubator-opendal/issues/422).
+
+## Trademarks & Licenses
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -138,7 +138,7 @@ If you want to build the documentations yourself, you could use
 make doc
 ```
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -138,6 +138,9 @@ If you want to build the documentations yourself, you could use
 make doc
 ```
 
-## License
+## Trademarks & Licenses
 
-[Apache v2.0](https://www.apache.org/licenses/LICENSE-2.0)
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.
+

--- a/bindings/cpp/README.md
+++ b/bindings/cpp/README.md
@@ -102,3 +102,9 @@ make docs
 - `OPENDAL_ENABLE_DOCUMENTATION`: Enable documentation. Default: `OFF`
 - `OPENDAL_DOCS_ONLY`: Only build documentation. Default: `OFF`
 - `OPENDAL_ENABLE_TESTING`: Enable testing. Default: `OFF`
+
+## Trademarks & Licenses
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bindings/cpp/README.md
+++ b/bindings/cpp/README.md
@@ -103,7 +103,7 @@ make docs
 - `OPENDAL_DOCS_ONLY`: Only build documentation. Default: `OFF`
 - `OPENDAL_ENABLE_TESTING`: Enable testing. Default: `OFF`
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bindings/dotnet/README.md
+++ b/bindings/dotnet/README.md
@@ -3,3 +3,9 @@
 ![](https://img.shields.io/badge/status-unreleased-red)
 
 This binding is currently under development. Please check back later.
+
+## Trademarks & Licenses
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bindings/dotnet/README.md
+++ b/bindings/dotnet/README.md
@@ -4,7 +4,7 @@
 
 This binding is currently under development. Please check back later.
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -56,7 +56,7 @@ For benchmark
 go test -bench=. -tags dynamic .
 ```
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -55,3 +55,9 @@ For benchmark
 ```shell
 go test -bench=. -tags dynamic .
 ```
+
+## Trademarks & Licenses
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bindings/haskell/README.md
+++ b/bindings/haskell/README.md
@@ -56,3 +56,9 @@ cabal haddock
 ```
 
 If your `cabal` version is greater than `3.8`, you can use `cabal haddock --open` to open the documentation in your browser. Otherwise, you can visit the documentation from `dist-newstyle/build/$ARCH/ghc-$VERSION/opendal-$VERSION/doc/html/opendal/index.html`.
+
+## Trademarks & Licenses
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bindings/haskell/README.md
+++ b/bindings/haskell/README.md
@@ -57,7 +57,7 @@ cabal haddock
 
 If your `cabal` version is greater than `3.8`, you can use `cabal haddock --open` to open the documentation in your browser. Otherwise, you can visit the documentation from `dist-newstyle/build/$ARCH/ghc-$VERSION/opendal-$VERSION/doc/html/opendal/index.html`.
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -157,7 +157,7 @@ export OPENDAL_REDIS_DB=0
 ./mvnw test -Dtest="behavior.*Test" -Dcargo-build.features=services-redis
 ```
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -156,3 +156,9 @@ export OPENDAL_REDIS_ROOT=/
 export OPENDAL_REDIS_DB=0
 ./mvnw test -Dtest="behavior.*Test" -Dcargo-build.features=services-redis
 ```
+
+## Trademarks & Licenses
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bindings/lua/README.md
+++ b/bindings/lua/README.md
@@ -64,3 +64,9 @@ $ busted -o gtest test/opendal_test.lua
 [==========] 2 tests from 1 test file ran. (3.54 ms total)
 [  PASSED  ] 2 tests.
 ```
+
+## Trademarks & Licenses
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bindings/lua/README.md
+++ b/bindings/lua/README.md
@@ -65,7 +65,7 @@ $ busted -o gtest test/opendal_test.lua
 [  PASSED  ] 2 tests.
 ```
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -50,7 +50,7 @@ main();
 - Asking questions in the [Discussions](https://github.com/apache/incubator-opendal/discussions/new?category=q-a).
 - Talk to community at [Discord](https://discord.gg/XQy8yGR2dg).
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -50,6 +50,8 @@ main();
 - Asking questions in the [Discussions](https://github.com/apache/incubator-opendal/discussions/new?category=q-a).
 - Talk to community at [Discord](https://discord.gg/XQy8yGR2dg).
 
-## License
+## Trademarks & Licenses
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bindings/ocaml/README.md
+++ b/bindings/ocaml/README.md
@@ -77,3 +77,9 @@ To execute unit tests, we can simply use the following command:
 cd bindings/ocaml
 dune test
 ```
+
+## Trademarks & Licenses
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bindings/ocaml/README.md
+++ b/bindings/ocaml/README.md
@@ -78,7 +78,7 @@ cd bindings/ocaml
 dune test
 ```
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bindings/php/README.md
+++ b/bindings/php/README.md
@@ -82,3 +82,9 @@ cd incubator-opendal/bindings/php
 composer install
 composer test
 ```
+
+## Trademarks & Licenses
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bindings/php/README.md
+++ b/bindings/php/README.md
@@ -83,7 +83,7 @@ composer install
 composer test
 ```
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -105,3 +105,9 @@ Build API docs:
 maturin develop -E docs
 pdoc -t ./template opendal
 ```
+
+## Trademarks & Licenses
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -106,7 +106,7 @@ maturin develop -E docs
 pdoc -t ./template opendal
 ```
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bindings/ruby/README.md
+++ b/bindings/ruby/README.md
@@ -26,7 +26,7 @@ Run tests:
 rake spec
 ```
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bindings/ruby/README.md
+++ b/bindings/ruby/README.md
@@ -25,3 +25,9 @@ Run tests:
 ```shell
 rake spec
 ```
+
+## Trademarks & Licenses
+
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bindings/swift/README.md
+++ b/bindings/swift/README.md
@@ -63,7 +63,7 @@ let readData = try op.blockingRead("/demo")
 print(readData!)
 ```
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/bindings/swift/README.md
+++ b/bindings/swift/README.md
@@ -63,6 +63,9 @@ let readData = try op.blockingRead("/demo")
 print(readData!)
 ```
 
-## License
+## Trademarks & Licenses
 
-[Apache v2.0](https://www.apache.org/licenses/LICENSE-2.0)
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.
+

--- a/bindings/zig/README.md
+++ b/bindings/zig/README.md
@@ -21,6 +21,8 @@ zig build libopendal_c
 zig build test --summary all
 ```
 
-## License
+## Trademarks & Licenses
 
-[Apache v2.0](https://www.apache.org/licenses/LICENSE-2.0)
+Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/bindings/zig/README.md
+++ b/bindings/zig/README.md
@@ -21,7 +21,7 @@ zig build libopendal_c
 zig build test --summary all
 ```
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/core/README.md
+++ b/core/README.md
@@ -159,6 +159,8 @@ The examples are available at [here](../examples/rust).
 
 Check out the [CONTRIBUTING](CONTRIBUTING.md) guide for more details on getting started with contributing to this project.
 
-## License
+## Trademarks & Licenses
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.

--- a/core/README.md
+++ b/core/README.md
@@ -159,7 +159,7 @@ The examples are available at [here](../examples/rust).
 
 Check out the [CONTRIBUTING](CONTRIBUTING.md) guide for more details on getting started with contributing to this project.
 
-## Trademarks & Licenses
+## License and Trademarks
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 


### PR DESCRIPTION
- Add trademark information to every README page that may be published or become an entry point. (bin/bindings/core/repo)
- Unified format.

```
## Trademarks & Licenses

Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0

Apache OpenDAL, OpenDAL, and Apache are either registered trademarks or trademarks of the Apache Software Foundation.
```