### PR TITLE
docs(website): replace podling to project in website

### DIFF
--- a/website/community/index.mdx
+++ b/website/community/index.mdx
@@ -98,7 +98,7 @@ We sincerely appreciate your support and efforts!
 
 ### Committers
 
-The list below could be outdated. Please find the most up-to-date list [here](https://people.apache.org/phonebook.html?podling=opendal).
+The list below could be outdated. Please find the most up-to-date list [here](https://people.apache.org/phonebook.html?project=opendal).
 
 This list of committers is sorted alphabetically by Apache ID.
 And bolded names are PPMC members.


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced by this PR. -->

Since we've graduated from ASF, change url from `podling` to `project`. 🎉